### PR TITLE
ADAPT-2654 : Fixed issue of CSS being duplicated while exporting the corses.

### DIFF
--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -76,8 +76,7 @@ var Constants = {
         Components: 'components',
         Less: 'less',
         Framework: 'adapt_framework',
-        Plugins: 'plugins',
-        CustomStyleDirectory: 'zzzzz'
+        Plugins: 'plugins'
     },
     Filenames: {
       Download: 'download.zip',
@@ -523,7 +522,7 @@ OutputPlugin.prototype.applyTheme = function(tenantId, courseId, jsonObject, des
  * @param next
  */
 OutputPlugin.prototype.writeThemeVariables = function(courseId, theme, themeVariables, destinationFolder, next) {
-  var destinationFile = path.join(destinationFolder, Constants.Folders.Less, Constants.Folders.CustomStyleDirectory, Constants.Filenames.Variables);
+  var destinationFile = path.join(destinationFolder, Constants.Folders.Less, Constants.Filenames.Variables);
   var customeCSSdestinationFile = path.join(destinationFolder, Constants.Folders.Less, Constants.Filenames.Variables);
   var modifiedProperties = "";
   var props = {};
@@ -799,7 +798,7 @@ OutputPlugin.prototype.writeCustomStyle = function(tenantId, courseId, destinati
         if (results[0].customStyle) {
           // There is a custom style applied
           var data = results[0].customStyle;
-          var filename = path.join(destinationFolder, Constants.Folders.Less, Constants.Folders.CustomStyleDirectory, Constants.Filenames.CustomStyle);
+          var filename = path.join(destinationFolder, Constants.Folders.Less, Constants.Filenames.CustomStyle);
           var customCSSfilename = path.join(destinationFolder, Constants.Folders.Less, Constants.Filenames.CustomStyle);
 
           fs.outputFile(filename, data, 'utf8', function(err) {


### PR DESCRIPTION
As a course creator, the course that is exported with the custom CSS misses the custom CSS in Project settings when I import the same exported package within the authoring tool - This causes it the duplicate CSS while it was being re-exported.

**Expected Behavior**
Make sure there shouldn't be any CSS with duplicate content.