### PR TITLE
Add Notification Popups for Deprecated Plugins

### DIFF
--- a/frontend/src/modules/navigation/views/navigationView.js
+++ b/frontend/src/modules/navigation/views/navigationView.js
@@ -17,6 +17,7 @@ define(function(require){
     },
 
     render: function() {
+      Origin.Notify.alert({ type: 'info', text: '<p style="text-align:left">To streamline our extensions, we will soon disable some that are no longer needed. Below is a list of the extensions being replaced, along with their alternatives. Please note that this will not affect existing courses.</p><br/> <ul style="text-align:left"><li>Laerdal Branching → Branching + Trickle</li><li>Laerdal Spoor → Spoor</li><li>Inline Feedback → Tutor with inline option</li></ul>' });
       var data = this.model ? this.model.toJSON() : null;
       var template = Handlebars.templates[this.constructor.template];
       this.$el.html(template(data));


### PR DESCRIPTION
## Proposed changes

Implemented notification popups to inform users about deprecated plugins. These popups provide proactive alerts to ensure users are aware of outdated plugins and encourage timely action. The notifications include:

Plugin name 
Information on deprecation reasons
<img width="390" alt="image" src="https://github.com/user-attachments/assets/676eab46-aa51-4b44-8a1b-12a00f40904c">

