### PR TITLE
Feature: ADAPT-3466 Tooptip UI issue

### DIFF
--- a/frontend/src/modules/scaffold/less/help-assistant.less
+++ b/frontend/src/modules/scaffold/less/help-assistant.less
@@ -174,6 +174,10 @@ span.help-assistant {
   }
 }
 
+.ck.ck-balloon-panel{
+  z-index: 1001 !important;
+}
+
 // Animation keyframes
 @keyframes helpPopupFadeIn {
   from {


### PR DESCRIPTION
**ADDRESS : [ADAPT-3466](https://laerdal.atlassian.net/browse/ADAPT-3466)**

## Proposed changes

This pull request makes a small but important update to the `help-assistant.less` stylesheet to address z-index stacking issues for CKEditor balloon panels.

* Increased the `z-index` of `.ck.ck-balloon-panel` to `1001` with `!important` to ensure CKEditor popups appear above other UI elements.