### PR TITLE
Feedback Label and Help Icon Overlap Slightly When Articles Are Toggled #131

### DIFF
--- a/frontend/src/modules/contentPane/views/contentPaneView.js
+++ b/frontend/src/modules/contentPane/views/contentPaneView.js
@@ -61,6 +61,9 @@ define(function(require) {
     resize: function() {
       var windowHeight = $(window).height();
       this.$el.height(windowHeight - this.$el.offset().top);
+      let headerHeight = $('.navigation').height() + $('.location-title').height();
+      (windowHeight <= this.el.scrollHeight + headerHeight) ? $('html').addClass('feedbackScrollPosition') : $('html').removeClass('feedbackScrollPosition');
+    
     },
 
     onScroll: function(e) {

--- a/frontend/src/modules/editor/contentObject/views/editorPageArticleView.js
+++ b/frontend/src/modules/editor/contentObject/views/editorPageArticleView.js
@@ -283,12 +283,18 @@ define(function(require){
 
     collapseAllArticles: function() {
       if (this.model.get('_isCollapsed') === true) return; 
-      this.model.set('_isCollapsed', true);
+      this.model.set('_isCollapsed', true);      
+      let windowHeight = $(window).height();
+      let headerHeight = $('.navigation').height() + $('.location-title').height();
+      (windowHeight <= this.el.scrollHeight + Math.round(headerHeight)) ? $('html').addClass('feedbackScrollPosition') : $('html').removeClass('feedbackScrollPosition');
     },
 
     expandAllArticles: function() {
       if (this.model.get('_isCollapsed') === false) return; 
       this.model.set('_isCollapsed', false);
+      let windowHeight = $(window).height();
+      let headerHeight = $('.navigation').height() + $('.location-title').height();
+      (windowHeight <= $('.contentPane').height() + Math.ceil(headerHeight)) ? $('html').addClass('feedbackScrollPosition') : $('html').removeClass('feedbackScrollPosition');
     },
 
     collapseArticle: function() {

--- a/routes/index/index.hbs
+++ b/routes/index/index.hbs
@@ -29,9 +29,15 @@
     <!-- End Google Analytics -->
     {{/if}}
     <style>
+      .location-login a#atlwdg-trigger {
+        left: 100%!important;
+      }
       a#atlwdg-trigger {
-        left: calc(100% - 18px);
+        left: 100%;
         background-color: #2aa3ce;
+      }
+      .feedbackScrollPosition a#atlwdg-trigger {
+        left: calc(100% - 16px);
       }
     </style>
   </head>


### PR DESCRIPTION
## Proposed changes
This pull request introduces changes to enhance the handling of scroll feedback and visual adjustments for specific UI elements. The changes primarily focus on dynamically adding or removing a CSS class based on viewport and content height calculations, as well as updating styles for a feedback widget trigger.

### Scroll feedback improvements:

* [`frontend/src/modules/contentPane/views/contentPaneView.js`](diffhunk://#diff-1e9341bae98aed2036edd434ba6bac8954fa15c87a8b26cb9f9a3a8e3254b5f3R64-R66): Added logic in the `resize` method to dynamically toggle the `feedbackScrollPosition` class on the `<html>` element based on the height of the viewport and content.
* [`frontend/src/modules/editor/contentObject/views/editorPageArticleView.js`](diffhunk://#diff-138d0573c1d51a0fea128570d110be28ceed05fe33df4cdd72000c1519f4b22bR287-R297): Updated the `collapseAllArticles` and `expandAllArticles` methods to include similar logic for toggling the `feedbackScrollPosition` class, ensuring consistent behavior when articles are collapsed or expanded.

### Feedback widget style adjustments:

* [`routes/index/index.hbs`](diffhunk://#diff-ade867bfceb69ce0512bac850b8765b7beda6d34ffd250e9718561362464b384R32-R41): Updated styles for the `#atlwdg-trigger` element to adjust its position based on the presence of the `feedbackScrollPosition` class, ensuring proper alignment in different scenarios.
Please describe your changes in full here, including steps needed to build/test it. The more useful detail you give, the easier it is for the core team to review and approve :smile:

![image](https://github.com/user-attachments/assets/42c0c82e-04ab-46de-a54f-e1df660893a5)
