### PR TITLE
disable validation until fixed

### DIFF
--- a/frontend/src/modules/editor/themeEditor/less/editorThemingCustom.less
+++ b/frontend/src/modules/editor/themeEditor/less/editorThemingCustom.less
@@ -140,6 +140,11 @@
           flex-basis: calc(50% - 10px);
           box-sizing: border-box;
 
+          // disable for timebeing as we want to show validation colour fixed
+          &.field-validation-success-colour, &.field-validation-error-colour {
+            pointer-events: none;
+          }
+
           label {
             font-weight: 500;
             color: #333;


### PR DESCRIPTION
## Proposed changes
 
This pull request makes a minor update to the theme editor's styles to temporarily disable pointer events on fields that display validation success or error colors as they are not functional now. This ensures that users cannot interact with these fields while the validation color is shown.

* Styling adjustment:
  * In `editorThemingCustom.less`, disabled pointer events for elements with the `field-validation-success-colour` and `field-validation-error-colour` classes to prevent user interaction while validation colors are displayed.