### PR TITLE
Support H5P asset type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /node_modules/
 /nbproject/
 /master/
+/public/assets
 
 /plugins/content/component/versions/
 /plugins/content/component/componentcache/

--- a/lib/application.js
+++ b/lib/application.js
@@ -300,6 +300,7 @@ Origin.prototype.createServer = function (options, cb) {
     server.use(auth.session());
     server.use(express.static(path.join(require('./configuration').serverRoot, 'frontend', 'build')));
     server.use(express.static(path.join(require('./configuration').serverRoot, 'frontend', 'src', 'libraries')));
+    server.use(express.static('public'));
     if(!app.configuration.getConfig('isProduction')) {
       server.use(express.static(path.join(app.configuration.serverRoot, 'frontend', 'src')));
     }

--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -763,7 +763,7 @@ OutputPlugin.prototype.writeCustomStyle = function(tenantId, courseId, destinati
   }, tenantId);
 };
 
-OutputPlugin.prototype.writeCourseAssets = function(tenantId, courseId, jsonDestinationFolder, destinationFolder, jsonObject, next) {
+OutputPlugin.prototype.writeCourseAssets = function(tenantId, courseId, jsonDestinationFolder, destinationFolder, jsonObject, mode, next) {
 
   fs.remove(destinationFolder, function(err) {
     if (err) {
@@ -821,19 +821,52 @@ OutputPlugin.prototype.writeCourseAssets = function(tenantId, courseId, jsonDest
                     return callback(err);
                   }
 
-                  return storage && storage.createReadStream(asset.path, function (ars) {
-                    var aws = fs.createWriteStream(outputFilename);
-                    ars.on('error', function (err) {
-                      logger.log('error', 'Error copying ' + asset.path + ' to ' + outputFilename + ": " + err.message);
-                      return callback('Error copying ' + asset.path + ' to ' + outputFilename + ": " + err.message);
-                    });
-                    ars.on('end', function () {
+                  if (!storage) {
+                    logger.log('error', 'Error getting storage plugin.');
+                    return callback(err);
+                  }
+
+                  // ---- Handle H5P assets ----
+                  const assetPathSrc = storage.resolvePath(asset.path);
+                  if (assetPathSrc.match(/\.h5p$/)) {
+                    // check asset exists unzipped in public/assets/
+                    const h5pFolder = storage.checkH5PAssetExistsUnzipped(assetPathSrc);
+
+                    // PREVIEW - do nothing, H5P assets will be served statically from public/assets/
+                    if (mode === Constants.Modes.Preview) {
+                      return callback();
+                    }
+
+                    // PUBLISH - copy H5P folder to course build
+                    if (mode === Constants.Modes.Publish) {
+                      fs.copy(h5pFolder, outputFilename.replace(/\.h5p$/, ''), (err) => {
+                        if (err) {
+                            logger.log('error', `Error copying file ${assetPathSrc}`);
+                            return callback(err);
+                          }
+                          return callback();
+                        }
+                      );
+                    }
+
+                    // EXPORT - zip up H5P folder in public/assets and copy to course build
+                    if (mode === Constants.Modes.Export) {
+                      storage.zipH5PAsset(h5pFolder, outputFilename);
+                      return callback();
+                    }
+                  } else {
+                    // All other assets get copied to build folder
+                    fs.copy(assetPathSrc, outputFilename, (err) => {
+                      if (err) {
+                        logger.log('error', `Error copying file ${assetPathSrc}`);
+                        return callback(err);
+                      }
                       return callback();
                     });
-                    ars.pipe(aws);
-                  });
-                });
-              }, function(err) {
+                  }
+                }
+              );
+            }, function(err) {
                 if (err) {
                   logger.log('error', 'Error processing course assets');
                   return next(err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@babel/core": "^7.19.6",
         "@babel/preset-env": "^7.19.4",
+        "adm-zip": "^0.5.10",
         "archiver": "^3.1.1",
         "async": "^3.2.3",
         "bcrypt-nodejs": "0.0.3",
@@ -3298,6 +3299,14 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/ajv": {
@@ -16195,6 +16204,11 @@
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
+    },
+    "adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ=="
     },
     "ajv": {
       "version": "6.12.6",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@babel/core": "^7.19.6",
     "@babel/preset-env": "^7.19.4",
+    "adm-zip": "^0.5.10",
     "archiver": "^3.1.1",
     "async": "^3.2.3",
     "bcrypt-nodejs": "0.0.3",

--- a/plugins/output/adapt/importsource.js
+++ b/plugins/output/adapt/importsource.js
@@ -173,10 +173,18 @@ function ImportSource(req, done) {
           var assetJson = assetsJson[assetName];
           var tags = [];
 
+          let fileType = mime.getType(assetName);
+          if (!fileType) {
+            //Handling H5P fileType null/undefined
+            if (assetExt.toLowerCase() === '.h5p') {
+              fileType = 'application/octet-stream';
+            }
+          }
+
           var fileMeta = {
             oldId: assetId,
             title: assetTitle,
-            type: mime.getType(assetName),
+            type: fileType,
             size: fileStat["size"],
             filename: assetName,
             description: assetDescription,

--- a/plugins/output/adapt/publish.js
+++ b/plugins/output/adapt/publish.js
@@ -136,7 +136,7 @@ function publishCourse(courseId, mode, request, response, next) {
       var assetsJsonFolder = path.join(BUILD_FOLDER, Constants.Folders.Course, outputJson['config']._defaultLanguage);
       var assetsFolder = path.join(assetsJsonFolder, Constants.Folders.Assets);
 
-      self.writeCourseAssets(tenantId, courseId, assetsJsonFolder, assetsFolder, outputJson, function(err, modifiedJson) {
+      self.writeCourseAssets(tenantId, courseId, assetsJsonFolder, assetsFolder, outputJson, mode, function(err, modifiedJson) {
         if (err) {
           return callback(err);
         }


### PR DESCRIPTION
Resolves https://github.com/Laerdal/adapt_authoring/issues/5
https://h5p.org/
- adm-zip package added to handle the unpacking of H5P assets (standard .zip but named .h5p instead)
- For fast preview of assets, unpacked H5P assets can be served from the public/assets folder
- Mode of build "preview/export/publish" is now passed to writeCourseAssets, to handle each case for H5P assets
- Helper functions added to localfs/index.js to unpack/check state of H5P assets
- Importing courses with H5P assets now checks the file extension, to avoid undefined fileType for H5P assets