### PR TITLE
Fixed CKEditor body text sometimes not editable issue

### DIFF
--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -68,8 +68,7 @@ define([
   Backbone.Form.editors.TextArea.prototype.render = function() {
     textAreaRender.call(this);
 
-    _.defer(function() {
-      setTimeout(function() {
+    _.delay(function() {
       this.editor = CKEDITOR.replace(this.$el[0], {      
 	      delayDetached: true,
         dataIndentationChars: '',
@@ -115,7 +114,6 @@ define([
         ]
       });
     }.bind(this), 100);
-    }.bind(this));
 
     return this;
   };

--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -69,6 +69,7 @@ define([
     textAreaRender.call(this);
 
     _.defer(function() {
+      setTimeout(function() {
       this.editor = CKEDITOR.replace(this.$el[0], {      
 	      delayDetached: true,
         dataIndentationChars: '',
@@ -113,6 +114,7 @@ define([
           { name: 'others', items: [ '-' ] }
         ]
       });
+    }.bind(this), 100);
     }.bind(this));
 
     return this;


### PR DESCRIPTION
## Proposed changes
fixes https://github.com/Laerdal/adapt_authoring/issues/26

**Description**

Problem addressed: Sometimes, when I open the editor page, the body text section is empty, and not always editable.

![285867647-c020f4c5-92f8-4bd2-8437-f92b26b05d72](https://github.com/Laerdal/adapt_authoring/assets/35100121/1ce433dd-12d1-4ccc-b6f4-e19eaf3969e0)
