### PR TITLE
Feature: ADAPT-3537 Custom fonts implementation in custom theme

### DIFF
--- a/frontend/src/modules/editor/themeEditor/views/editorThemingView.custom.js
+++ b/frontend/src/modules/editor/themeEditor/views/editorThemingView.custom.js
@@ -1,0 +1,164 @@
+// Custom extension for editorThemingView.js to add font preview functionality
+// This file extends the existing ThemingView without modifying the original
+define(function(require) {
+  var Backbone = require('backbone');
+  var Origin = require('core/origin');
+  
+  // Wait for the original ThemingView to be loaded, then extend it
+  return function(ThemingView) {
+    
+    // Store original methods we'll override
+    var originalPostRender = ThemingView.prototype.postRender;
+    var originalRenderForm = ThemingView.prototype.renderForm;
+    var originalRestoreFormSettings = ThemingView.prototype.restoreFormSettings;
+    var originalOnFieldChanged = ThemingView.prototype.onFieldChanged;
+    
+    // Extend the existing ThemingView
+    return ThemingView.extend({
+      
+      // Override postRender to add font preview setup
+      postRender: function() {
+        // Call original method first
+        var result = originalPostRender.apply(this, arguments);
+        
+        // Add our custom font preview functionality
+        this.setupFontPreview();
+        
+        return result;
+      },
+      
+      // Override renderForm to ensure font preview is applied after form rendering
+      renderForm: function() {
+        // Call original method first
+        var result = originalRenderForm.apply(this, arguments);
+        
+        // Apply font preview after form is rendered
+        var self = this;
+        _.defer(function() {
+          self.applyFontPreviewToSelects();
+        });
+        
+        return result;
+      },
+      
+      // Override restoreFormSettings to apply font preview after restoration
+      restoreFormSettings: function(toRestore) {
+        // Call original method first
+        var result = originalRestoreFormSettings.apply(this, arguments);
+        
+        // Apply font preview after restoration
+        var self = this;
+        _.defer(function() {
+          self.applyFontPreviewToSelects();
+        });
+        
+        return result;
+      },
+      
+      // Override onFieldChanged to update font preview when fonts change
+      onFieldChanged: function() {
+        // Call original method first
+        var result = originalOnFieldChanged.apply(this, arguments);
+        
+        // Update font preview for any changed font selects
+        this.updateFontPreviewOnChange();
+        
+        return result;
+      },
+      
+      // NEW: Setup font preview functionality
+      setupFontPreview: function() {
+        var self = this;
+        
+        // Listen for changes to font family selects
+        this.$el.on('change', 'select[name*="font-family"], select[name*="font"]', function() {
+          self.updateSelectFontPreview($(this));
+        });
+        
+        // Apply initial font preview
+        this.applyFontPreviewToSelects();
+      },
+      
+      // NEW: Apply font preview to all font-related selects
+      applyFontPreviewToSelects: function() {
+        var self = this;
+        
+        // Find all font-related selects
+        this.$('select[name*="font-family"], select[name*="font"]').each(function() {
+          self.updateSelectFontPreview($(this));
+        });
+      },
+      
+      // NEW: Update font preview for a specific select element
+      updateSelectFontPreview: function($select) {
+        var selectedValue = $select.val();
+        
+        if (!selectedValue) return;
+        
+        // Remove any existing font classes
+        $select.removeClass(function(index, className) {
+          return (className.match(/\\bfont-\\S+/g) || []).join(' ');
+        });
+        
+        // Apply the appropriate font class based on selected value
+        var fontClass = this.getFontClassForValue(selectedValue);
+        if (fontClass) {
+          $select.addClass(fontClass);
+        }
+        
+        // Also apply inline style as fallback
+        var fontFamily = this.getFontFamilyForValue(selectedValue);
+        if (fontFamily) {
+          $select.css('font-family', fontFamily);
+        }
+      },
+      
+      // NEW: Get CSS class name for a font value
+      getFontClassForValue: function(value) {
+        var fontClassMap = {
+          'Lato': 'font-lato',
+          'Georgia': 'font-georgia', 
+          'Helvetica Neue': 'font-helvetica-neue',
+          'Inter': 'font-inter',
+          'Merriweather': 'font-merriweather',
+          'Montserrat': 'font-montserrat',
+          'Open Sans': 'font-open-sans',
+          'Poppins': 'font-poppins',
+          'Roboto': 'font-roboto',
+          'Source Sans Pro': 'font-source-sans-pro'
+        };
+        
+        return fontClassMap[value] || null;
+      },
+      
+      // NEW: Get font-family CSS value for a font value
+      getFontFamilyForValue: function(value) {
+        var fontFamilyMap = {
+          'Lato': "'Lato', sans-serif",
+          'Georgia': "'Georgia', serif",
+          'Helvetica Neue': "'Helvetica Neue', sans-serif", 
+          'Inter': "'Inter', sans-serif",
+          'Merriweather': "'Merriweather', serif",
+          'Montserrat': "'Montserrat', sans-serif",
+          'Open Sans': "'Open Sans', sans-serif",
+          'Poppins': "'Poppins', sans-serif",
+          'Roboto': "'Roboto', sans-serif",
+          'Source Sans Pro': "'Source Sans Pro', sans-serif"
+        };
+        
+        return fontFamilyMap[value] || null;
+      },
+      
+      // NEW: Update font preview when fields change
+      updateFontPreviewOnChange: function() {
+        var self = this;
+        
+        // Delay to ensure DOM has updated
+        _.defer(function() {
+          self.applyFontPreviewToSelects();
+        });
+      }
+      
+    });
+  };
+});

