### PR TITLE
Feature: ADAPT-3348 CK Editor UI changes

### DIFF
--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -116,12 +116,12 @@ define([
       panelElement.innerHTML = `
         <div class="AiAgent">
           <select class="ai-select-prompt" id="aiSelectPrompt">
-            <option value="select">Select a prompt</option>
+            <option value="select" selected disabled hidden>Select a prompt</option>            
+            <option value="generateAI">Generate Content</option>
             <option value="ImproveWriting">Improve Writing</option>
             <option value="makeShorter">Make Shorter</option>
             <option value="makeLonger">Make Longer</option>
             <option value="spellChecker">Spell Checker</option>
-            <option value="generateAI">Generate Content</option>
           </select>
         </div>
       `;


### PR DESCRIPTION
**Resolved : [ADAPT-3348](https://laerdal.atlassian.net/browse/ADAPT-3348)**

This pull request makes a small update to the AI prompt selection dropdown in the `backboneFormsOverrides.js` file. The change improves the user experience by making the default "Select a prompt" option unselectable and reordering the "Generate Content" option.

- The default "Select a prompt" option in the prompt dropdown is now set as selected, disabled, and hidden, preventing users from submitting it as a valid choice.
- The "Generate Content" option has been moved to appear immediately after the default option, making it more prominent in the list.