### PR TITLE
Bugfix: ADAPT-3588 Custom theme Info Text chopping issue for tooltip

### DIFF
--- a/frontend/src/modules/scaffold/index.js
+++ b/frontend/src/modules/scaffold/index.js
@@ -5,6 +5,7 @@ define([
   'backbone-forms',
   'backbone-forms-lists',
   './backboneFormsOverrides',
+  './tooltipOverrides',
   './views/scaffoldAssetView',
   './views/scaffoldAssetItemView',
   './views/scaffoldCodeEditorView',
@@ -15,7 +16,7 @@ define([
   './views/scaffoldListView',
   './views/scaffoldTagsView',
   './views/scaffoldUsersView'
-], function(Origin, Helpers, Schemas, BackboneForms, BackboneFormsLists, Overrides, ScaffoldAssetView, ScaffoldAssetItemView, ScaffoldCodeEditorView, ScaffoldColourPickerView, ScaffoldColourPickerViewCustom, ScaffoldDisplayTitleView, ScaffoldItemsModalView, ScaffoldListView, ScaffoldTagsView, ScaffoldUsersView) {
+], function(Origin, Helpers, Schemas, BackboneForms, BackboneFormsLists, Overrides, TooltipOverrides, ScaffoldAssetView, ScaffoldAssetItemView, ScaffoldCodeEditorView, ScaffoldColourPickerView, ScaffoldColourPickerViewCustom, ScaffoldDisplayTitleView, ScaffoldItemsModalView, ScaffoldListView, ScaffoldTagsView, ScaffoldUsersView) {
 
   var Scaffold = {};
   var alternativeModel;

--- a/frontend/src/modules/scaffold/less/tooltip.less
+++ b/frontend/src/modules/scaffold/less/tooltip.less
@@ -1,0 +1,42 @@
+/**
+ * Tooltip styles for field help icons (Laerdal customisation – ADAPT-3588)
+ *
+ * Overrides the default position:absolute tooltip (from forms.less) with a
+ * position:fixed approach so it is never clipped by scrollable ancestors.
+ * The JavaScript counterpart lives in tooltipOverrides.js (NOT in
+ * backboneFormsOverrides.js, which remains community-owned).
+ *
+ * Kept separate so upstream Adapt pulls do not overwrite these styles.
+ */
+
+.field-help {
+  i {
+    cursor: pointer;
+  }
+  .tooltip {
+    position: fixed;
+    // z-index hierarchy: tooltip=9998 < help-assistant-backdrop=9999 < AI/XML popups=99999
+    z-index: 9998;
+    max-width: ~'min(350px, calc(100vw - 16px))';
+    padding: 8px 10px;
+    border-radius: 6px;
+    background-color: @tertiary-color;
+    color: @white;
+    opacity: 0;
+    display: none;
+    visibility: visible; // override forms.less visibility:hidden — display:none keeps it hidden
+    text-align: left;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
+    transition: opacity 0.3s;
+    pointer-events: none;
+  }
+  // Disable the CSS-driven hover from forms.less — JS handles show/hide.
+  // display:none from the base rule already prevents hover from revealing the tooltip,
+  // so we only need to reset opacity and transition-delay to avoid visual flicker.
+  i:hover + .tooltip {
+    opacity: 0;
+    transition-delay: 0s;
+  }
+}

--- a/frontend/src/modules/scaffold/templates/field.hbs
+++ b/frontend/src/modules/scaffold/templates/field.hbs
@@ -3,8 +3,8 @@
   <label for="{{editorId}}" title="{{key}}">{{title}}</label>
   {{#if help}}
   <div class="field-help">
-    <i class="fa fa-info-circle"></i>
-    <div class="tooltip">{{help}}</div>
+    <i class="fa fa-info-circle" tabindex="0" role="button" aria-label="Help"></i>
+    <div class="tooltip" role="tooltip" aria-hidden="true">{{help}}</div>
   </div>
   {{/if}}
   <button class="field-default" data-action="default" title="{{t 'app.reset'}}">

--- a/frontend/src/modules/scaffold/templates/field.hbs
+++ b/frontend/src/modules/scaffold/templates/field.hbs
@@ -3,7 +3,7 @@
   <label for="{{editorId}}" title="{{key}}">{{title}}</label>
   {{#if help}}
   <div class="field-help">
-    <i class="fa fa-info-circle" tabindex="0" role="button" aria-label="Help"></i>
+    <i class="fa fa-info-circle" tabindex="0" role="button" aria-label="Help" aria-expanded="false"></i>
     <div class="tooltip" role="tooltip" aria-hidden="true">{{help}}</div>
   </div>
   {{/if}}

--- a/frontend/src/modules/scaffold/tooltipOverrides.js
+++ b/frontend/src/modules/scaffold/tooltipOverrides.js
@@ -1,0 +1,235 @@
+/**
+ * Tooltip overrides for Backbone.Form.Field  (ADAPT-3588)
+ *
+ * Laerdal customisation – this is the ONLY file that contains the tooltip
+ * event handlers (mouseenter/leave, focus/blur, keydown) and positioning
+ * logic.  backboneFormsOverrides.js is NOT modified for tooltip behaviour;
+ * this module extends the events object that backboneFormsOverrides sets.
+ *
+ * Companion CSS lives in less/tooltip.less.
+ *
+ * Uses position:fixed with JavaScript-based viewport-aware placement,
+ * ARIA attributes, keyboard accessibility, and proper cleanup on field
+ * removal.
+ *
+ * Kept separate so upstream Adapt community pulls do not overwrite it.
+ */
+define([
+  'backbone-forms',
+  './backboneFormsOverrides'
+], function() {
+
+  // ---- constants ----
+
+  // Unique counter for tooltip instance namespacing and ARIA association
+  var tooltipInstanceId = 0;
+
+  // Viewport edge padding (px) used for tooltip placement clamping
+  var TOOLTIP_VIEWPORT_MARGIN = 8;
+
+  // Duration (ms) matching the CSS opacity transition for fade-out
+  var TOOLTIP_FADE_DURATION = 300;
+
+  // ---- store original remove so we can call it in our override ----
+  var fieldRemove = Backbone.Form.Field.prototype.remove;
+
+  // ---- tooltip show / hide / dismiss helpers ----
+
+  /**
+   * Collect every scrollable ancestor between the icon and <html>.
+   * Used to bind scroll-dismiss listeners so that scrolling a container
+   * like .scaffold-items-modal-sidebar also hides the tooltip.
+   */
+  var getScrollableAncestors = function($el) {
+    var ancestors = [];
+    $el.parents().each(function() {
+      var style = window.getComputedStyle(this);
+      var overflow = style.overflowY || style.overflow;
+      if (overflow === 'auto' || overflow === 'scroll') {
+        ancestors.push(this);
+      }
+    });
+    return ancestors;
+  };
+
+  var showTooltip = function(e) {
+    var $target = $(e.currentTarget);
+    // mouseenter fires on .field-help; focus fires on .field-help i
+    var $icon = $target.is('i') ? $target : $target.find('i').first();
+    var $tooltip = $icon.siblings('.tooltip');
+    if (!$tooltip.length) return;
+
+    // Dismiss all other visible tooltips scoped to the closest form container,
+    // using dismissTooltip to ensure their window event handlers are cleaned up
+    var $form = $icon.closest('.form-container, form');
+    var $scope = $form.length ? $form : $(document);
+    $scope.find('.field-help .tooltip').not($tooltip).each(function() {
+      var $t = $(this);
+      var $otherIcon = $t.siblings('i');
+      var otherNs = '.tooltip-' + ($t.attr('id') || '');
+      dismissTooltip($otherIcon, $t, otherNs, true);
+    });
+
+    // Clear any pending hide timeout for this tooltip
+    var pendingTimeout = $tooltip.data('hideTimeout');
+    if (pendingTimeout) {
+      clearTimeout(pendingTimeout);
+      $tooltip.removeData('hideTimeout');
+    }
+
+    // Ensure ARIA association between icon and tooltip
+    if (!$tooltip.attr('id')) {
+      var tooltipId = 'tooltip-' + (++tooltipInstanceId);
+      $tooltip.attr('id', tooltipId);
+      $icon.attr('aria-describedby', tooltipId);
+    }
+
+    // Render tooltip hidden for measurement; pointer-events stay disabled (CSS default)
+    $tooltip.css({ display: 'block', opacity: 0 });
+    var iconRect = $icon[0].getBoundingClientRect();
+
+    // Ensure the tooltip never exceeds viewport width minus margins
+    var maxAllowedWidth = window.innerWidth - TOOLTIP_VIEWPORT_MARGIN * 2;
+    if ($tooltip.outerWidth() > maxAllowedWidth) {
+      $tooltip.css('max-width', maxAllowedWidth + 'px');
+    }
+
+    var tooltipWidth = $tooltip.outerWidth();
+    var tooltipHeight = $tooltip.outerHeight();
+
+    var spaceBelow = window.innerHeight - iconRect.bottom;
+
+    // Vertical: prefer below, use above if not enough space below
+    var top;
+    if (spaceBelow >= tooltipHeight + TOOLTIP_VIEWPORT_MARGIN) {
+      top = iconRect.bottom + TOOLTIP_VIEWPORT_MARGIN;
+    } else {
+      top = iconRect.top - tooltipHeight - TOOLTIP_VIEWPORT_MARGIN;
+    }
+
+    // Horizontal: align left edge to icon, clamp to viewport
+    var left = iconRect.left;
+    if (left + tooltipWidth > window.innerWidth - TOOLTIP_VIEWPORT_MARGIN) {
+      left = window.innerWidth - tooltipWidth - TOOLTIP_VIEWPORT_MARGIN;
+    }
+    left = Math.max(TOOLTIP_VIEWPORT_MARGIN, left);
+
+    // Clamp vertical to viewport
+    top = Math.max(TOOLTIP_VIEWPORT_MARGIN, Math.min(top, window.innerHeight - tooltipHeight - TOOLTIP_VIEWPORT_MARGIN));
+
+    $tooltip.css({
+      top: top + 'px',
+      left: left + 'px',
+      opacity: 0.9,
+      pointerEvents: 'auto'  // allow hover/interaction while visible
+    }).attr('aria-hidden', 'false');
+
+    // Dismiss tooltip on window scroll/resize and on scrollable-ancestor scroll
+    var ns = '.tooltip-' + $tooltip.attr('id');
+    var dismiss = function() {
+      dismissTooltip($icon, $tooltip, ns, false);
+    };
+    $(window).off(ns);
+    $(window).on('scroll' + ns + ' resize' + ns, dismiss);
+
+    // Also bind to every scrollable ancestor (e.g. .scaffold-items-modal-sidebar)
+    var scrollParents = getScrollableAncestors($icon);
+    $tooltip.data('scrollParents', scrollParents);
+    $(scrollParents).off(ns);
+    $(scrollParents).on('scroll' + ns, dismiss);
+  };
+
+  var hideTooltip = function(e) {
+    var $target = $(e.currentTarget);
+    var $icon = $target.is('i') ? $target : $target.find('i').first();
+    var $tooltip = $icon.siblings('.tooltip');
+    if (!$tooltip.length) return;
+
+    var ns = '.tooltip-' + ($tooltip.attr('id') || '');
+    dismissTooltip($icon, $tooltip, ns, false);
+  };
+
+  // Core dismiss logic using direct element references (not event.currentTarget).
+  // When immediate=true, hides instantly without fade (used when replacing one tooltip with another).
+  var dismissTooltip = function($icon, $tooltip, ns, immediate) {
+    // Clear any existing hide timeout
+    var existingTimeout = $tooltip.data('hideTimeout');
+    if (existingTimeout) {
+      clearTimeout(existingTimeout);
+      $tooltip.removeData('hideTimeout');
+    }
+
+    if (immediate) {
+      $tooltip.css({ top: '', left: '', opacity: 0, display: 'none', pointerEvents: '', maxWidth: '' })
+        .attr('aria-hidden', 'true');
+    } else {
+      // Fade out: pointer-events revert to CSS default (none) so the
+      // transparent tooltip cannot block clicks during the animation.
+      $tooltip.css({ opacity: 0, pointerEvents: '' });
+      var hideTimeout = setTimeout(function() {
+        // Guard against element being removed from the DOM during fade
+        if (!$.contains(document.documentElement, $tooltip[0])) return;
+        $tooltip.css({ top: '', left: '', display: 'none', maxWidth: '' })
+          .attr('aria-hidden', 'true');
+        $tooltip.removeData('hideTimeout');
+      }, TOOLTIP_FADE_DURATION);
+      $tooltip.data('hideTimeout', hideTimeout);
+    }
+    // Clean up window and scrollable-ancestor listeners
+    $(window).off(ns);
+    var scrollParents = $tooltip.data('scrollParents');
+    if (scrollParents) {
+      $(scrollParents).off(ns);
+      $tooltip.removeData('scrollParents');
+    }
+  };
+
+  // ---- extend Field.prototype.events with tooltip handlers ----
+
+  var existingEvents = Backbone.Form.Field.prototype.events || {};
+
+  Backbone.Form.Field.prototype.events = _.extend({}, existingEvents, {
+    'mouseenter .field-help': showTooltip,
+    'mouseleave .field-help': hideTooltip,
+    'focus .field-help i': showTooltip,
+    'blur .field-help i': hideTooltip,
+    'keydown .field-help i': function(e) {
+      // Activate tooltip on Enter or Space for role="button" accessibility
+      var key = e.key || e.keyCode || e.which;
+      if (key === 'Enter' || key === ' ' || key === 13 || key === 32) {
+        e.preventDefault();
+        var $icon = $(e.currentTarget);
+        var $tooltip = $icon.siblings('.tooltip');
+        var isVisible = $tooltip.length && $tooltip.css('display') !== 'none';
+        if (isVisible) {
+          hideTooltip(e);
+        } else {
+          showTooltip(e);
+        }
+      }
+    }
+  });
+
+  // ---- cleanup on field removal ----
+
+  Backbone.Form.Field.prototype.remove = function() {
+    var $el = this.$el;
+    $el.find('.field-help .tooltip').each(function() {
+      var $t = $(this);
+      var existingTimeout = $t.data('hideTimeout');
+      if (existingTimeout) {
+        clearTimeout(existingTimeout);
+        $t.removeData('hideTimeout');
+      }
+      var ns = '.tooltip-' + ($t.attr('id') || '');
+      $(window).off(ns);
+      var scrollParents = $t.data('scrollParents');
+      if (scrollParents) {
+        $(scrollParents).off(ns);
+        $t.removeData('scrollParents');
+      }
+    });
+    return fieldRemove.apply(this, arguments);
+  };
+
+});


### PR DESCRIPTION
## Proposed changes

Addressed the text chopping issue for tooltip.
This pull request introduces a new custom tooltip system for field help icons in the scaffold module, replacing the default tooltip behavior with improved accessibility, positioning, and event handling. The changes are carefully separated from community-owned code to ensure maintainability and prevent overwrites during upstream updates.

**Tooltip functionality and accessibility enhancements:**

* Added new `tooltipOverrides.js` module implementing JavaScript-driven tooltips with viewport-aware positioning, ARIA attributes, keyboard accessibility, and robust event cleanup. Tooltips use `position:fixed` to prevent clipping by scrollable ancestors, and are dismissed on scroll/resize or ancestor scroll events.
* Updated `field.hbs` template to enhance accessibility for help icons: added `tabindex="0"`, `role="button"`, and `aria-label="Help"` to the icon, and `role="tooltip"` and `aria-hidden="true"` to the tooltip element.

**Styling improvements:**

* Added new `tooltip.less` stylesheet with custom styles for tooltips, including fixed positioning, max-width constraints, fade transitions, and z-index hierarchy. Also disables CSS-driven hover in favor of JS-controlled show/hide.

**Module integration:**

* Registered `tooltipOverrides.js` in the scaffold module's dependency list and constructor, ensuring the new tooltip logic is loaded and applied. [[1]](diffhunk://#diff-939e56437389d0e2527d513abef539275467d07c45116e7680bee681dcbc1618R8) [[2]](diffhunk://#diff-939e56437389d0e2527d513abef539275467d07c45116e7680bee681dcbc1618L18-R19)
