### PR TITLE
hotfix: disabled version check for ckeditor to avoid getting upgrade …

### DIFF
--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -75,6 +75,7 @@ define([
 	      delayDetached: true,
         dataIndentationChars: '',
         disableNativeSpellChecker: false,
+        versionCheck:false,
         enterMode: CKEDITOR[Origin.constants.ckEditorEnterMode],
         entities: false,
         allowedContent: true,


### PR DESCRIPTION
resolves https://github.com/Laerdal/adapt_authoring/issues/56

### Temporarily solution: disabling the version check for ckeditor until there is an upgrade from the community 