### PR TITLE
Fixed-Custom-CSS-Issue-While-Importing

### DIFF
--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -523,7 +523,7 @@ OutputPlugin.prototype.applyTheme = function(tenantId, courseId, jsonObject, des
  * @param next
  */
 OutputPlugin.prototype.writeThemeVariables = function(courseId, theme, themeVariables, destinationFolder, next) {
-  var destinationFile = path.join(destinationFolder, Constants.Folders.Less, Constants.Folders.CustomStyleDirectory, Constants.Filenames.Variables);
+  var destinationFile = path.join(destinationFolder, Constants.Folders.Less, Constants.Filenames.Variables);
   var modifiedProperties = "";
   var props = {};
   var savedSettings = {};
@@ -755,7 +755,7 @@ OutputPlugin.prototype.writeCustomStyle = function(tenantId, courseId, destinati
         if (results[0].customStyle) {
           // There is a custom style applied
           var data = results[0].customStyle;
-          var filename = path.join(destinationFolder, Constants.Folders.Less, Constants.Folders.CustomStyleDirectory, Constants.Filenames.CustomStyle);
+          var filename = path.join(destinationFolder, Constants.Folders.Less, Constants.Filenames.CustomStyle);
 
           fs.outputFile(filename, data, 'utf8', function(err) {
             if (err) {


### PR DESCRIPTION
## Expected Behaviour
While importing the course with custom CSS in the project settings - it should be intact (i.e.) The Custom CSS should not be empty.

## Actual Behaviour
As a course creator, They see that a course that is exported with the custom CSS misses the custom CSS in Project settings when I import the same exported package within the authoring tool.

## Steps to Reproduce
1. Export the Course - having Custom CSS in the project setting.
2. Edit some data in the exported course.
3. Import back the course - check the custom CSS in project setting (It gets disappear).