### PR TITLE
remove unsupported options from the image uploader in ckeditor

### DIFF
--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -1031,14 +1031,10 @@ define([
         },
         table: {
           contentToolbar: ['tableColumn', 'tableRow', 'mergeTableCells', 'tableProperties', 'tableCellProperties', 'toggleTableCaption'],
-          tableCaptionPosition: 'top'
         },
+        tableCaptionPosition: 'bottom',
         image: {
           toolbar: [
-            'imageStyle:inline',
-            'imageStyle:block',
-            'imageStyle:side',
-            '|',
             'toggleImageCaption',
             'imageTextAlternative',
             '|',


### PR DESCRIPTION
This pull request makes a minor adjustment to the table caption positioning in the CKEditor configuration. The caption will now appear at the bottom of tables instead of the top and remove image alignment options as they don't support in Adapt


* Changed the `tableCaptionPosition` setting from `'top'` to `'bottom'` in the CKEditor table configuration in `frontend/src/modules/scaffold/backboneFormsOverrides.js`.