### PR TITLE
Fix: CKEditor body text sometimes not editable issue #26

### DIFF
--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -69,7 +69,8 @@ define([
     textAreaRender.call(this);
 
     _.defer(function() {
-      this.editor = CKEDITOR.replace(this.$el[0], {
+      this.editor = CKEDITOR.replace(this.$el[0], {      
+	      delayDetached: true,
         dataIndentationChars: '',
         disableNativeSpellChecker: false,
         enterMode: CKEDITOR[Origin.constants.ckEditorEnterMode],

--- a/routes/index/index.hbs
+++ b/routes/index/index.hbs
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="css/adapt.css" />
     <link rel="stylesheet" href="font-awesome-4.5.0/css/font-awesome.min.css">
     <script type="text/javascript" src="modernizr.js"></script>
-    <script src="//cdn.ckeditor.com/4.16.2/full-all/ckeditor.js"></script>
+    <script src="//cdn.ckeditor.com/4.17.1/full-all/ckeditor.js"></script>
     {{#if isProduction}}
       <script type="text/javascript" src="require.js" data-main="js/origin.js{{#if dateStampAsString}}?{{dateStampAsString}}{{/if}}"></script>
     {{else}}


### PR DESCRIPTION
## Proposed changes

fixes https://github.com/Laerdal/adapt_authoring/issues/26

## Description

Problem addressed: Sometimes, when I open the editor page, the body text section is thin, empty, and not always editable.

![image](https://github.com/Laerdal/adapt_authoring/assets/132436261/c020f4c5-92f8-4bd2-8437-f92b26b05d72)

