### PR TITLE
More robust check of asset string to get the file extension

### DIFF
--- a/frontend/src/core/helpers.js
+++ b/frontend/src/core/helpers.js
@@ -196,6 +196,23 @@ define(function(require){
       return isMultiPart ? block.fn(this) : block.inverse(this);
     },
 
+    getFileExtension(filename) {  
+  
+      if (!filename || typeof filename !== 'string') return "";  
+      
+      // Split the filename by dot into an array
+      var filenameParts = filename.split('.');  
+      
+      // If the array has only one element, there's no extension  
+      if (filenameParts.length === 1) return "";  
+      
+      // Pop the last element from the array, which is the file extension  
+      var extension = filenameParts.pop();  
+      
+      // Return the extension e.g. "jpg", "svg", "mp4"
+      return extension.toLowerCase();
+    },
+        
     copyStringToClipboard: function(data) {
       var textArea = document.createElement("textarea");
 

--- a/frontend/src/modules/assetManagement/views/assetManagementItemView.js
+++ b/frontend/src/modules/assetManagement/views/assetManagementItemView.js
@@ -5,6 +5,7 @@ define(function(require){
   var Handlebars = require('handlebars');
   var OriginView = require('core/views/originView');
   var Origin = require('core/origin');
+  var Helpers = require('core/helpers');
 
   var AssetItemView = OriginView.extend({
 
@@ -27,7 +28,7 @@ define(function(require){
         
         // Set the extension of the file, so it can be used in the template
         const filename = this.model.get('filename');
-        this.model.set('assetExt', filename.split('.').pop()); // e.g. 'jpg', 'svg', 'mp4'
+        this.model.set('assetExt', Helpers.getFileExtension(filename));
     },
 
     onReRender: function() {

--- a/frontend/src/modules/scaffold/views/scaffoldAssetView.js
+++ b/frontend/src/modules/scaffold/views/scaffoldAssetView.js
@@ -53,8 +53,8 @@ define([
     renderData: function(id) {
       var inputType = this.schema.inputType;
       var dataUrl = Helpers.isAssetExternal(this.value) ? this.value : '';
-      var assetExt = this.value.split('.').pop(); // e.g. 'jpg', 'svg', 'mp4'
-
+      var assetExt = Helpers.getFileExtension(this.value);
+   
       this.assetType = typeof inputType === 'string' ?
         inputType.replace(/Asset|:/g, '') :
         inputType.media;


### PR DESCRIPTION
fixes https://github.com/Laerdal/adapt_authoring/issues/18

## Proposed changes
Due to changes from https://github.com/Laerdal/adapt_authoring/pull/4 a bug was introduced where a `null` value of an asset filename was not handled, causes the view not to render.

These changes:
- Now handles null value
- always returns extension in lowercase
- same functionality used in Asset Management and Scaffold views
