### PR TITLE
Feature/adapt 3354 ck editor xml to html conversion styling

### DIFF
--- a/frontend/src/modules/scaffold/less/textArea.less
+++ b/frontend/src/modules/scaffold/less/textArea.less
@@ -157,60 +157,60 @@ button.ai-button, button.ai-predefined-button {
 // XML Import Modal Styles
 .xml-import-popup-panel {
   background: #fff !important;
-  border: 1px solid #ccc;
+  border: 0.063rem solid #ccc;
   border-radius: 6px;
-  box-shadow: 0px 0px 6px 2px rgba(0,0,0,.15);
+  box-shadow: 0px 0.375rem 0.375rem 0.125rem rgba(0,0,0,.15);
   z-index: 99999;
-  width: 450px !important;
-  margin-top: -18px !important;
+  width: 28.688rem !important;
+  margin-top: -1.125rem !important;
 
   textarea {
-      border: 1px #ccc solid !important;
-      margin: 10px 0 !important;
-      padding: 10px !important;
-      height: 120px !important;
+      border: 0.063rem #ccc solid !important;
+      margin: 0.625rem 0 !important;
+      padding: 0.625rem !important;
+      height: 7.5rem !important;
       width: 100% !important;
       resize: vertical !important;
       font-family: monospace !important;
-      font-size: 12px !important;
+      font-size: 0.75rem !important;
   }
   
   label {
       width: 100% !important;
-      font-size: 14px !important;
+      font-size: 0.875rem !important;
       font-weight: bold !important;
       display: flex !important;
       align-items: center !important;
   }
   
   svg {
-      margin-right: 8px !important;
-      font-size: 16px !important;
-      width: 22px !important;
+      margin-right: 0.5rem !important;
+      font-size: 1rem !important;
+      width: 1.375rem !important;
   }
 }
 
 .XmlImport {
   position: relative !important;
-  padding: 10px !important; 
+  padding: 0.625rem !important; 
   width: 100% !important;
   .btnXmlImport {
-    margin-top: 8px;
+    margin-top: 0.5rem;
     background: #2aa3ce !important;
-    padding: 1px 5px !important;
+    padding: 0.0625rem 0.3125rem !important;
     cursor: pointer !important;
-    border-radius: 3px;
+    border-radius: 0.188rem;
     color: #fff !important;
-    margin-right: 5px !important;
+    margin-right: 0.5rem !important;
   }
 }
 
 #closeXmlPopup {
   position: absolute; 
-  top: 8px; 
-  right: 10px; 
+  top: 0.5rem; 
+  right: 0.625rem; 
   cursor: pointer; 
-  font-size: 22px;
+  font-size: 1.375rem;
   font-weight: bold;
   color: #666;
   
@@ -220,16 +220,16 @@ button.ai-button, button.ai-predefined-button {
 }
 
 .btnXmlImport {
-  margin-top: 10px;
+  margin-top: 0.625rem;
   background: #2aa3ce !important;
-  padding: 8px 15px !important;
+  padding: 0.5rem 0.9375rem !important;
   cursor: pointer !important;
-  border-radius: 3px;
+  border-radius: 0.188rem;
   color: #fff !important;
-  margin-right: 8px !important;
+  margin-right: 0.5rem !important;
   border: none !important;
-  font-size: 13px !important;
-  
+  font-size: 0.8125rem !important;
+
   &:hover {
     background: #1e8bb5 !important;
   }
@@ -246,14 +246,14 @@ button.ai-button, button.ai-predefined-button {
 .xmlButtons {
   display: flex;
   justify-content: flex-start;
-  margin-top: 15px;
+  margin-top: 0.9375rem;
 }
 
 button.xml-to-html-button {
     padding: 0 !important;
     margin: 0 !important;
     svg {
-      font-size: 12px !important;
-      margin: 0 3px !important;
+      font-size: 0.75rem !important;
+      margin: 0 0.1875rem !important;
     }
 }

--- a/frontend/src/modules/scaffold/less/textArea.less
+++ b/frontend/src/modules/scaffold/less/textArea.less
@@ -153,3 +153,107 @@ button.ai-button, button.ai-predefined-button {
 .ck.ck-balloon-panel.ck-balloon-panel_with-arrow:after {
     border: 0;
 }
+
+// XML Import Modal Styles
+.xml-import-popup-panel {
+  background: #fff !important;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  box-shadow: 0px 0px 6px 2px rgba(0,0,0,.15);
+  z-index: 99999;
+  width: 450px !important;
+  margin-top: -18px !important;
+
+  textarea {
+      border: 1px #ccc solid !important;
+      margin: 10px 0 !important;
+      padding: 10px !important;
+      height: 120px !important;
+      width: 100% !important;
+      resize: vertical !important;
+      font-family: monospace !important;
+      font-size: 12px !important;
+  }
+  
+  label {
+      width: 100% !important;
+      font-size: 14px !important;
+      font-weight: bold !important;
+      display: flex !important;
+      align-items: center !important;
+  }
+  
+  svg {
+      margin-right: 8px !important;
+      font-size: 16px !important;
+      width: 22px !important;
+  }
+}
+
+.XmlImport {
+  position: relative !important;
+  padding: 10px !important; 
+  width: 100% !important;
+  .btnXmlImport {
+    margin-top: 8px;
+    background: #2aa3ce !important;
+    padding: 1px 5px !important;
+    cursor: pointer !important;
+    border-radius: 3px;
+    color: #fff !important;
+    margin-right: 5px !important;
+  }
+}
+
+#closeXmlPopup {
+  position: absolute; 
+  top: 8px; 
+  right: 10px; 
+  cursor: pointer; 
+  font-size: 22px;
+  font-weight: bold;
+  color: #666;
+  
+  &:hover {
+    color: #000;
+  }
+}
+
+.btnXmlImport {
+  margin-top: 10px;
+  background: #2aa3ce !important;
+  padding: 8px 15px !important;
+  cursor: pointer !important;
+  border-radius: 3px;
+  color: #fff !important;
+  margin-right: 8px !important;
+  border: none !important;
+  font-size: 13px !important;
+  
+  &:hover {
+    background: #1e8bb5 !important;
+  }
+  
+  &.buttonCancel {
+    background: #666 !important;
+    
+    &:hover {
+      background: #555 !important;
+    }
+  }
+}
+
+.xmlButtons {
+  display: flex;
+  justify-content: flex-start;
+  margin-top: 15px;
+}
+
+button.xml-to-html-button {
+    padding: 0 !important;
+    margin: 0 !important;
+    svg {
+      font-size: 12px !important;
+      margin: 0 3px !important;
+    }
+}


### PR DESCRIPTION
**ADDRESSES : [ADAPT-3354](https://laerdal.atlassian.net/browse/ADAPT-3354)**

This pull request introduces new styles for the XML Import modal and its related UI elements in the `textArea.less` stylesheet. The changes are focused on improving the appearance and usability of the XML import feature by defining specific classes and styling rules.

**New XML Import Modal Styles:**

* Added `.xml-import-popup-panel` class for the modal container, including background, border, shadow, and sizing styles. Nested styles for `textarea`, `label`, and `svg` elements are also defined for consistent appearance.
* Introduced `.XmlImport` class for the modal content area, with specific padding and button styling via `.btnXmlImport`.
* Added `#closeXmlPopup` styles for the close button, including positioning, font size, color, and hover effect.
* Defined `.btnXmlImport` button styles, including color, padding, border radius, hover effects, and a `.buttonCancel` modifier for cancel actions.
* Added `.xmlButtons` for button layout and `button.xml-to-html-button` for icon button styling.