### PR TITLE
Feature : ADAPT-3354 Remove unused paramater it causing timeout error

### DIFF
--- a/frontend/src/modules/scaffold/xmlToHtmlPlugin.js
+++ b/frontend/src/modules/scaffold/xmlToHtmlPlugin.js
@@ -1,6 +1,4 @@
-define([
-  'core/origin'
-], function(Origin) {
+define([], function() {
   
   // XML to HTML Conversion Plugin with XSLT support
   function xmlToHtmlPlugin(editor) {


### PR DESCRIPTION
**ADDRESSES : [ADAPT-3354](https://laerdal.atlassian.net/browse/ADAPT-3354)**

This pull request makes a minor update to the `xmlToHtmlPlugin.js` file by removing the unused dependency on `core/origin`, simplifying the module's dependencies. After this change timeout error is fixed now

