### PR TITLE
Serve SVG assets for preview thumbnails

### DIFF
--- a/frontend/src/modules/assetManagement/templates/assetManagementListItem.hbs
+++ b/frontend/src/modules/assetManagement/templates/assetManagementListItem.hbs
@@ -28,7 +28,7 @@
 
     {{#ifValueEquals assetType "image"}}
         {{#if metadata}}
-        <div class="asset-management-list-item-image" data-style="background-image:url(api/asset/thumb/{{_id}})">
+        <div class="asset-management-list-item-image" data-style="background-image:url(api/asset/{{#ifValueEquals assetExt "svg"}}serve{{else}}thumb{{/ifValueEquals}}/{{_id}})">
         {{else}}
         <div class="asset-management-list-item-image">
             <i class="fa fa-file-image-o"></i>

--- a/frontend/src/modules/assetManagement/views/assetManagementItemView.js
+++ b/frontend/src/modules/assetManagement/views/assetManagementItemView.js
@@ -24,6 +24,10 @@ define(function(require){
         this.listenTo(this, 'remove', this.remove);
         this.listenTo(this.model, 'destroy', this.remove);
         this.listenTo(this.model, 'change:_isDeleted', this.onReRender);
+        
+        // Set the extension of the file, so it can be used in the template
+        const filename = this.model.get('filename');
+        this.model.set('assetExt', filename.split('.').pop()); // e.g. 'jpg', 'svg', 'mp4'
     },
 
     onReRender: function() {

--- a/frontend/src/modules/scaffold/templates/scaffoldAsset.hbs
+++ b/frontend/src/modules/scaffold/templates/scaffoldAsset.hbs
@@ -3,7 +3,7 @@
 
   {{#ifValueEquals type 'image'}}
     {{#if thumbUrl}}
-      <img class="scaffold-asset-preview" src="{{thumbUrl}}"/>
+      <img class="scaffold-asset-preview" src="{{#ifValueEquals assetExt 'svg'}}{{url}}{{else}}{{thumbUrl}}{{/ifValueEquals}}"/>
     {{else}}
       <a class="scaffold-asset-preview" title="{{t 'app.nothumbnailforimage'}}" href="{{url}}" target="_blank">
         <i class="fa fa-file-image-o fa-large"></i>

--- a/frontend/src/modules/scaffold/views/scaffoldAssetView.js
+++ b/frontend/src/modules/scaffold/views/scaffoldAssetView.js
@@ -53,6 +53,7 @@ define([
     renderData: function(id) {
       var inputType = this.schema.inputType;
       var dataUrl = Helpers.isAssetExternal(this.value) ? this.value : '';
+      var assetExt = this.value.split('.').pop(); // e.g. 'jpg', 'svg', 'mp4'
 
       this.assetType = typeof inputType === 'string' ?
         inputType.replace(/Asset|:/g, '') :
@@ -62,7 +63,8 @@ define([
         value: this.value,
         type: this.assetType,
         url: id ? 'api/asset/serve/' + id : dataUrl,
-        thumbUrl: id ? 'api/asset/thumb/' + id : dataUrl
+        thumbUrl: id ? 'api/asset/thumb/' + id : dataUrl,
+        assetExt: assetExt
       }));
     },
 


### PR DESCRIPTION
Fixes https://github.com/Laerdal/adapt_authoring/issues/3

## Proposed changes

Include the asset file extension in the views for Asset Management and Scaffold assets.
When the file extension matches "svg" we can serve the SVG for preview

## Examples
### Graphic component
![image](https://github.com/Laerdal/adapt_authoring/assets/40148279/bd19723d-c7ce-44d6-9fc3-86513e0dbc26)

### Asset management
![image](https://github.com/Laerdal/adapt_authoring/assets/40148279/46fffb7c-b405-4fda-8ad0-614b229a01b2)



