### PR TITLE
Feature: ADAPT-3204 CKEditor Enhancement for Accurate Markdown-to-HTML Transformation

### DIFF
--- a/frontend/src/modules/scaffold/less/textArea.less
+++ b/frontend/src/modules/scaffold/less/textArea.less
@@ -93,6 +93,7 @@ button.ai-button {
     
    li{    
   white-space: normal !important;
+  margin-left: 15px !important;
   }
   
 
@@ -138,4 +139,7 @@ button.ai-button {
   .ai-select-prompt{
     padding: 10px!important;
   }
+}
+.ck-content li{
+  margin-left: 20px !important;
 }


### PR DESCRIPTION
**Address :  [ADAPT-3204](https://laerdal.atlassian.net/browse/ADAPT-3204)**

## Proposed changes

This pull request includes updates to improve code readability, enhance the functionality of a Markdown-to-HTML conversion utility, and refine UI styling. The most significant changes involve replacing `var` with `let` for better variable scoping, updating the Markdown conversion logic to support additional features, and adjusting CSS styles for list elements.

### Code readability improvements:
* Replaced `var` with `let` for the `$aiTitle` variable in multiple instances within `frontend/src/modules/scaffold/backboneFormsOverrides.js` to ensure proper block scoping. [[1]](diffhunk://#diff-8fa0d79f50d5ae8542f7eda95461365c530023006ff162de479de6ad03e5983dL223-R223) [[2]](diffhunk://#diff-8fa0d79f50d5ae8542f7eda95461365c530023006ff162de479de6ad03e5983dL702-R702)

### Markdown-to-HTML conversion enhancements:
* Enhanced the `simpleMarkdownToHTML` function in `frontend/src/modules/scaffold/backboneFormsOverrides.js`:
  - Added decoding of known HTML entities before escaping to improve compatibility. 
  - Expanded support for headings, inline HTML tags, and lists (both ordered and unordered).
  - Introduced support for GFM-style tables and improved handling of paragraphs and block elements.

### UI styling adjustments:
* Updated CSS styles in `frontend/src/modules/scaffold/less/textArea.less`:
  - Adjusted `margin-left` for list items (`li`) to improve spacing in the UI.
  - Added specific styles for `.ck-content li` to ensure consistent list formatting within CKEditor content. [[1]](diffhunk://#diff-07e150ca49995c02adf47dff657a21000813fa250f49f3e9f9d1f5428471e56bR96) [[2]](diffhunk://#diff-07e150ca49995c02adf47dff657a21000813fa250f49f3e9f9d1f5428471e56bR143-R145)

### Functional UI changes:
* Modified the visibility of the `tryAgainBtn` element in `frontend/src/modules/scaffold/backboneFormsOverrides.js` to be hidden (`display: none`) instead of inline-block, improving the user interface flow.