### PR TITLE
Hotfix: WHO Update the support Link

### DIFF
--- a/frontend/src/modules/support/index.js
+++ b/frontend/src/modules/support/index.js
@@ -11,7 +11,7 @@ define(function (require) {
     });
 
     function openSupportLink() {
-        let SUPPORT_URL = 'https://laerdal.atlassian.net/jira/servicedesk/projects/AS/queues/custom/10';
+        let SUPPORT_URL = 'https://laerdal.atlassian.net/servicedesk/customer/portal/2';
         window.open(SUPPORT_URL);
     }
 });


### PR DESCRIPTION
## Proposed changes

Fixed: [ADAPT-3063](https://laerdal.atlassian.net/browse/ADAPT-3063)

Updated the Support link from “https://laerdal.atlassian.net/jira/servicedesk/projects/AS/queues/custom/10 “ to “[Adapt support](https://laerdal.atlassian.net/servicedesk/customer/portal/2) “
