### PR TITLE
Add new postinstall script to setup custom plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 /frontend/src/plugins/plugins.js
 /frontend/src/templates/templates.js
 
-/node_modules/
+node_modules
 /nbproject/
 /master/
 /public/assets

--- a/INSTALLPLUGINS.md
+++ b/INSTALLPLUGINS.md
@@ -66,7 +66,7 @@ Example of conf/config.json with three custom plugins:
     },
     // This plugin is disabled
     "name-of-plugin-3": {
-      "isEnabled": true,
+      "isEnabled": false,
       "frontend": null,
       "backend": {
         "path": "/home/user/my-custom-plugins/plugin-3/plugin-3-backend",

--- a/INSTALLPLUGINS.md
+++ b/INSTALLPLUGINS.md
@@ -1,0 +1,134 @@
+# Install Plugins (Authoring Tool)
+
+A helper script is available to install custom plugins for the Authoring Tool, see [installPlugins.js](installPlugins.js)
+
+A custom plugin can have a backend, a frontend, or both.
+
+## Summary
+
+**✅ Does**
+
+- Run as a postinstall script
+- Clean the plugins directory before installing
+- Copy backend plugins to the correct location
+- Install any npm dependencies the plugin may have
+- Copy frontend plugins to `frontend/src/plugins`
+- Only install plugins with the `isEnabled` property set to `true`
+
+**❌ Does not**
+
+- Rebuild the frontend
+- Handle running individual installation steps
+
+## Usage
+
+From the root of the Authoring Tool project, run the following command:
+
+```bash
+node installPlugins.js
+```
+
+_(Note: Requires setup below)_
+
+## Setup
+
+For each custom plugin, the conf/config.json should be updated.
+
+Example of conf/config.json with three custom plugins:
+
+```json
+{
+  /*
+    ...the rest of the conf/config.json
+    */
+
+  // The plugins object should be added to the config.json
+  "plugins": {
+    // This plugin has a frontend and a backend
+    "name-of-plugin-1": {
+      "isEnabled": true,
+      "frontend": {
+        "path": "/home/user/my-custom-plugins/plugin-1/plugin-1-frontend"
+      },
+      "backend": {
+        "path": "/home/user/my-custom-plugins/plugin-1/plugin-1-backend",
+        "dest": "plugintype"
+      }
+    },
+    // This plugin only has a backend
+    "name-of-plugin-2": {
+      "isEnabled": true,
+      "frontend": null,
+      "backend": {
+        "path": "/home/user/my-custom-plugins/plugin-2/plugin-2-backend",
+        "dest": "plugintype"
+      }
+    },
+    // This plugin is disabled
+    "name-of-plugin-3": {
+      "isEnabled": true,
+      "frontend": null,
+      "backend": {
+        "path": "/home/user/my-custom-plugins/plugin-3/plugin-3-backend",
+        "dest": "plugintype"
+      }
+    }
+  }
+}
+```
+
+## Break down of plugin configuration
+
+#### Name of plugin `(String)`
+
+e.g. `name-of-plugin-1`
+
+This name should match the name given in the plugin's `package.json` file. If it's a custom plugin without a backend, something beginning with `adapt-` should be used.
+
+#### isEnabled `(Boolean)`
+
+If set to `true`, the plugin will be installed. If set to `false`, the plugin will not be installed.
+
+#### frontend `(Object)`
+
+All frontend plugins are copied to `frontend/src/plugins`.
+
+Can be `null`
+
+If the plugin has a frontend, the frontend object should contain:
+
+`path` property, which is used as the source for the frontend plugin files.
+
+Should be a valid path on the local filesystem.
+
+The name of the last folder in the path will be used as the name of the plugin folder in `frontend/src/plugins`.
+e.g.
+
+```json
+"frontend": {
+  "path": "path/to/my-frontend-plugin"
+}
+```
+
+Will copy the plugin to `frontend/src/plugins/my-frontend-plugin`
+
+#### backend `(Object)`
+
+The backend object should contain:
+
+`path` property, which is used as the source for the backend plugin files.
+Should be a valid path on the local filesystem.
+
+`dest` property, which is used as the destination for the backend plugin files.
+Can be one of the plugin folders that already exist, e.g. "auth", "content", "output", "filestorage", or it can be a new folder name.
+
+e.g.
+
+```json
+"backend": {
+  "path": "path/to/my-backend-plugin",
+  "dest": "plugintype"
+}
+```
+
+Will copy the plugin to `plugins/plugintype/my-backend-plugin`

--- a/installPlugins.js
+++ b/installPlugins.js
@@ -1,0 +1,127 @@
+const chalk = require('chalk');
+const fs = require('fs-extra');
+const path = require('path');
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+const config = require('./conf/config.json');
+
+let frontendPlugins = [];
+let backendPlugins = [];
+
+async function setupPlugins() {
+  
+  console.log(chalk.bgCyan('\n🔌 (Step 1/6) Checking plugins config'));
+  checkConfig();
+  
+  console.log(chalk.bgCyan('\n🔌 (Step 2/6) Cleanup frontend'));
+  await cleanUpFrontend();
+  
+  console.log(chalk.bgCyan('\n🔌 (Step 3/6) Cleanup backend'));
+  await cleanUpBackend();
+  
+  console.log(chalk.bgCyan('\n🔌 (Step 4/6) Copy frontend plugins'));
+  await copyFrontendPlugins();
+
+  console.log(chalk.bgCyan('\n🔌 (Step 5/6) Copy backend plugins'));
+  await copyBackendPlugins();
+
+  console.log(chalk.bgCyan('\n🔌 (Step 6/6) Installing backend plugin dependencies'));
+  await installBackendPlugins();
+
+  console.log(chalk.bgCyan('\n🔌 Done '));
+}
+
+function checkConfig() {
+  const pluginsConfig = config?.plugins;
+  if (!pluginsConfig) {
+    console.log(chalk.yellow('No plugins config found in config.json'));
+    process.exit(1);
+  }
+
+  for (const [pluginName, configValues] of Object.entries(pluginsConfig)) {
+    if (!configValues?.isEnabled) {
+      console.log(`Plugin ${chalk.yellow(pluginName)} is not enabled. Skipping...`);
+      continue;
+    }
+    
+    console.log(`👀 Checking config for plugin: ${chalk.blue(pluginName)}`);
+
+    // Add frontend plugins
+    if (configValues.frontend) {
+      frontendPlugins.push(configValues.frontend);
+    }
+
+    // Add backend plugins
+    if (configValues.backend) {
+      backendPlugins.push({ ...configValues.backend, name: pluginName });
+    }
+  }
+}
+
+async function cleanUpFrontend() {
+  // remove all plugins from frontend/src/plugins
+  const pluginsDir = path.join(__dirname, 'frontend', 'src', 'plugins');
+  await fs.remove(pluginsDir);
+  console.log(`🗑 Removed all frontend plugins from ${chalk.blue( pluginsDir)}`);
+}
+
+async function cleanUpBackend() {
+  // restore backend plugins folder
+  await fs.remove('plugins');
+  const checkout = await exec(`git checkout ./plugins`);
+  console.log(`♻ Checkout ./plugins from git`);
+  console.log(checkout.stdout);
+}
+
+async function copyFrontendPlugins() {
+  return Promise.all(
+    frontendPlugins.map(async (config) => {
+      const pluginDir = config.path;
+      const pluginName = path.basename(pluginDir);
+      const dest = path.join(
+        __dirname,
+        'frontend',
+        'src',
+        'plugins',
+        pluginName
+      );
+      await fs.copy(pluginDir, dest);
+      console.log(`Copied frontend ${chalk.blue(pluginName)} to ${chalk.blue(dest)}`);
+    })
+  );
+}
+
+async function copyBackendPlugins() {
+  return Promise.all(
+    backendPlugins.map(async (config) => {
+      if (!config.path) {
+        console.log(`💢 No path found for plugin ${chalk.red(config.name)}`);
+        return;
+      }
+      if (!config.dest) {
+        console.log(`💢 No dest found for plugin ${chalk.red(config.name)}`);
+        return;
+      }
+      const pluginDir = config.path;
+      const pluginName = path.basename(pluginDir);
+      const dest = path.join(__dirname, 'plugins', config.dest, pluginName);
+      await fs.ensureDir(dest);
+      await fs.copy(pluginDir, dest);
+      console.log(`Copied backend plugin ${chalk.blue(pluginName)} to ${chalk.blue(dest)}`);
+    })
+  );
+}
+
+async function installBackendPlugins() {
+  return Promise.all(
+    backendPlugins.map(async (config) => {
+      const pluginDir = config.path;
+      const pluginName = path.basename(pluginDir);
+      const dest = path.join(__dirname, 'plugins', config.dest, pluginName);
+      const install = await exec(`npm install`, { cwd: dest });
+      console.log(install.stdout);
+    })
+  );
+}
+
+setupPlugins();

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "adapt_authoring",
       "version": "0.11.2",
+      "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {
         "@babel/core": "^7.19.6",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "scripts": {
     "test": "grunt test",
-    "create-migration": "npx migrate-mongo create -f conf/migrations.js"
+    "create-migration": "npx migrate-mongo create -f conf/migrations.js",
+    "postinstall": "node ./installPlugins.js"
   },
   "dependencies": {
     "@babel/core": "^7.19.6",


### PR DESCRIPTION
Resolves https://github.com/Laerdal/adapt_authoring/issues/22

## Proposed changes

A new script is added `installPlugins.js` which can be run by itself, but it also runs after a `npm install` is executed.

(Below is copy/paste of the new readme INSTALLPLUGINS.MD)

# Install Plugins (Authoring Tool)

A helper script is available to install custom plugins for the Authoring Tool, see [installPlugins.js](installPlugins.js)

A custom plugin can have a backend, a frontend, or both.

## Summary

**✅ Does**

- Run as a postinstall script
- Clean the plugins directory before installing
- Copy backend plugins to the correct location
- Install any npm dependencies the plugin may have
- Copy frontend plugins to `frontend/src/plugins`
- Only install plugins with the `isEnabled` property set to `true`

**❌ Does not**

- Rebuild the frontend
- Handle running individual installation steps

## Usage

From the root of the Authoring Tool project, run the following command:

```bash
node installPlugins.js
```

_(Note: Requires setup below)_

## Setup

For each custom plugin, the conf/config.json should be updated.

Example of conf/config.json with three custom plugins:

```json
{
  /*
    ...the rest of the conf/config.json
    */

  // The plugins object should be added to the config.json
  "plugins": {
    // This plugin has a frontend and a backend
    "name-of-plugin-1": {
      "isEnabled": true,
      "frontend": {
        "path": "/home/user/my-custom-plugins/plugin-1/plugin-1-frontend"
      },
      "backend": {
        "path": "/home/user/my-custom-plugins/plugin-1/plugin-1-backend",
        "dest": "plugintype"
      }
    },
    // This plugin only has a backend
    "name-of-plugin-2": {
      "isEnabled": true,
      "frontend": null,
      "backend": {
        "path": "/home/user/my-custom-plugins/plugin-2/plugin-2-backend",
        "dest": "plugintype"
      }
    },
    // This plugin is disabled
    "name-of-plugin-3": {
      "isEnabled": false,
      "frontend": null,
      "backend": {
        "path": "/home/user/my-custom-plugins/plugin-3/plugin-3-backend",
        "dest": "plugintype"
      }
    }
  }
}
```

## Break down of plugin configuration

#### Name of plugin `(String)`

e.g. `name-of-plugin-1`

This name should match the name given in the plugin's `package.json` file. If it's a custom plugin without a backend, something beginning with `adapt-` should be used.

#### isEnabled `(Boolean)`

If set to `true`, the plugin will be installed. If set to `false`, the plugin will not be installed.

#### frontend `(Object)`

All frontend plugins are copied to `frontend/src/plugins`.

Can be `null`

If the plugin has a frontend, the frontend object should contain:

`path` property, which is used as the source for the frontend plugin files.

Should be a valid path on the local filesystem.

The name of the last folder in the path will be used as the name of the plugin folder in `frontend/src/plugins`.
e.g.

```json
"frontend": {
  "path": "path/to/my-frontend-plugin"
}
```

Will copy the plugin to `frontend/src/plugins/my-frontend-plugin`

#### backend `(Object)`

The backend object should contain:

`path` property, which is used as the source for the backend plugin files.
Should be a valid path on the local filesystem.

`dest` property, which is used as the destination for the backend plugin files.
Can be one of the plugin folders that already exist, e.g. "auth", "content", "output", "filestorage", or it can be a new folder name.

e.g.

```json
"backend": {
  "path": "path/to/my-backend-plugin",
  "dest": "plugintype"
}
```

Will copy the plugin to `plugins/plugintype/my-backend-plugin`

# Console output example
![image](https://github.com/Laerdal/adapt_authoring/assets/40148279/06d7983a-13e7-4a6b-a02b-30f7fdca9050)



