### PR TITLE
Preserve the HTML tags inserted into the CKEditor's source option.

### DIFF
--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -77,7 +77,7 @@ define([
         disableNativeSpellChecker: false,
         enterMode: CKEDITOR[Origin.constants.ckEditorEnterMode],
         entities: false,
-        extraAllowedContent: Origin.constants.ckEditorExtraAllowedContent,
+        allowedContent: true,
         on: {
           change: function() {
             this.trigger('change', this);


### PR DESCRIPTION
resolves https://github.com/Laerdal/adapt_authoring/issues/42

To allow all HTML tags in CKEditor 4, we can achieve this by setting the allowedContent configuration option to true. Here's how it is done:

```
allowedContent: true
```

Note: This configuration will disable content filtering entirely, allowing users to input any HTML tags and attributes into the CKEditor without them being stripped out.