### PR TITLE
Release : Fixed theme preset issue w.r.t custom CSS

### DIFF
--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -76,8 +76,7 @@ var Constants = {
         Components: 'components',
         Less: 'less',
         Framework: 'adapt_framework',
-        Plugins: 'plugins',
-        CustomStyleDirectory: 'zzzzz'
+        Plugins: 'plugins'
     },
     Filenames: {
       Download: 'download.zip',
@@ -648,7 +647,7 @@ OutputPlugin.prototype.writeThemeVariables = function(courseId, theme, themeVari
       // Delete old/write new LESS file
       if (modifiedProperties.length === 0) {
         // No theme customisation, clear file
-        fs.removeSync(path.join(destinationFolder, Constants.Folders.Less, Constants.Folders.CustomStyleDirectory, Constants.Filenames.Variables));
+        fs.removeSync(path.join(destinationFolder, Constants.Folders.Less, Constants.Filenames.Variables));
         return seriesCallback(null);
       }
 


### PR DESCRIPTION
## Expected Behaviour
While importing the course with custom CSS in the project settings - it should be intact (i.e.) The Custom CSS should not be empty.
 
## Actual Behaviour
As a course creator, They see that a course that is exported with the custom CSS misses the custom CSS in Project settings when I import the same exported package within the authoring tool.
 
## Steps to Reproduce
1. Export the Course - having Custom CSS in the project setting.
2. Edit some data in the exported course.
3. Import back the course - check the custom CSS in project setting (It gets disappear).