### PR TITLE
BugFix: ADAPT-3010-Revert the CKEditor5 changes

### DIFF
--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -88,31 +88,14 @@ define([
       };
     }
 
-    function convertStringsToRegExDeep (arr) {
-      function processEntry ([key, value]) {
-        value = (typeof value === "string")
-          ? new RegExp(value, 'i')
-          : Array.isArray(value)
-            ? arr.map((value, index) => processEntry([index, value])[1])
-            : (typeof value === "object" && value !== null)
-              ? Object.fromEntries(Object.entries(value).map(processEntry))
-              : value;
-        return [key, value];
-      }
-      return arr.map((value, index) => processEntry([index, value])[1])
-    }
-
-    until(isAttached(this.$el)).then(() => {
-      return CKEDITOR.create(this.$el[0], {
+    until(isAttached(this.$el)).then(function() {
+      this.editor = CKEDITOR.replace(this.$el[0], {
         dataIndentationChars: '',
         disableNativeSpellChecker: false,
+        versionCheck:false,
         enterMode: CKEDITOR[Origin.constants.ckEditorEnterMode],
         entities: false,
-        htmlSupport: {
-          // Convert all allow/disallow strings to regexp, as config is json only
-          allow: convertStringsToRegExDeep((Origin.constants.ckEditorHtmlSupport && Origin.constants.ckEditorHtmlSupport.allow) || []),
-          disallow: convertStringsToRegExDeep((Origin.constants.ckEditorHtmlSupport && Origin.constants.ckEditorHtmlSupport.disallow) || [])
-        },
+        allowedContent: true,
         on: {
           change: function() {
             this.trigger('change', this);
@@ -134,50 +117,24 @@ define([
             elements.forEach(function(element) { writer.setRules(element, rules); });
           }
         },
-        plugins: window.CKEDITOR.pluginsConfig,
-        toolbar: {
-          items: [
-            'sourceEditing',
-            'showBlocks',
-            'undo',
-            'redo',
-            '|',
-            'findAndReplace',
-            'selectAll',
-            '|',
-            'numberedList',
-            'bulletedList',
-            'blockQuote',
-            'indent',
-            'outdent',
-            '|',
-            'bold',
-            'italic',
-            'underline',
-            'strikethrough',
-            'subscript',
-            'superscript',
-            'alignment',
-            'removeFormat',
-            '|',
-            'link',
-            'fontColor',
-            'fontBackgroundColor',
-            '|',
-            'specialCharacters',
-            'insertTable'
-          ],
-          shouldNotGroupWhenFull: true
-        }
-      }).then(editor => {
-        this.editor = editor
-        CKEDITOR.instances = CKEDITOR.instances || []
-        CKEDITOR.instances.length = CKEDITOR.instances.length || 0;
-        this.editor.id = CKEDITOR.instances.length
-        CKEDITOR.instances.length++;
-        CKEDITOR.instances[this.editor.id] = this.editor
-      })
-    });
+        toolbar: [
+          { name: 'document', groups: [ 'mode', 'document', 'doctools' ], items: [ 'Source', '-', 'ShowBlocks' ] },
+          { name: 'clipboard', groups: [ 'clipboard', 'undo' ], items: [ 'PasteText', 'PasteFromWord', '-', 'Undo', 'Redo' ] },
+          { name: 'editing', groups: [ 'find', 'selection', 'spellchecker' ], items: [ 'Find', 'Replace', '-', 'SelectAll' ] },
+          { name: 'paragraph', groups: [ 'list', 'indent', 'blocks', 'align', 'bidi' ], items: [ 'NumberedList', 'BulletedList', '-', 'Outdent', 'Indent', '-', 'Blockquote', 'CreateDiv' ] },
+          { name: 'direction', items: [ 'BidiLtr', 'BidiRtl' ] },
+          '/',
+          { name: 'basicstyles', groups: [ 'basicstyles', 'cleanup' ], items: [ 'Bold', 'Italic', 'Underline', 'Strike', 'Subscript', 'Superscript', '-', 'RemoveFormat'] },
+          { name: 'styles', items: [ 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock' ] },
+          { name: 'links', items: [ 'Link', 'Unlink' ] },
+          { name: 'colors', items: [ 'TextColor', 'BGColor' ] },
+          { name: 'insert', items: [ 'SpecialChar', 'Table' ] },
+          { name: 'tools', items: [] },
+          { name: 'others', items: [ '-' ] }
+        ]
+      });
+    }.bind(this));
+
     return this;
   };
 
@@ -197,8 +154,8 @@ define([
 
   // ckeditor removal
   Backbone.Form.editors.TextArea.prototype.remove = function() {
-    this.editor.stopListening()
-    delete CKEDITOR.instances[this.editor.id]
+    this.editor.removeAllListeners();
+    CKEDITOR.remove(this.editor);
   };
 
   // add override to allow prevention of validation

--- a/frontend/src/modules/scaffold/less/textArea.less
+++ b/frontend/src/modules/scaffold/less/textArea.less
@@ -1,9 +1,26 @@
 .field-editor {
-  .ck.ck-editor {
-    width: 93% !important;
+  .cke_chrome {
+    border-color: #ccc;
+    border-radius: 2px;
+    overflow: hidden;
+    box-shadow: none;
+    width: 93%;
+  }
 
-    .ck.ck-content {
-      min-height: 200px !important;
-    }
+  .cke_top {
+    background: #eee;
+    border-color: #ccc;
+    box-shadow: none;
+  }
+
+  .cke_bottom {
+    background: @white;
+    border-color: #ccc;
+  }
+
+  .cke_toolgroup {
+    background-image: none;
+    background: @white;
+    border-color: #ccc;
   }
 }

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -32,12 +32,13 @@ var ALLOWED_CLIENT_SIDE_KEYS = [
   'useSmtp',
   'isProduction',
   'maxLoginAttempts',
-  'ckEditorHtmlSupport',
+  'ckEditorExtraAllowedContent',
   'ckEditorEnterMode',
   'maxFileUploadSize',
   'supportLink',
   'supportContact',
-  "maxAge"
+  "maxAge",
+  'skipVersionCheck',
 ];
 
 /**
@@ -82,88 +83,11 @@ function Configuration() {
   this.conf = {
     root: this.serverRoot,
     maxLoginAttempts: 3,
-    ckEditorHtmlSupport: {
-      allow: [
-        {
-          // Allow HTML elements with their attributes, classes, and styles.
-          name: "^(blockquote|ul|ol|span|video|source|iframe|img|audio|style)$",
-          attributes: true,
-          classes: true,
-          styles: true,
-        },
-        {
-          // Define specific attributes for the <video> element.
-          name: "video",
-          attributes: {
-            width: true,
-            height: true,
-            controls: true,
-            autoplay: true,
-            muted: true,
-            loop: true,
-            src: true,
-
-          },
-        },
-        {
-          // Define specific attributes for the <source> element.
-          name: "source",
-          attributes: {
-            src: true,
-            type: true,
-          },
-        },
-        {
-          // define specific attributes for the <img> element.
-          name: "img",
-          attributes: {
-            src: true,
-            alt: true,
-            width: true,
-            height: true,
-          },
-        },
-        {
-          // Define specific attributes for the <audio> element.
-          name: "audio",
-          attributes: {
-            src: true,
-            controls: true,
-            autoplay: true,
-            loop: true,
-            muted: true,
-            preload: true,
-            crossorigin: true,
-            playsinline: true,
-          },
-        },
-        {
-          // Define specific attributes for the <style> element.
-          name: "style",
-          attributes: {
-            type: true,
-          },
-        },
-        {
-          // Define specific attributes for the <div> element.
-          name: "div",
-          attributes: {
-            class: true,
-            style: true,
-          },
-        },
-        {
-          // Define specific attributes for the <a> element.
-          name: "^a$",
-          attributes: {
-            target: true,
-          },
-        },
-      ],
-    },
+    ckEditorExtraAllowedContent: 'span(*)',    
     maxFileUploadSize: '200MB',
     ckEditorEnterMode: 'ENTER_P',
-    maxAge: 3600000
+    maxAge: 3600000,
+    skipVersionCheck: false,
   };
   this.mconf = {};
   return this;

--- a/routes/index/index.hbs
+++ b/routes/index/index.hbs
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="css/adapt.css" />
     <link rel="stylesheet" href="font-awesome-4.5.0/css/font-awesome.min.css">
     <script type="text/javascript" src="modernizr.js"></script>
-		<link rel="stylesheet" href="https://cdn.ckeditor.com/ckeditor5/42.0.0/ckeditor5.css">
+		<script src="//cdn.ckeditor.com/4.17.0/full-all/ckeditor.js"></script>
     {{#if isProduction}}
       <script type="text/javascript" src="require.js" data-main="js/origin.js{{#if dateStampAsString}}?{{dateStampAsString}}{{/if}}"></script>
     {{else}}
@@ -47,106 +47,5 @@
         </div>
       </div>
     </div>
-    <script type="importmap">
-			{
-				"imports": {
-					"ckeditor5": "https://cdn.ckeditor.com/ckeditor5/42.0.0/ckeditor5.js",
-					"ckeditor5/": "https://cdn.ckeditor.com/ckeditor5/42.0.0/"
-				}
-			}
-		</script>
-    <script type="module">
-      import {
-        ClassicEditor,
-        Alignment,
-        Autoformat,
-        AutoLink,
-        Autosave,
-        BalloonToolbar,
-        BlockQuote,
-        BlockToolbar,
-        Bold,
-        Clipboard,
-        Code,
-        Essentials,
-        FindAndReplace,
-        GeneralHtmlSupport,
-        Font,
-        Highlight,
-        Indent,
-        IndentBlock,
-        Italic,
-        Link,
-        List,
-        ListProperties,
-        Paragraph,
-        SelectAll,
-        ShowBlocks,
-        SourceEditing,
-        SpecialCharacters,
-        SpecialCharactersArrows,
-        SpecialCharactersCurrency,
-        SpecialCharactersEssentials,
-        SpecialCharactersLatin,
-        SpecialCharactersMathematical,
-        SpecialCharactersText,
-        Strikethrough,
-        Subscript,
-        Superscript,
-        Table,
-        TableCellProperties,
-        TableProperties,
-        TableToolbar,
-        TextTransformation,
-        Underline,
-        Undo
-      } from 'ckeditor5';
-      
-      window.CKEDITOR = ClassicEditor
-      window.CKEDITOR.pluginsConfig = [
-        Alignment,
-        Autoformat,
-        AutoLink,
-        Autosave,
-        BalloonToolbar,
-        BlockQuote,
-        BlockToolbar,
-        Bold,
-        Clipboard,
-        Code,
-        Essentials,
-        FindAndReplace,
-        GeneralHtmlSupport,
-        Font,
-        Highlight,
-        Indent,
-        IndentBlock,
-        Italic,
-        Link,
-        List,
-        ListProperties,
-        Paragraph,
-        SelectAll,
-        ShowBlocks,
-        SourceEditing,
-        SpecialCharacters,
-        SpecialCharactersArrows,
-        SpecialCharactersCurrency,
-        SpecialCharactersEssentials,
-        SpecialCharactersLatin,
-        SpecialCharactersMathematical,
-        SpecialCharactersText,
-        Strikethrough,
-        Subscript,
-        Superscript,
-        Table,
-        TableCellProperties,
-        TableProperties,
-        TableToolbar,
-        TextTransformation,
-        Underline,
-        Undo
-      ];
-    </script>
   </body>
 </html>


### PR DESCRIPTION
## Proposed changes
Fixed: [ADAPT-3010](https://laerdal.atlassian.net/browse/ADAPT-3010)
Updated CKEditor version is stripping the HTML tags that were allowed earlier to CKEditor5 to CKEditor4

Below are the PR changes are Reverting
https://github.com/Laerdal/adapt_authoring/pull/87/files

https://github.com/adaptlearning/adapt_authoring/pull/2780/files#diff-8fa0d79f50d5ae8542f7eda95461365c530023006ff162de479de6ad03e5983d
https://github.com/adaptlearning/adapt_authoring/pull/2773/files#diff-ade867bfceb69ce0512bac850b8765b7beda6d34ffd250e9718561362464b384


