### PR TITLE
Provide feedback toggling articles moves the label issue #131

### DIFF
--- a/frontend/src/modules/editor/contentObject/views/editorPageArticleView.js
+++ b/frontend/src/modules/editor/contentObject/views/editorPageArticleView.js
@@ -284,17 +284,13 @@ define(function(require){
     collapseAllArticles: function() {
       if (this.model.get('_isCollapsed') === true) return; 
       this.model.set('_isCollapsed', true);      
-      let windowHeight = $(window).height();
-      let headerHeight = $('.navigation').height() + $('.location-title').height();
-      (windowHeight <= this.el.scrollHeight + Math.round(headerHeight)) ? $('html').addClass('feedbackScrollPosition') : $('html').removeClass('feedbackScrollPosition');
+      this.checkScrollbarVisibility();
     },
 
     expandAllArticles: function() {
       if (this.model.get('_isCollapsed') === false) return; 
       this.model.set('_isCollapsed', false);
-      let windowHeight = $(window).height();
-      let headerHeight = $('.navigation').height() + $('.location-title').height();
-      (windowHeight <= $('.contentPane').height() + Math.ceil(headerHeight)) ? $('html').addClass('feedbackScrollPosition') : $('html').removeClass('feedbackScrollPosition');
+      this.checkScrollbarVisibility();
     },
 
     collapseArticle: function() {
@@ -307,6 +303,15 @@ define(function(require){
         duration = 0;
       }
       this.$('.article-content').velocity(shouldCollapse ? 'slideUp' : 'slideDown', duration);
+    },
+
+    checkScrollbarVisibility: function() {
+      setTimeout(() => {
+        const $container = $('.contentPane');
+        const hasScrollbar = $container[0].scrollHeight > $container[0].clientHeight;
+        hasScrollbar ? $('html').addClass('feedbackScrollPosition') : $('html').removeClass('feedbackScrollPosition');
+        console.log('Articles collapsed - Scrollbar visible:', hasScrollbar);
+      }, 250);
     }
 
   }, {


### PR DESCRIPTION
## Proposed changes

This pull request refactors the logic for handling scrollbar visibility in the `editorPageArticleView.js` file by consolidating duplicate code into a new helper method, `checkScrollbarVisibility`. This change improves code readability and maintainability.

### Refactoring for scrollbar visibility:

* Replaced duplicated logic in `collapseAllArticles` and `expandAllArticles` methods with a call to the new `checkScrollbarVisibility` method. This reduces code redundancy and centralizes the logic for determining scrollbar visibility. (`frontend/src/modules/editor/contentObject/views/editorPageArticleView.js`, [frontend/src/modules/editor/contentObject/views/editorPageArticleView.jsL287-R293](diffhunk://#diff-138d0573c1d51a0fea128570d110be28ceed05fe33df4cdd72000c1519f4b22bL287-R293))
* Added the `checkScrollbarVisibility` method, which uses a `setTimeout` to check if the content pane has a scrollbar and toggles the `feedbackScrollPosition` class on the `<html>` element accordingly. This method also logs the visibility status to the console for debugging purposes. (`frontend/src/modules/editor/contentObject/views/editorPageArticleView.js`, [frontend/src/modules/editor/contentObject/views/editorPageArticleView.jsR306-R314](diffhunk://#diff-138d0573c1d51a0fea128570d110be28ceed05fe33df4cdd72000c1519f4b22bR306-R314))


![image](https://github.com/user-attachments/assets/127d8b95-b68b-4c6e-b810-f3478b887959)
