### PR TITLE
The default screenSize values have been added to the configuration settings Added

### DIFF
--- a/plugins/content/config/index.js
+++ b/plugins/content/config/index.js
@@ -82,6 +82,12 @@ function initialize () {
           _isEnabled : false,
           _shouldSupportLegacyBrowsers : true,
           _isTextProcessorEnabled: false
+        },
+        screenSize: {
+          small: 0,
+          medium: 720,
+          large: 960,
+          xlarge: 1280
         }
       };
 


### PR DESCRIPTION

Fix [31](https://github.com/Laerdal/adapt_authoring/issues/31)
## Description
Issue addressed: The default screenSize values have been added to the configuration settings, and they successfully load when the course is being previewed.
![image](https://github.com/Laerdal/adapt_authoring/assets/35100121/e0ebd7f7-9804-4afc-81f5-112763177cfc)

 

