### PR TITLE
Feature: ADAPT- 3214 Hide the Replace button in CKEditor where it's not needed or relevant.

### DIFF
--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -579,7 +579,7 @@ define([
             elements.input.disabled = true;
             elements.loading.style.display = 'none';
             elements.insertBtn.disabled = false;
-            elements.replaceBtn.disabled = isCKEditorEmpty(editor) ? true : false;
+            elements.replaceBtn.disabled = !!((isCKEditorEmpty(editor) || selectedTextValue == ''));
             elements.tryAgainBtn.disabled = false;
             elements.replaceBtn.style.display = 'inline-block';
             elements.tryAgainBtn.style.display = 'inline-block';
@@ -885,7 +885,7 @@ define([
     };
     
      // API call function
-    getAIAssistantResponse = async (selectText, promptInstruction) => {
+    let getAIAssistantResponse = async (selectText, promptInstruction) => {
       if (typeof configData !== 'undefined' && typeof aiconfigJson !== 'undefined' && aiconfigJson.AiEnv) {
         configData.AiEnv = aiconfigJson.AiEnv;
         console.log('configData.AiEnv:', configData.AiEnv);


### PR DESCRIPTION
Resolves : https://github.com/Laerdal/adapt_authoring/issues/137

## Proposed changes
This pull request makes two changes to the `frontend/src/modules/scaffold/backboneFormsOverrides.js` file, focusing on improving functionality and code clarity. The first change refines the logic for enabling or disabling the `replaceBtn`, and the second change updates the declaration of the `getAIAssistantResponse` function.

### Functional Improvements:

* Updated the logic for disabling the `replaceBtn` to account for both an empty CKEditor and an empty `selectedTextValue`, ensuring more accurate button state management.

### Code Clarity:

* Changed the declaration of the `getAIAssistantResponse` function from `function` to `let`, aligning it with modern JavaScript practices for defining asynchronous functions.
