### PR TITLE
Hotfix: Reverting CKEditor5 back to V4

### DIFF
--- a/frontend/src/modules/scaffold/less/textArea.less
+++ b/frontend/src/modules/scaffold/less/textArea.less
@@ -1,9 +1,26 @@
 .field-editor {
-  .ck.ck-editor {
-    width: 93% !important;
+  .cke_chrome {
+    border-color: #ccc;
+    border-radius: 2px;
+    overflow: hidden;
+    box-shadow: none;
+    width: 93%;
+  }
 
-    .ck.ck-content {
-      min-height: 200px !important;
-    }
+  .cke_top {
+    background: #eee;
+    border-color: #ccc;
+    box-shadow: none;
+  }
+
+  .cke_bottom {
+    background: @white;
+    border-color: #ccc;
+  }
+
+  .cke_toolgroup {
+    background-image: none;
+    background: @white;
+    border-color: #ccc;
   }
 }

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -32,12 +32,13 @@ var ALLOWED_CLIENT_SIDE_KEYS = [
   'useSmtp',
   'isProduction',
   'maxLoginAttempts',
-  'ckEditorHtmlSupport',
+  'ckEditorExtraAllowedContent',
   'ckEditorEnterMode',
   'maxFileUploadSize',
   'supportLink',
   'supportContact',
-  "maxAge"
+  "maxAge",
+  'skipVersionCheck',
 ];
 
 /**
@@ -82,88 +83,11 @@ function Configuration() {
   this.conf = {
     root: this.serverRoot,
     maxLoginAttempts: 3,
-    ckEditorHtmlSupport: {
-      allow: [
-        {
-          // Allow HTML elements with their attributes, classes, and styles.
-          name: "^(blockquote|ul|ol|span|video|source|iframe|img|audio|style)$",
-          attributes: true,
-          classes: true,
-          styles: true,
-        },
-        {
-          // Define specific attributes for the <video> element.
-          name: "video",
-          attributes: {
-            width: true,
-            height: true,
-            controls: true,
-            autoplay: true,
-            muted: true,
-            loop: true,
-            src: true,
-
-          },
-        },
-        {
-          // Define specific attributes for the <source> element.
-          name: "source",
-          attributes: {
-            src: true,
-            type: true,
-          },
-        },
-        {
-          // define specific attributes for the <img> element.
-          name: "img",
-          attributes: {
-            src: true,
-            alt: true,
-            width: true,
-            height: true,
-          },
-        },
-        {
-          // Define specific attributes for the <audio> element.
-          name: "audio",
-          attributes: {
-            src: true,
-            controls: true,
-            autoplay: true,
-            loop: true,
-            muted: true,
-            preload: true,
-            crossorigin: true,
-            playsinline: true,
-          },
-        },
-        {
-          // Define specific attributes for the <style> element.
-          name: "style",
-          attributes: {
-            type: true,
-          },
-        },
-        {
-          // Define specific attributes for the <div> element.
-          name: "div",
-          attributes: {
-            class: true,
-            style: true,
-          },
-        },
-        {
-          // Define specific attributes for the <a> element.
-          name: "^a$",
-          attributes: {
-            target: true,
-          },
-        },
-      ],
-    },
+    ckEditorExtraAllowedContent: 'span(*)',    
     maxFileUploadSize: '200MB',
     ckEditorEnterMode: 'ENTER_P',
-    maxAge: 3600000
+    maxAge: 3600000,
+    skipVersionCheck: false,
   };
   this.mconf = {};
   return this;

--- a/routes/index/index.hbs
+++ b/routes/index/index.hbs
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="css/adapt.css" />
     <link rel="stylesheet" href="font-awesome-4.5.0/css/font-awesome.min.css">
     <script type="text/javascript" src="modernizr.js"></script>
-		<link rel="stylesheet" href="https://cdn.ckeditor.com/ckeditor5/42.0.0/ckeditor5.css">
+		<script src="//cdn.ckeditor.com/4.17.0/full-all/ckeditor.js"></script>
     {{#if isProduction}}
       <script type="text/javascript" src="require.js" data-main="js/origin.js{{#if dateStampAsString}}?{{dateStampAsString}}{{/if}}"></script>
     {{else}}
@@ -47,106 +47,5 @@
         </div>
       </div>
     </div>
-    <script type="importmap">
-			{
-				"imports": {
-					"ckeditor5": "https://cdn.ckeditor.com/ckeditor5/42.0.0/ckeditor5.js",
-					"ckeditor5/": "https://cdn.ckeditor.com/ckeditor5/42.0.0/"
-				}
-			}
-		</script>
-    <script type="module">
-      import {
-        ClassicEditor,
-        Alignment,
-        Autoformat,
-        AutoLink,
-        Autosave,
-        BalloonToolbar,
-        BlockQuote,
-        BlockToolbar,
-        Bold,
-        Clipboard,
-        Code,
-        Essentials,
-        FindAndReplace,
-        GeneralHtmlSupport,
-        Font,
-        Highlight,
-        Indent,
-        IndentBlock,
-        Italic,
-        Link,
-        List,
-        ListProperties,
-        Paragraph,
-        SelectAll,
-        ShowBlocks,
-        SourceEditing,
-        SpecialCharacters,
-        SpecialCharactersArrows,
-        SpecialCharactersCurrency,
-        SpecialCharactersEssentials,
-        SpecialCharactersLatin,
-        SpecialCharactersMathematical,
-        SpecialCharactersText,
-        Strikethrough,
-        Subscript,
-        Superscript,
-        Table,
-        TableCellProperties,
-        TableProperties,
-        TableToolbar,
-        TextTransformation,
-        Underline,
-        Undo
-      } from 'ckeditor5';
-      
-      window.CKEDITOR = ClassicEditor
-      window.CKEDITOR.pluginsConfig = [
-        Alignment,
-        Autoformat,
-        AutoLink,
-        Autosave,
-        BalloonToolbar,
-        BlockQuote,
-        BlockToolbar,
-        Bold,
-        Clipboard,
-        Code,
-        Essentials,
-        FindAndReplace,
-        GeneralHtmlSupport,
-        Font,
-        Highlight,
-        Indent,
-        IndentBlock,
-        Italic,
-        Link,
-        List,
-        ListProperties,
-        Paragraph,
-        SelectAll,
-        ShowBlocks,
-        SourceEditing,
-        SpecialCharacters,
-        SpecialCharactersArrows,
-        SpecialCharactersCurrency,
-        SpecialCharactersEssentials,
-        SpecialCharactersLatin,
-        SpecialCharactersMathematical,
-        SpecialCharactersText,
-        Strikethrough,
-        Subscript,
-        Superscript,
-        Table,
-        TableCellProperties,
-        TableProperties,
-        TableToolbar,
-        TextTransformation,
-        Underline,
-        Undo
-      ];
-    </script>
   </body>
 </html>


### PR DESCRIPTION
Reverting CKEditor5 back to V4 as some of the HTML tags used in existing courses are not retained.