### PR TITLE
feature: ADAPT-3285 Enable AI Assistant for target instance

### DIFF
--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -939,6 +939,7 @@ define([
 
 
     until(isAttached(this.$el)).then(() => {
+      let ckEditorAIAssistantEnable = (Origin && Origin.constants && Origin.constants.ckEditorAIApiKey) ? true : false;
       return CKEDITOR.create(this.$el[0], {
         dataIndentationChars: "",
         disableNativeSpellChecker: false,
@@ -1017,7 +1018,8 @@ define([
             "|",
             "specialCharacters",
             "insertTable",
-            "insertTableLayout","|", "AIPreDefinedPromptsOption", "|", "AIAssistant"
+            "insertTableLayout",
+            ...(ckEditorAIAssistantEnable ? ["|", "AIPreDefinedPromptsOption", "|", "AIAssistant"] : [])
           ],
           shouldNotGroupWhenFull: true,
         },

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -112,21 +112,22 @@ Configuration.prototype.load = function (filePath, callback) {
     return callback();
   }
 
-  // Load OpenAI configuration from environment variables
-  if (process.env.CKEditor_AI_ASST_API_KEY) {
-    config.conf.ckEditorAIApiKey = process.env.CKEditor_AI_ASST_API_KEY;
-  }
-
   // else, load from the default config file
   fs.exists(filePath, function(exists){
     if (exists) {
       if (config.configFile !== filePath) { // @TODO - notify that config file needs updated
         config.configFile = filePath;
       }
+      
 
       absorbConfigFile(config, filePath, function (error) {
         if (error) {
           return callback(error)
+        }
+
+         // Load OpenAI configuration from environment variables (after config file to override)
+        if (process.env.CKEditor_AI_ASST_API_KEY) {
+          config.conf.ckEditorAIApiKey = process.env.CKEditor_AI_ASST_API_KEY;
         }
 
         config.emit('change:config', 'configuration');


### PR DESCRIPTION
**Address : [ADAPT-3285](https://laerdal.atlassian.net/browse/ADAPT-3285)**

## Proposed changes

In develop branch the CK Editor AI assistant is working fine. So I am applying the same in the dev-next.

This pull request introduces changes to enhance the integration of the CKEditor AI Assistant feature by adding conditional logic for enabling related options and improving configuration loading. The most important changes include enabling AI Assistant options dynamically based on configuration and restructuring the loading of the OpenAI API key in the configuration file.

### Enhancements to CKEditor AI Assistant integration:

* [`frontend/src/modules/scaffold/backboneFormsOverrides.js`](diffhunk://#diff-8fa0d79f50d5ae8542f7eda95461365c530023006ff162de479de6ad03e5983dR942): Added a check (`ckEditorAIAssistantEnable`) to determine if the CKEditor AI Assistant feature should be enabled based on the presence of an API key in `Origin.constants`. This ensures the feature is conditionally activated.
* [`frontend/src/modules/scaffold/backboneFormsOverrides.js`](diffhunk://#diff-8fa0d79f50d5ae8542f7eda95461365c530023006ff162de479de6ad03e5983dL1020-R1022): Modified toolbar configuration to include AI Assistant options (`AIPreDefinedPromptsOption` and `AIAssistant`) only when the feature is enabled, improving flexibility.

### Improvements to configuration loading:

* [`lib/configuration.js`](diffhunk://#diff-c47540330d377e9cd0e6b633a168ffa74b2781e7a7f14ab6a8e934bd39576e22L115-R132): Refactored the loading of the OpenAI API key from environment variables to occur after the configuration file is absorbed, allowing environment variables to override file settings. This ensures better configurability and precedence handling.
