### PR TITLE
Feature: ADAPT-3236: Dynamic ID Updates Preserve Internal References for Attempt Band Branching in Courses

### DIFF
--- a/plugins/content/course/index.js
+++ b/plugins/content/course/index.js
@@ -675,6 +675,13 @@ async function updateBlocksCollection(db, blocks) {
         const correct = metadata.idMap[branching._correct];
         const partlyCorrect = metadata.idMap[branching._partlyCorrect];
         const incorrect = metadata.idMap[branching._incorrect];
+        
+        const attemptBands = branching._attemptBands?.map((band) => ({
+          _attempts: band._attempts,
+          _correct: metadata.idMap[band._correct] || band._correct,
+          _partlyCorrect: metadata.idMap[band._partlyCorrect] || band._partlyCorrect,
+          _incorrect: metadata.idMap[band._incorrect] || band._incorrect,
+        })) || [];
 
         await db.collection('blocks').updateOne(
           { _id: record._id },
@@ -683,6 +690,7 @@ async function updateBlocksCollection(db, blocks) {
               '_extensions._branching._correct': correct || branching._correct,
               '_extensions._branching._partlyCorrect': partlyCorrect || branching._partlyCorrect,
               '_extensions._branching._incorrect': incorrect || branching._incorrect,
+              '_extensions._branching._attemptBands': attemptBands,
             },
           }
         );

--- a/plugins/output/adapt/importsource.js
+++ b/plugins/output/adapt/importsource.js
@@ -802,6 +802,13 @@ function ImportSource(req, done) {
           const partlyCorrect = metadata.idMap[branching._partlyCorrect];
           const incorrect = metadata.idMap[branching._incorrect];
 
+          const attemptBands = branching._attemptBands?.map((band) => ({
+          _attempts: band._attempts,
+          _correct: metadata.idMap[band._correct] || band._correct,
+          _partlyCorrect: metadata.idMap[band._partlyCorrect] || band._partlyCorrect,
+          _incorrect: metadata.idMap[band._incorrect] || band._incorrect,
+        })) || [];
+
           await db.collection('blocks').updateOne(
             { _id: record._id },
             {
@@ -809,6 +816,7 @@ function ImportSource(req, done) {
                 '_extensions._branching._correct': correct || branching._correct,
                 '_extensions._branching._partlyCorrect': partlyCorrect || branching._partlyCorrect,
                 '_extensions._branching._incorrect': incorrect || branching._incorrect,
+                '_extensions._branching._attemptBands': attemptBands,
               },
             }
           );


### PR DESCRIPTION
Fixed: [158](https://github.com/Laerdal/adapt_authoring/issues/158)

This pull request introduces support for handling `attemptBands` in branching logic across two modules, ensuring that additional metadata related to attempts is properly mapped and stored in the database. The changes enhance the handling of branching scenarios by including this new structure.

### Enhancements to branching logic:

* **Support for `attemptBands` in `updateBlocksCollection` function**: Added logic to map and store `attemptBands` metadata in the `blocks` collection, ensuring correct handling of `_correct`, `_partlyCorrect`, and `_incorrect` fields. (`plugins/content/course/index.js`, [plugins/content/course/index.jsR679-R693](diffhunk://#diff-ee6f735ab391b76123e5a568e0e9978b70023e339647344063b3afae19f42bc0R679-R693))
* **Support for `attemptBands` in `ImportSource` function**: Introduced similar logic for mapping and storing `attemptBands` metadata in the `blocks` collection within the `ImportSource` module. (`plugins/output/adapt/importsource.js`, [plugins/output/adapt/importsource.jsR805-R819](diffhunk://#diff-c55e1d038a75d5ef28f85a1e35da587b93a546b21425a813217f12925165bd48R805-R819))