### PR TITLE
feature: ADAPT-3285 Enable CK Editor AI Assistant for the target instance

### DIFF
--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -943,6 +943,7 @@ define([
 
 
     until(isAttached(this.$el)).then(() => {
+      let ckEditorAIAssistantEnable = (Origin && Origin.constants && Origin.constants.ckEditorAIApiKey) ? true : false;
       return CKEDITOR.create(this.$el[0], {
         dataIndentationChars: "",
         disableNativeSpellChecker: false,
@@ -1021,7 +1022,8 @@ define([
             "|",
             "specialCharacters",
             "insertTable",
-            "insertTableLayout","|", "AIPreDefinedPromptsOption", "|", "AIAssistant"
+            "insertTableLayout", 
+            ...(ckEditorAIAssistantEnable ? ["|", "AIPreDefinedPromptsOption", "|", "AIAssistant"] : [])
           ],
           shouldNotGroupWhenFull: true,
         },

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -112,11 +112,6 @@ Configuration.prototype.load = function (filePath, callback) {
     return callback();
   }
   
-  // Load OpenAI configuration from environment variables
-  if (process.env.CKEditor_AI_ASST_API_KEY) {
-    config.conf.ckEditorAIApiKey = process.env.CKEditor_AI_ASST_API_KEY;
-  }
-
   // else, load from the default config file
   fs.exists(filePath, function(exists){
     if (exists) {
@@ -127,6 +122,11 @@ Configuration.prototype.load = function (filePath, callback) {
       absorbConfigFile(config, filePath, function (error) {
         if (error) {
           return callback(error)
+        }
+
+        // Load OpenAI configuration from environment variables (after config file to override)
+        if (process.env.CKEditor_AI_ASST_API_KEY) {
+          config.conf.ckEditorAIApiKey = process.env.CKEditor_AI_ASST_API_KEY;
         }
 
         config.emit('change:config', 'configuration');


### PR DESCRIPTION
**Address : [ADAPT-3285](https://laerdal.atlassian.net/browse/ADAPT-3285)**

## Proposed changes

This pull request introduces changes to enable conditional support for an AI Assistant feature in CKEditor based on configuration settings. The updates include modifications to how the feature is toggled in the frontend and backend, ensuring flexibility and proper handling of environment variables.

### Frontend changes for conditional AI Assistant support:
* [`frontend/src/modules/scaffold/backboneFormsOverrides.js`](diffhunk://#diff-8fa0d79f50d5ae8542f7eda95461365c530023006ff162de479de6ad03e5983dR946): Added a conditional check (`ckEditorAIAssistantEnable`) to determine whether the AI Assistant feature should be enabled based on the presence of `Origin.constants.ckEditorAIApiKey`.
* [`frontend/src/modules/scaffold/backboneFormsOverrides.js`](diffhunk://#diff-8fa0d79f50d5ae8542f7eda95461365c530023006ff162de479de6ad03e5983dL1024-R1026): Updated toolbar configuration to dynamically include AI Assistant options (`AIPreDefinedPromptsOption`, `AIAssistant`) only when the feature is enabled.

### Backend changes for configuration handling:
* [`lib/configuration.js`](diffhunk://#diff-c47540330d377e9cd0e6b633a168ffa74b2781e7a7f14ab6a8e934bd39576e22R127-R131): Moved the loading of the `CKEditor_AI_ASST_API_KEY` environment variable to occur after reading the configuration file, allowing environment variables to override file-based settings.
* [`lib/configuration.js`](diffhunk://#diff-c47540330d377e9cd0e6b633a168ffa74b2781e7a7f14ab6a8e934bd39576e22L115-L119): Removed redundant code that loaded the `CKEditor_AI_ASST_API_KEY` environment variable before reading the configuration file, ensuring a cleaner and more logical flow.

