### PR TITLE
New upgrade option added "skipFrameworkPluginUpdate"

### DIFF
--- a/lib/installHelpers.js
+++ b/lib/installHelpers.js
@@ -560,6 +560,10 @@ function updateFrameworkPlugins(opts, callback) {
   if(arguments.length !== 2) {
     return callback(new Error('Cannot update Adapt framework plugins, invalid options passed.'));
   }
+  if(opts.skipFrameworkPluginUpdate) {
+    log('Adapt framework plugin updates were skipped.');
+    return callback();
+  }
   if(!opts.directory) {
     return callback(new Error('Cannot update Adapt framework plugins, no target directory specified.'));
   }

--- a/upgrade.js
+++ b/upgrade.js
@@ -77,6 +77,16 @@ function getUserInput() {
       default: ''
     }
   ];
+
+  var frameworkProperties = [
+    {
+      name: 'skipFrameworkPluginUpdate',
+      type: 'confirm',
+      message: 'Skip framework plugin update?',
+      default: false
+    }
+  ];
+
   if (IS_INTERACTIVE) {
     console.log(`\nThis script will update the ${app.polyglot.t('app.productname')} and/or Adapt Framework. Would you like to continue?`);
   }
@@ -100,9 +110,15 @@ function getUserInput() {
         if(!result.authoringToolGitTag && !result.frameworkGitTag) {
           return installHelpers.exit(1, 'Cannot update sofware if no revisions are specified.');
         }
-        doUpdate({
+        const updateData = {
           adapt_authoring: result.authoringToolGitTag,
           adapt_framework: result.frameworkGitTag
+        };
+
+        // check if the user wants to skip framework plugin updates
+        installHelpers.getInput(frameworkProperties, argv, function(result) {
+          updateData.skipFrameworkPluginUpdate = !installHelpers.inputHelpers.isFalsy(result.skipFrameworkPluginUpdate);
+          doUpdate(updateData);
         });
       });
     });
@@ -156,7 +172,8 @@ function doUpdate(data) {
       installHelpers.updateFramework({
         repository: configuration.getConfig('frameworkRepository'),
         revision: data.adapt_framework,
-        directory: dir
+        directory: dir,
+        skipFrameworkPluginUpdate: data.skipFrameworkPluginUpdate
       }, function(error) {
         if(error) {
           console.log(`Failed to upgrade ${dir.replace(configuration.serverRoot, '')} to ${data.adapt_framework}`);


### PR DESCRIPTION
resolves https://github.com/Laerdal/adapt_authoring/issues/28

## Proposed changes

A new upgrade option `skipFrameworkPluginUpdate` is now available when **not** choosing the automatic update.
![image](https://github.com/Laerdal/adapt_authoring/assets/40148279/2362cf4a-e6b2-4939-8564-9f69723a8c73)

The default value is `false`, which would then perform the standard behaviour of the upgrade script.
If this `skipFrameworkPluginUpdate` is not "falsey" when it comes to upgrading the adapt_framework it will skip the `adapt install` and so no adapt-contrib* plugins will be updated.

## How to test
Example of how to use this option is shown below:
```bash
node upgrade --continue=yes --updateAutomatically=false --authoringToolGitTag=false --frameworkGitTag=master --skipFrameworkPluginUpdate=true
```

