### PR TITLE
Add support for palette options for the ColourPicker input type

### DIFF
--- a/frontend/src/modules/scaffold/index.js
+++ b/frontend/src/modules/scaffold/index.js
@@ -128,7 +128,8 @@ define([
       title: getTitle(),
       titleHTML: field.titleHTML,
       type: getType(),
-      validators: getValidators()
+      validators: getValidators(),
+      extra: field.extra
     };
 
     if (_.isObject(inputType)) {

--- a/frontend/src/modules/scaffold/less/colourPicker.less
+++ b/frontend/src/modules/scaffold/less/colourPicker.less
@@ -1,6 +1,6 @@
 @darkBorderColour: #dcdcdc;
 @lightBorderColour: #cccccc;
-@paletteBackgroundColour: #eff7f9;
+@paletteBackgroundColour: #ffffff;
 
 .scaffold-colour-picker {
   & + .sp-replacer,
@@ -19,14 +19,13 @@
 body .sp-container {
   border-color: @darkBorderColour;
   .sp-palette {
-    max-width: 90px;
     .sp-thumb-el {
-      border-radius: 11px;
+      border-radius: 50%;
       border-color: @paletteBackgroundColour;
       box-sizing: border-box;
       overflow: hidden;
-      width: 20px;
-      height: 20px;
+      width: 24px;
+      height: 24px;
       margin: 4px;
       &:hover {
         transform: scale(1.2);

--- a/frontend/src/modules/scaffold/views/scaffoldColourPickerView.js
+++ b/frontend/src/modules/scaffold/views/scaffoldColourPickerView.js
@@ -22,7 +22,8 @@ define([
     },
 
     postRender: function() {
-      this.$el.spectrum({
+
+      const options = {
         color: this.value,
         showAlpha: true,
         showInitial: true,
@@ -42,7 +43,17 @@ define([
         hide: function(colour) {
           Origin.contentPane.enableScroll();
         }
-      });
+      }
+
+      if(this.schema && this.schema.extra && this.schema.extra.palette) {
+        options.palette = this.schema.extra.palette;
+        options.localStorageKey = null;
+        options.showPaletteOnly = true;
+        options.showSelectionPalette = false;
+        options.togglePaletteOnly = true
+      }
+
+      this.$el.spectrum(options);
       // remove class beacuse we aren't using the clear button
       $('.sp-container').removeClass('sp-clear-enabled');
     },


### PR DESCRIPTION
resolves https://github.com/Laerdal/adapt_authoring/issues/11

## Proposed changes
To extend the customisation of the ColourPicker input type.
This can be done by passing extra options from the plugin schema, and using them in the scaffold color picker view.

## Implemented
The "extra" property is now available for all field objects.
Example of use in a plugin's properties.schema:
![image](https://github.com/Laerdal/adapt_authoring/assets/40148279/d9ccf742-69bb-4e8b-8b48-77f762a91b3f)
As shown in the Authoring Tool UI:
![image](https://github.com/Laerdal/adapt_authoring/assets/40148279/82462765-19a1-41bd-a335-90419985a779)


Default colour picker styles updated:
-  color option circles made bigger
- max-width removed, so palette rows are rendered correctly 
- background colour updated to white
