### PR TITLE
Feature: ADAPT-2493 Conditional view for checkbox

### DIFF
--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -10,6 +10,8 @@ define([
   var textInitialize = Backbone.Form.editors.Text.prototype.initialize;
   var selectInitialize = Backbone.Form.editors.Select.prototype.initialize;
   var selectRender = Backbone.Form.editors.Select.prototype.render;
+  var checkboxInitialize = Backbone.Form.editors.Checkbox.prototype.initialize;
+  var checkboxRender = Backbone.Form.editors.Checkbox.prototype.render;
   var textAreaRender = Backbone.Form.editors.TextArea.prototype.render;
   var textAreaSetValue = Backbone.Form.editors.TextArea.prototype.setValue;
 
@@ -248,7 +250,21 @@ define([
     return this;
   };
 
-  // If a radio or select input has the data-is-conditional attribute, then show/hide the relevant fields
+  Backbone.Form.editors.Checkbox.prototype.initialize = function (options) {
+    checkboxInitialize.call(this, options);
+    this.on('change', updateConditionalView, this);
+  };
+
+  Backbone.Form.editors.Checkbox.prototype.render = function() {
+    checkboxRender.call(this);
+
+    // Update view after the checkbox has been rendered
+    _.defer(updateConditionalView.bind(this));
+
+    return this;
+  };
+
+  // If a radio, select, or checkbox input has the data-is-conditional attribute, then show/hide the relevant fields
   function updateConditionalView() {
 
     const editorAttrs = this.schema.editorAttrs;
@@ -256,8 +272,12 @@ define([
   
     if (editorAttrs['data-is-conditional']) {
       const currentOption = this.getValue();
-      $(`[data-depends-on=${this.key}]`).toggle(false);
-      $(`[data-depends-on=${this.key}][data-option-match=${currentOption}]`).toggle(true);
+      if (this instanceof Backbone.Form.editors.Checkbox) {
+        $(`[data-depends-on=${this.key}]`).toggle(currentOption);
+      } else {
+        $(`[data-depends-on=${this.key}]`).toggle(false);
+        $(`[data-depends-on=${this.key}][data-option-match=${currentOption}]`).toggle(true);
+      }
     }
   }
 });


### PR DESCRIPTION
resolves https://github.com/Laerdal/adapt_authoring/issues/35

Plugins setup using the data-is-conditional, data-depends-on and data-option-match in their properties schema can use Checkbox input types to conditionally show other plugin properties. See example below:

              "_emailConfirmation": {
                "default": false,
                "type": "boolean",
                "title": "Confirmation field",
                "inputType": "Checkbox",
                "editorAttrs": { "data-is-conditional": true },
                "help": "If enabled, it will create an additional field for re-confirming the input."
              },
              "_emailConfirmationLabel": {
                "type": "string",
                "required": false,
                "default": "",
                "title": "Label",
                "inputType": "Text",
                "validators": [],
                "help": "Label for the email confirmation field.",
                "translatable": true,
                "fieldAttrs": {
                  "data-depends-on": "_emailConfirmation",
                  "data-option-match": true
                }
              },
              "_emailConfirmationPlaceholder": {
                "type": "string",
                "required": false,
                "default": "",
                "title": "Placeholder",
                "inputType": "Text",
                "validators": [],
                "help": "Suggested input or a hint for the expected value in the field.",
                "translatable": true,
                "fieldAttrs": {
                  "data-depends-on": "_emailConfirmation",
                  "data-option-match": true
                }
              }