### PR TITLE
Feature: ADAPT-3608 Optimize the Adapt publish package to enhance performance.

### DIFF
--- a/plugins/output/adapt/publish.js
+++ b/plugins/output/adapt/publish.js
@@ -406,7 +406,18 @@ function publishCourse(courseId, mode, request, response, next) {
         callback(err);
       });
       archive.pipe(output);
-      archive.glob('**/*', { cwd: path.join(BUILD_FOLDER) });
+      // Exclude dev-only and unnecessary files to optimize SCORM package size:
+      // - selection.json: IcoMoon project file, not needed at runtime
+      // - react-dom.development.js: prod builds use react-dom.production.min.js
+      // - .ttf fonts: only needed for legacy browsers (IE9/Android 4.x)
+      archive.glob('**/*', {
+        cwd: path.join(BUILD_FOLDER),
+        ignore: [
+          '**/selection.json',
+          '**/react-dom.development.js',
+          '**/*.ttf'
+        ]
+      });
       archive.finalize();
     },
     // fetch and register deployment URLs

--- a/plugins/output/adapt/publish.js
+++ b/plugins/output/adapt/publish.js
@@ -408,9 +408,10 @@ function publishCourse(courseId, mode, request, response, next) {
         callback(err);
       });
       archive.pipe(output);
-      // Exclude dev-only and unnecessary files to optimize SCORM package size:
+      // Exclude unnecessary files to optimize SCORM package size:
       // - selection.json: IcoMoon project file, not needed at runtime
-      // - react-dom.development.js: only excluded for prod builds (dev builds load it via scriptLoader)
+      // - react-dom.development.js: excluded only for prod builds; dev builds
+      //   (_generateSourcemap === true) need it as scriptLoader loads the dev bundle
       // - .ttf fonts: only needed for legacy browsers (IE9/Android 4.x)
       var ignorePatterns = [
         '**/selection.json',

--- a/plugins/output/adapt/publish.js
+++ b/plugins/output/adapt/publish.js
@@ -24,6 +24,7 @@ function publishCourse(courseId, mode, request, response, next) {
   let tenantId = user.tenant._id;
   let outputJson = {};
   let isRebuildRequired = false;
+  let isProductionBuild = true;
   let themeName;
   let menuName;
   let frameworkVersion;
@@ -343,6 +344,7 @@ function publishCourse(courseId, mode, request, response, next) {
 
       var generateSourcemap = outputJson.config._generateSourcemap;
       var buildMode = generateSourcemap === true ? 'dev' : 'prod';
+      isProductionBuild = buildMode === 'prod';
 
       logger.log('info', 'npx grunt server-build:' + buildMode + ' ' + args.join(' '));
 
@@ -408,15 +410,18 @@ function publishCourse(courseId, mode, request, response, next) {
       archive.pipe(output);
       // Exclude dev-only and unnecessary files to optimize SCORM package size:
       // - selection.json: IcoMoon project file, not needed at runtime
-      // - react-dom.development.js: prod builds use react-dom.production.min.js
+      // - react-dom.development.js: only excluded for prod builds (dev builds load it via scriptLoader)
       // - .ttf fonts: only needed for legacy browsers (IE9/Android 4.x)
+      var ignorePatterns = [
+        '**/selection.json',
+        '**/*.ttf'
+      ];
+      if (isProductionBuild) {
+        ignorePatterns.push('**/react-dom.development.js');
+      }
       archive.glob('**/*', {
         cwd: path.join(BUILD_FOLDER),
-        ignore: [
-          '**/selection.json',
-          '**/react-dom.development.js',
-          '**/*.ttf'
-        ]
+        ignore: ignorePatterns
       });
       archive.finalize();
     },


### PR DESCRIPTION
## Proposed changes
The change is a single targeted edit in publish.js — the archiver zip step now excludes three file patterns:
<img width="473" height="148" alt="image" src="https://github.com/user-attachments/assets/bb2b32d0-24e9-4811-b0f9-b936c45495ea" />

 Why this is safe:

selection.json is never referenced at runtime — browsers load the compiled font files (.woff2/.woff)

react-dom.development.js is only loaded when isProduction === false (the scriptLoader.js conditional at line 46). Publish/Export runs server-build:prod, so only the .production.min.js build is used

.ttf exclusion only affects the zip archive — preview mode skips the zip step entirely, so dev/preview is unaffected

Total savings: ~1.7 MB+ per SCORM package, translating to ~10-16 seconds on 256 kbps connections.
