### PR TITLE
Add support to restore a List input type in the Theme editor view

### DIFF
--- a/frontend/src/modules/editor/themeEditor/views/editorThemingView.js
+++ b/frontend/src/modules/editor/themeEditor/views/editorThemingView.js
@@ -219,7 +219,9 @@ define(function(require) {
         fieldView.setValue(value);
         fieldView.render();
         $('div[data-editor-id*="' + key + '"]').append(fieldView.editor.$el);
-      } else {
+      } else if (inputType === "List"){
+        fieldView.setValue(value);
+      }else {
         fieldView.editor.$el.val(value.toString())
       }
     },


### PR DESCRIPTION
resolves https://github.com/Laerdal/adapt_authoring/issues/13

"List" input type, if used, now restores in the Theme Picker view.