### PR TITLE
Feature: ADAPT-2918 : Added an feature to track the user inactivity for more than 1 hour.

### DIFF
--- a/frontend/src/modules/user/index.js
+++ b/frontend/src/modules/user/index.js
@@ -6,11 +6,54 @@ define(function(require) {
   var UserProfileView = require('./views/userProfileView');
   var UserProfileSidebarView = require('./views/userProfileSidebarView');
   var UserProfileModel = require('./models/userProfileModel');
-
+  
   var ForgotPasswordView = require('./views/forgotPasswordView');
   var ResetPasswordView = require('./views/resetPasswordView');
   var UserPasswordResetModel = require('./models/userPasswordResetModel');
 
+  var inactivityTimer;
+  var idleTimeLimit = (Origin.constants.maxAge ?  Origin.constants.maxAge : 3600000); // 1 hrs of inactivity before logout or 1 day if maxAge is not defined.
+
+  // Function to handle user activity and reset inactivity timer
+  function resetInactivityTimer() {
+    if (inactivityTimer) {
+      clearTimeout(inactivityTimer);
+    }
+    inactivityTimer = setTimeout(logoutUser, idleTimeLimit); // Log out after 10 seconds of inactivity
+  }
+
+  // Function to log out the user
+  function logoutUser() {
+    console.log("User logged out due to inactivity");
+    Origin.Notify.alert({
+      type: 'error',
+      text: Origin.l10n.t('app.errorsessionexpired')
+    });  
+    Origin.sessionModel.logout();
+  }
+
+  // Listen for various user interactions to reset the inactivity timer
+  document.addEventListener('mousemove', resetInactivityTimer);
+  document.addEventListener('mousedown', resetInactivityTimer);
+  document.addEventListener('scroll', resetInactivityTimer);
+
+  window.addEventListener('scroll', resetInactivityTimer);
+  document.addEventListener('keydown', resetInactivityTimer);
+  window.addEventListener('resize', resetInactivityTimer);
+  
+  window.addEventListener('click', resetInactivityTimer);
+  document.addEventListener('click', resetInactivityTimer);
+  
+  document.addEventListener('touchstart', resetInactivityTimer);
+  document.addEventListener('pointerdown', resetInactivityTimer);
+   
+  document.addEventListener('focus', resetInactivityTimer, true); // Capture the event on the document level
+  document.addEventListener('visibilitychange', resetInactivityTimer);
+
+  // Initializing the inactivity timer when the module loads
+  resetInactivityTimer();
+
+  // Handling navigation actions
   Origin.on('navigation:user:logout', function() {
     Origin.router.navigateTo('user/logout');
   });
@@ -47,7 +90,7 @@ define(function(require) {
         currentView = UserProfileView;
         break;
     }
-
+    
     if (currentView) {
       switch (location) {
         case 'profile':

--- a/frontend/src/modules/user/index.js
+++ b/frontend/src/modules/user/index.js
@@ -5,21 +5,20 @@ define(function(require) {
   var LoginView = require('./views/loginView');
   var UserProfileView = require('./views/userProfileView');
   var UserProfileSidebarView = require('./views/userProfileSidebarView');
-  var UserProfileModel = require('./models/userProfileModel');
-  
+  var UserProfileModel = require('./models/userProfileModel');  
   var ForgotPasswordView = require('./views/forgotPasswordView');
   var ResetPasswordView = require('./views/resetPasswordView');
   var UserPasswordResetModel = require('./models/userPasswordResetModel');
 
   var inactivityTimer;
-  var idleTimeLimit = (Origin.constants.maxAge ?  Origin.constants.maxAge : 3600000); // 1 hrs of inactivity before logout or 1 day if maxAge is not defined.
+  var idleTimeLimit = (Origin.constants.maxAge ?  Origin.constants.maxAge : 3600000); // 1 hrs of inactivity before logout or 1 hour by default - if maxAge is not defined.
 
   // Function to handle user activity and reset inactivity timer
   function resetInactivityTimer() {
     if (inactivityTimer) {
       clearTimeout(inactivityTimer);
     }
-    inactivityTimer = setTimeout(logoutUser, idleTimeLimit); // Log out after 10 seconds of inactivity
+    inactivityTimer = setTimeout(logoutUser, idleTimeLimit); // Log out after 1 hour of inactivity
   }
 
   // Function to log out the user
@@ -90,7 +89,6 @@ define(function(require) {
         currentView = UserProfileView;
         break;
     }
-    
     if (currentView) {
       switch (location) {
         case 'profile':

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -36,7 +36,8 @@ var ALLOWED_CLIENT_SIDE_KEYS = [
   'ckEditorEnterMode',
   'maxFileUploadSize',
   'supportLink',
-  'supportContact'
+  'supportContact',
+  "maxAge"
 ];
 
 /**
@@ -161,7 +162,8 @@ function Configuration() {
       ],
     },
     maxFileUploadSize: '200MB',
-    ckEditorEnterMode: 'ENTER_P'
+    ckEditorEnterMode: 'ENTER_P',
+    maxAge: 3600000
   };
   this.mconf = {};
   return this;


### PR DESCRIPTION
Resolves #101 
Every user profile blocks some memory space in the server and the increased number of users with inactive sessions appear to impact the performance of the production instances.

This needs to be addressed by killing an user session which has been inactive for more than an hour. The user can then login to create another active session.

**Note**: the "maxAge" configuration variable is used to set the inactivity session timer on different instances, so as to reduce the different builds to be delivered for different stakeholders.