### PR TITLE
BugFix: ADAPT-2966 Theme Picker: Color Settings Not Fully Functional

### DIFF
--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -82,11 +82,11 @@ var Constants = {
       Download: 'download.zip',
       Main: 'index.html',
       Rebuild: '.rebuild',
-      CustomStyle: '2-customStyles.less',
+      CustomStyle: 'z-2-customStyles.less',
       Bower: 'bower.json',
       Package: 'package.json',
       Metadata: 'metadata.json',
-      Variables: '1-themeVariables.less',
+      Variables: 'z-1-themeVariables.less',
       Assets: 'assets.json'
     },
     Modes: {


### PR DESCRIPTION
## Proposed changes

**Fixed: [ADAPT-2966](https://laerdal.atlassian.net/browse/ADAPT-2966)**

The Theme Picker's Color Settings feature is malfunctioning due to the rendering order of the files '1-customStyles.less' and '1-themeVariables.less'. Since these filenames begin with a number, they are processed first. Consequently, any values added in '1-customStyles.less' and '1-themeVariables.less' are being overwritten by other .less files that are rendered afterward. To resolve this issue, I have renamed the .less files accordingly.