--- a/frontend/src/modules/editor/themeEditor/views/editorThemingView.js
+++ b/frontend/src/modules/editor/themeEditor/views/editorThemingView.js
@@ -1180,6 +1180,18 @@ define(function(require) {
     template: 'editorTheming'
   });
 
+  // Try to load custom extension if available
+  try {
+    var customExtension = require('./editorThemingView.custom');
+    if (typeof customExtension === 'function') {
+      // Apply custom extension to ThemingView
+      ThemingView = customExtension(ThemingView);
+    }
+  } catch(e) {
+    // Custom extension not found or error loading, continue with original
+    console.log('Custom theming extension not loaded:', e.message);
+  }
+
   return ThemingView;
 
 });

--- a/frontend/src/modules/scaffold/less/editorTheming.custom.less
+++ b/frontend/src/modules/scaffold/less/editorTheming.custom.less
@@ -1,0 +1,98 @@
+// Import Google Fonts for font preview
+@import url('https://fonts.googleapis.com/css2?family=Lato:wght@300;400;700&family=Roboto:wght@300;400;500;700&family=Inter:wght@300;400;500;600;700&family=Merriweather:wght@300;400;700&family=Montserrat:wght@300;400;500;600;700&family=Open+Sans:wght@300;400;500;600;700&family=Poppins:wght@300;400;500;600;700&family=Source+Sans+Pro:wght@300;400;600;700&display=swap');
+
+// Font preview in dropdown options - show each font option in its actual font
+// Define font family variables for easy maintenance
+@font-lato: 'Lato', sans-serif;
+@font-georgia: 'Georgia', serif;
+@font-helvetica-neue: 'Helvetica Neue', sans-serif;
+@font-inter: 'Inter', sans-serif;
+@font-merriweather: 'Merriweather', serif;
+@font-montserrat: 'Montserrat', sans-serif;
+@font-open-sans: 'Open Sans', sans-serif;
+@font-poppins: 'Poppins', sans-serif;
+@font-roboto: 'Roboto', sans-serif;
+@font-source-sans-pro: 'Source Sans Pro', sans-serif;
+
+// Font preview base styling
+@font-preview-size: 14px;
+@font-preview-weight: 400;
+
+// Mixin to generate font preview styles for options
+.font-preview-option(@value, @family) {
+  option[value="@{value}"],
+  &[value="@{value}"] option {
+    font-family: @family !important;
+    font-size: @font-preview-size !important;
+  }
+}
+
+// Mixin to generate font preview styles for select elements
+.font-preview-select(@value, @family, @class) {
+  &[value="@{value}"] {
+    font-family: @family !important;
+  }
+  
+  &.font-@{class} {
+    font-family: @family !important;
+    font-weight: @font-preview-weight !important;
+  }
+}
+
+.font-preview-container {
+  font-family: @font-lato; // Fallback font
+}
+
+// Generate font preview styles for all select elements
+select {
+  .font-preview-option("Lato", @font-lato);
+  .font-preview-option("Georgia", @font-georgia);
+  .font-preview-option("Helvetica Neue", @font-helvetica-neue);
+  .font-preview-option("Inter", @font-inter);
+  .font-preview-option("Merriweather", @font-merriweather);
+  .font-preview-option("Montserrat", @font-montserrat);
+  .font-preview-option("Open Sans", @font-open-sans);
+  .font-preview-option("Poppins", @font-poppins);
+  .font-preview-option("Roboto", @font-roboto);
+  .font-preview-option("Source Sans Pro", @font-source-sans-pro);
+}
+
+// Specific targeting for font family dropdowns with enhanced styling
+select[name*="font-family"],
+select[data-field*="font-family"],
+.field-heading-font-family select,
+.field-paragraph-font-family select,
+select.font-family-field {
+  option {
+    padding: 8px 12px !important;
+    line-height: 1.4 !important;
+  }
+  
+  // Generate preview styles for select elements and JS classes
+  .font-preview-select("Lato", @font-lato, "lato");
+  .font-preview-select("Georgia", @font-georgia, "georgia");
+  .font-preview-select("Helvetica Neue", @font-helvetica-neue, "helvetica-neue");
+  .font-preview-select("Inter", @font-inter, "inter");
+  .font-preview-select("Merriweather", @font-merriweather, "merriweather");
+  .font-preview-select("Montserrat", @font-montserrat, "montserrat");
+  .font-preview-select("Open Sans", @font-open-sans, "open-sans");
+  .font-preview-select("Poppins", @font-poppins, "poppins");
+  .font-preview-select("Roboto", @font-roboto, "roboto");
+  .font-preview-select("Source Sans Pro", @font-source-sans-pro, "source-sans-pro");
+}
+
+// Force font preview in all dropdown states using mixin
+select:focus option,
+select[size] option,
+select[multiple] option {
+  .font-preview-option("Lato", @font-lato);
+  .font-preview-option("Georgia", @font-georgia);
+  .font-preview-option("Helvetica Neue", @font-helvetica-neue);
+  .font-preview-option("Inter", @font-inter);
+  .font-preview-option("Merriweather", @font-merriweather);
+  .font-preview-option("Montserrat", @font-montserrat);
+  .font-preview-option("Open Sans", @font-open-sans);
+  .font-preview-option("Poppins", @font-poppins);
+  .font-preview-option("Roboto", @font-roboto);
+  .font-preview-option("Source Sans Pro", @font-source-sans-pro);
+}


### PR DESCRIPTION
#### Resolves [ADAPT-3537](https://laerdal.atlassian.net/browse/ADAPT-3537)
### Font Preview Enhancement for Theme Editor
**What's New:**


- Font dropdown options now display in their actual font style (Roboto appears in Roboto font, etc.)
- Selected fonts maintain their visual styling in the dropdown
- Font selections persist correctly after saving and returning to the theme editor

**Files Added:**


- [editorTheming.custom.less](vscode-file://vscode-app/c:/Users/inkte1/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - Font styling definitions and Google Fonts integration
- [editorThemingView.custom.js](vscode-file://vscode-app/c:/Users/inkte1/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - JavaScript functionality for font preview behavior

**Files Modified:**


- [editorThemingView.js](vscode-file://vscode-app/c:/Users/inkte1/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) - Minimal integration to load custom font preview features