### PR TITLE
Fix: Preserve HTML Tags in CKEditor

### DIFF
--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -95,7 +95,7 @@ define([
         versionCheck: false,
         enterMode: CKEDITOR[Origin.constants.ckEditorEnterMode],
         entities: false,
-        extraAllowedContent: true,
+        allowedContent: true,
         on: {
           change: function () {
             this.trigger('change', this);


### PR DESCRIPTION
### Resolves https://github.com/Laerdal/adapt_authoring/issues/85

Recent changes in CKEditor have caused HTML tags to vanish. This impacts users who rely on these tags for formatting and functionality within the editor.

This issue was previously resolved in https://github.com/Laerdal/adapt_authoring/issues/42, but the latest updates to the CKEditor core have overridden that fix (see https://github.com/Laerdal/adapt_authoring/pull/76).

Next steps
Any modifications made in CKEditor should be approached with caution, always considering the potential issues that may arise.