### PR TITLE
Feature: ADAPT-3589 Preview live info text updated

### DIFF
--- a/frontend/src/modules/editor/themeEditor/less/editorThemingCustom.less
+++ b/frontend/src/modules/editor/themeEditor/less/editorThemingCustom.less
@@ -1076,13 +1076,14 @@ body.preview-modal-open {
   }
 
   // Info text box
-  .preview-info,
-  span.preview-info {
+  .preview-info {
     background: #000 !important;
     color: #fff !important;
     border-color: #fff !important;
 
-    strong {
+    .preview-info-title,
+    .preview-info-subtitle,
+    p {
       color: #fff !important;
     }
   }
@@ -1261,13 +1262,49 @@ body.preview-modal-open {
   }
 }
 
-span.preview-info {
+.preview-info {
   z-index: 9;
   background: #FFFBEB;
   color: #973C00;
-  padding: 0.3rem;
+  padding: 12px 16px;
   position: relative;
   border-radius: 8px;
   border: 1px solid #FEE685;
-  display: inline-block;
+  display: block;
+  margin-top: 12px;
+  font-size: 13px;
+  line-height: 1.5;
+
+  .preview-info-title {
+    margin: 0 0 8px 0;
+    font-size: 15px;
+    font-weight: 600;
+    color: #973C00;
+
+    i {
+      margin-right: 6px;
+    }
+  }
+
+  .preview-info-subtitle {
+    margin: 10px 0 4px 0;
+    font-size: 13px;
+    font-weight: 600;
+    color: #7A3000;
+
+    &:first-of-type {
+      margin-top: 0;
+    }
+  }
+
+  p {
+    margin: 0 0 6px 0;
+    font-size: 12.5px;
+    line-height: 1.5;
+    color: #973C00;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
 }

--- a/frontend/src/modules/editor/themeEditor/templates/editorThemingPreview.hbs
+++ b/frontend/src/modules/editor/themeEditor/templates/editorThemingPreview.hbs
@@ -76,7 +76,13 @@
         </div>
       </div>
     </div>
-    <span class="preview-info"><strong>Info:</strong> Preview colours may vary slightly between the live preview and final rendering when background colours are used. Text colours are adjusted during course preview to ensure proper contrast and accessibility compliance.</span>
+    <div class="preview-info">
+      <h4 class="preview-info-title"><i class="fa fa-info-circle"></i> Info</h4>
+      <h5 class="preview-info-subtitle">Live Preview</h5>
+      <p>The live preview shows how heading and paragraph fonts, text colours (including font, heading, instruction, and link styles), and background colours for pages, articles, blocks, and components will appear. It also reflects navigation background settings and progress fill colours. Please note that preview colours may differ slightly from the final rendered output, as text colours are adjusted during course preview to ensure optimal visual consistency.</p>
+      <h5 class="preview-info-subtitle">Accessibility</h5>
+      <p>Colour contrast is automatically checked across navigation elements, menus, notify pop&#8209;ups, and drawers to ensure accessibility compliance. During course preview, text colours may be modified to maintain proper contrast ratios, which can result in slight variations from the initial preview.</p>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
## Proposed changes
Fixed: [ADAPT-3589](https://laerdal.atlassian.net/browse/ADAPT-3589)
Fixed the info text for preview editor
<img width="305" height="253" alt="image" src="https://github.com/user-attachments/assets/3eb4557c-9b68-4a13-be67-cece60b13329" />


