### PR TITLE
Release : Fixed theme preset issue w.r.t custom CSS

### DIFF
--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -76,7 +76,8 @@ var Constants = {
         Components: 'components',
         Less: 'less',
         Framework: 'adapt_framework',
-        Plugins: 'plugins'
+        Plugins: 'plugins',
+        CustomStyleDirectory: 'zzzzz'
     },
     Filenames: {
       Download: 'download.zip',
@@ -522,7 +523,7 @@ OutputPlugin.prototype.applyTheme = function(tenantId, courseId, jsonObject, des
  * @param next
  */
 OutputPlugin.prototype.writeThemeVariables = function(courseId, theme, themeVariables, destinationFolder, next) {
-  var destinationFile = path.join(destinationFolder, Constants.Folders.Less, Constants.Filenames.Variables);
+  var destinationFile = path.join(destinationFolder, Constants.Folders.Less, Constants.Folders.CustomStyleDirectory, Constants.Filenames.Variables);
   var modifiedProperties = "";
   var props = {};
   var savedSettings = {};
@@ -647,7 +648,7 @@ OutputPlugin.prototype.writeThemeVariables = function(courseId, theme, themeVari
       // Delete old/write new LESS file
       if (modifiedProperties.length === 0) {
         // No theme customisation, clear file
-        fs.removeSync(path.join(destinationFolder, Constants.Folders.Less, Constants.Filenames.Variables));
+        fs.removeSync(path.join(destinationFolder, Constants.Folders.Less, Constants.Folders.CustomStyleDirectory, Constants.Filenames.Variables));
         return seriesCallback(null);
       }
 
@@ -754,7 +755,7 @@ OutputPlugin.prototype.writeCustomStyle = function(tenantId, courseId, destinati
         if (results[0].customStyle) {
           // There is a custom style applied
           var data = results[0].customStyle;
-          var filename = path.join(destinationFolder, Constants.Folders.Less, Constants.Filenames.CustomStyle);
+          var filename = path.join(destinationFolder, Constants.Folders.Less, Constants.Folders.CustomStyleDirectory, Constants.Filenames.CustomStyle);
 
           fs.outputFile(filename, data, 'utf8', function(err) {
             if (err) {

--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -524,6 +524,7 @@ OutputPlugin.prototype.applyTheme = function(tenantId, courseId, jsonObject, des
  */
 OutputPlugin.prototype.writeThemeVariables = function(courseId, theme, themeVariables, destinationFolder, next) {
   var destinationFile = path.join(destinationFolder, Constants.Folders.Less, Constants.Folders.CustomStyleDirectory, Constants.Filenames.Variables);
+  var customeCSSdestinationFile = path.join(destinationFolder, Constants.Folders.Less, Constants.Filenames.Variables);
   var modifiedProperties = "";
   var props = {};
   var savedSettings = {};
@@ -645,18 +646,61 @@ OutputPlugin.prototype.writeThemeVariables = function(courseId, theme, themeVari
       });
     },
     function(seriesCallback) {
-      // Delete old/write new LESS file
-      if (modifiedProperties.length === 0) {
-        // No theme customisation, clear file
-        fs.removeSync(path.join(destinationFolder, Constants.Folders.Less, Constants.Folders.CustomStyleDirectory, Constants.Filenames.Variables));
-        return seriesCallback(null);
-      }
-
-      fs.outputFile(destinationFile, modifiedProperties, 'utf8', function(err) {
+      async.series([function(firstseriesCallback) {
+          // For custom LESS file
+          //const lessDestinationFile = path.join(destinationFolder, Constants.Folders.Less, Constants.Filenames.Variables);
+      
+          // Delete old or write new LESS file
+          if (modifiedProperties.length === 0) {
+            // No theme customisation, clear file synchronously
+            try {
+              fs.removeSync(destinationFile);
+              return firstseriesCallback(null); // No error, callback with null
+            } catch (err) {
+              logger.log('error', 'Failed to remove old LESS file');
+              return firstseriesCallback(err); // Error occurred, callback with error
+            }
+          }
+      
+          // Write modifiedProperties to LESS file
+          fs.outputFile(destinationFile, modifiedProperties, 'utf8', function(err) {
+            if (err) {
+              logger.log('error', 'Failed to write new LESS file');
+            }
+            firstseriesCallback(err); // Pass error or null to series callback
+          });
+        },
+        function(secondseriesCallback) {
+          // For custom CSS file
+          //const cssDestinationFile = path.join(customCSSdestinationFile, Constants.Folders.Less, Constants.Filenames.Variables);
+      
+          // Delete old or write new CSS file
+          if (modifiedProperties.length === 0) {
+            // No theme CSS customisation, clear file synchronously
+            try {
+              fs.removeSync(customeCSSdestinationFile);
+              return secondseriesCallback(null); // No error, callback with null
+            } catch (err) {
+              logger.log('error', 'Failed to remove old CSS file');
+              return secondseriesCallback(err); // Error occurred, callback with error
+            }
+          }
+      
+          // Write modifiedProperties to CSS file
+          fs.outputFile(customeCSSdestinationFile, modifiedProperties, 'utf8', function(err) {
+            if (err) {
+              logger.log('error', 'Failed to write new CSS file');
+            }
+            secondseriesCallback(err); // Pass error or null to series callback
+          });
+        }
+      ], function(err) {
         if (err) {
           logger.log('error', 'Theme customisations 4 of 4');
+          seriesCallback(err);
+        } else {
+          seriesCallback(null);
         }
-        seriesCallback(err);
       });
     },
     function(seriesCallback) {
@@ -756,6 +800,7 @@ OutputPlugin.prototype.writeCustomStyle = function(tenantId, courseId, destinati
           // There is a custom style applied
           var data = results[0].customStyle;
           var filename = path.join(destinationFolder, Constants.Folders.Less, Constants.Folders.CustomStyleDirectory, Constants.Filenames.CustomStyle);
+          var customCSSfilename = path.join(destinationFolder, Constants.Folders.Less, Constants.Filenames.CustomStyle);
 
           fs.outputFile(filename, data, 'utf8', function(err) {
             if (err) {
@@ -763,14 +808,28 @@ OutputPlugin.prototype.writeCustomStyle = function(tenantId, courseId, destinati
               return next(err);
             }
 
-            return next(null, 'Custom LESS file written');
+            logger.log('info', 'Custom LESS file written');
+            //return next(null, 'Custom LESS file written');
+          //});
+
+          fs.outputFile(customCSSfilename, data, 'utf8', function(err) {
+            if (err) {
+              logger.log('error', err);
+              return next(err);
+            }
+
+            logger.log('info', 'Custom LESS file written');
+            return next(null, 'Custom LESS and CSS file written');
+            //return next(null, 'Custom CSS LESS file written');
+        //});
           });
-        } else {
+        });
+      } else {
           return next(null, 'No custom LESS file required');
         }
       } else {
         logger.log('info', 'More than one course record');
-        return next(err);
+        return next(new Error('More than one course record'));
       }
     });
   }, tenantId);

--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -809,8 +809,6 @@ OutputPlugin.prototype.writeCustomStyle = function(tenantId, courseId, destinati
             }
 
             logger.log('info', 'Custom LESS file written');
-            //return next(null, 'Custom LESS file written');
-          //});
 
           fs.outputFile(customCSSfilename, data, 'utf8', function(err) {
             if (err) {
@@ -820,8 +818,6 @@ OutputPlugin.prototype.writeCustomStyle = function(tenantId, courseId, destinati
 
             logger.log('info', 'Custom LESS file written');
             return next(null, 'Custom LESS and CSS file written');
-            //return next(null, 'Custom CSS LESS file written');
-        //});
           });
         });
       } else {

--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -76,8 +76,7 @@ var Constants = {
         Components: 'components',
         Less: 'less',
         Framework: 'adapt_framework',
-        Plugins: 'plugins',
-        CustomStyleDirectory: 'zzzzz'
+        Plugins: 'plugins'
     },
     Filenames: {
       Download: 'download.zip',
@@ -648,7 +647,7 @@ OutputPlugin.prototype.writeThemeVariables = function(courseId, theme, themeVari
       // Delete old/write new LESS file
       if (modifiedProperties.length === 0) {
         // No theme customisation, clear file
-        fs.removeSync(path.join(destinationFolder, Constants.Folders.Less, Constants.Folders.CustomStyleDirectory, Constants.Filenames.Variables));
+        fs.removeSync(path.join(destinationFolder, Constants.Folders.Less, Constants.Filenames.Variables));
         return seriesCallback(null);
       }
 


### PR DESCRIPTION
## Expected Behaviour
While importing the course with custom CSS in the project settings - it should be intact (i.e.) The Custom CSS should not be empty.
 
## Actual Behaviour
As a course creator, They see that a course that is exported with the custom CSS misses the custom CSS in Project settings when I import the same exported package within the authoring tool.
 
## Steps to Reproduce
1. Export the Course - having Custom CSS in the project setting.
2. Edit some data in the exported course.
3. Import back the course - check the custom CSS in project setting (It gets disappear).