### PR TITLE
Allow select form fields to conditionally display other form fields

### DIFF
--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -8,6 +8,8 @@ define([
   var templateData = Backbone.Form.Field.prototype.templateData;
   var initialize = Backbone.Form.editors.Base.prototype.initialize;
   var textInitialize = Backbone.Form.editors.Text.prototype.initialize;
+  var selectInitialize = Backbone.Form.editors.Select.prototype.initialize;
+  var selectRender = Backbone.Form.editors.Select.prototype.render;
   var textAreaRender = Backbone.Form.editors.TextArea.prototype.render;
   var textAreaSetValue = Backbone.Form.editors.TextArea.prototype.setValue;
 
@@ -230,4 +232,31 @@ define([
     }
   };
 
+  // add listener to Select inputs with the "data-is-conditional" attribute
+  Backbone.Form.editors.Select.prototype.initialize = function (options) {
+    selectInitialize.call(this, options);
+    this.on('change', updateConditionalView, this);
+  };
+
+  Backbone.Form.editors.Select.prototype.render = function() {
+    selectRender.call(this);
+
+    // Update view after the select has been rendered
+    _.defer(updateConditionalView.bind(this));
+
+    return this;
+  };
+
+  // If a radio or select input has the data-is-conditional attribute, then show/hide the relevant fields
+  function updateConditionalView() {
+
+    const editorAttrs = this.schema.editorAttrs;
+    if (!editorAttrs) return;
+  
+    if (editorAttrs['data-is-conditional']) {
+      const currentOption = this.getValue();
+      $(`[data-depends-on=${this.key}]`).toggle(false);
+      $(`[data-depends-on=${this.key}][data-option-match=${currentOption}]`).toggle(true);
+    }
+  }
 });


### PR DESCRIPTION
resolves https://github.com/Laerdal/adapt_authoring/issues/9

Plugins setup using the `data-is-conditional`, `data-depends-on` and `data-option-match` in their properties schema can use Select or Radio input types to conditionally show other plugin properties. See example below:
```json
{
  "properties" : {
    "_optionSelect": {
      "type": "string",
      "required": false,
      "default": "option-a",
      "title": "Select an option to see conditional settings.",
      "inputType": {
        "type": "Select",
        "options": [
          { "val": "option-a", "label": "Option A" },
          { "val": "option-b", "label": "Option B" }
        ]
      },
      "validators": [],
      "editorAttrs": {
        "data-is-conditional": true
      },
      "help": "Select an option to see conditional settings."
    },
    "_optionA": {
      "type": "string",
      "required": false,
      "default": "",
      "title": "Option A settings",
      "inputType": "Text",
      "validators": [],
      "help": "",
      "translatable": true,
      "fieldAttrs": {
        "data-depends-on": "_optionSelect",
        "data-option-match": "option-a"
      }
    },
    "_optionB": {
      "type": "string",
      "required": false,
      "default": "",
      "title": "Option B settings",
      "inputType": "Text",
      "validators": [],
      "help": "",
      "translatable": true,
      "fieldAttrs": {
        "data-depends-on": "_optionSelect",
        "data-option-match": "option-b"
      }
    }
  }
}
```
