### PR TITLE
Feature: ADAPT-3648 Permanently disable deprecated plugins in Authori…

### DIFF
--- a/frontend/src/modules/pluginManagement/views/pluginTypeView.js
+++ b/frontend/src/modules/pluginManagement/views/pluginTypeView.js
@@ -30,9 +30,23 @@ define(function(require){
     },
 
     toggleEnabled: function () {
-      this.model.save({
-        _isAvailableInEditor: this.$('.pluginType-enabled').is(':checked')
-      }, { patch: true });
+      var self = this;
+      var isChecked = this.$('.pluginType-enabled').is(':checked');
+      this.model.save({ _isAvailableInEditor: isChecked }, {
+        patch: true,
+        wait: true,
+        error: function (model, response) {
+          // Revert the checkbox to its previous state
+          self.$('.pluginType-enabled').prop('checked', !isChecked);
+          if (response.status === 403) {
+            Origin.Notify.alert({
+              type: 'warning',
+              title: Origin.l10n.t('app.warningdefaulttitle'),
+              text: 'This plugin has been deprecated and cannot be enabled. Contact your administrator if you need further assistance.'
+            });
+          }
+        }
+      });
     },
 
     toggleAddedDefault: function() {

--- a/migrations/20260427000000-disable-deprecated-plugins.js
+++ b/migrations/20260427000000-disable-deprecated-plugins.js
@@ -1,0 +1,83 @@
+/**
+ * Migration: disable-deprecated-plugins
+ *
+ * Ensures deprecated plugins are permanently locked in the DB and removes
+ * any references to them (or orphaned/missing plugins) from existing course
+ * config documents so that builds do not fail.
+ *
+ * Safe to re-run: all operations are idempotent.
+ */
+
+const DEPRECATED_BY_TYPE = {
+  extension: ['adapt-laerdal-branching', 'adapt-inline-feedback', 'adapt-laerdal-spoor'],
+  component: [],
+  theme: [],
+  menu: []
+};
+
+module.exports = {
+  async up(db) {
+    // Step 1: lock _isAvailableInEditor on every deprecated plugin record
+    for (const [type, names] of Object.entries(DEPRECATED_BY_TYPE)) {
+      if (!names.length) continue;
+      const collection = `${type}type`;
+      await db.collection(collection).updateMany(
+        { name: { $in: names } },
+        { $set: { _isAvailableInEditor: false } }
+      );
+    }
+
+    // Step 2: for each extension in DEPRECATED_BY_TYPE.extension, find its
+    // 'extension' field value (the key used in _enabledExtensions) then
+    // $unset it from every config document that carries it.
+    const extensionCollection = db.collection('extensiontype');
+    const configCollection = db.collection('config');
+
+    const deprecatedExtNames = DEPRECATED_BY_TYPE.extension;
+
+    // Collect all installed deprecated extension records to get their field keys
+    const installedDeprecated = await extensionCollection
+      .find({ name: { $in: deprecatedExtNames } })
+      .toArray();
+
+    // Build an $unset map for keys we know about from the DB record
+    const unsetKnown = {};
+    installedDeprecated.forEach(function(ext) {
+      if (ext.extension) {
+        unsetKnown[`_enabledExtensions.${ext.extension}`] = '';
+      }
+    });
+
+    if (Object.keys(unsetKnown).length > 0) {
+      await configCollection.updateMany({}, { $unset: unsetKnown });
+    }
+
+    // Step 3: orphan cleanup — remove any _enabledExtensions entry whose
+    // extensiontype record no longer exists in the DB (covers adapt-laerdal-spoor
+    // and any other plugin removed without a prior cleanup).
+    const allExtensionTypes = await extensionCollection.find({}, { projection: { _id: 1 } }).toArray();
+    const validIds = new Set(allExtensionTypes.map(e => e._id.toString()));
+
+    const configDocs = await configCollection.find(
+      { _enabledExtensions: { $exists: true } },
+      { projection: { _id: 1, _enabledExtensions: 1 } }
+    ).toArray();
+
+    for (const doc of configDocs) {
+      const orphanedKeys = Object.entries(doc._enabledExtensions || {})
+        .filter(([, val]) => val && val._id && !validIds.has(val._id.toString()))
+        .map(([key]) => key);
+
+      if (orphanedKeys.length > 0) {
+        const unsetOrphans = {};
+        orphanedKeys.forEach(function(key) { unsetOrphans[`_enabledExtensions.${key}`] = ''; });
+        await configCollection.updateOne({ _id: doc._id }, { $unset: unsetOrphans });
+      }
+    }
+  },
+
+  async down(db) {
+    // Re-enable is intentionally not supported — deprecation is permanent.
+    // To undo, manually set _isAvailableInEditor: true via the admin account.
+  }
+};

--- a/plugins/content/bower/index.js
+++ b/plugins/content/bower/index.js
@@ -41,6 +41,19 @@ function PluginPackageError (msg) {
 
 util.inherits(PluginPackageError, Error);
 
+// Returns deprecated package names for a given DB plugin type string (e.g. 'extensiontype' -> 'extension')
+function getDeprecatedForType(pluginType) {
+  var typeKey = pluginType.replace('type', '');
+  var deprecated = configuration.getConfig('deprecatedPlugins') || {};
+  return deprecated[typeKey] || [];
+}
+
+// Only the built-in 'admin' account may see deprecated plugins
+function isAdminUser() {
+  var currentUser = usermanager.getCurrentUser();
+  return currentUser && currentUser.email === 'admin';
+}
+
 function BowerPlugin () {
 }
 
@@ -406,20 +419,19 @@ BowerPlugin.prototype.initialize = function (plugin) {
             return next(err);
           }
 
-          // Check if requests are on the master tenant
-          var currentUser = usermanager.getCurrentUser();
-          var isMasterTenantUser = currentUser
-            ? currentUser.tenant.isMaster
-            : false;
-
-          // Users on the master tenant should be able to see all plugins
-          var criteria = !isMasterTenantUser
-            ? {_isAvailableInEditor: true}
-            : {};
+          // Only the admin account may see deprecated/unavailable plugins
+          var adminUser = isAdminUser();
+          var criteria = adminUser ? {} : { _isAvailableInEditor: true };
 
           db.retrieve(plugin.type, criteria, function (err, results) {
             if (err) {
               return next(err);
+            }
+
+            // Strip deprecated plugins from the response for all non-admin users
+            if (!adminUser) {
+              var deprecated = getDeprecatedForType(plugin.type);
+              results = results.filter(function(r) { return deprecated.indexOf(r.name) === -1; });
             }
 
             res.statusCode = 200;
@@ -471,17 +483,33 @@ BowerPlugin.prototype.initialize = function (plugin) {
 
     // update a single plugin type definition by id
     rest.put('/' + plugin.type + '/:id', function (req, res, next) {
-      app.contentmanager.getContentPlugin(plugin.packageType, function (err, plugin) {
-        if (err) {
-          return next(err);
-        }
+      // Deprecated plugins cannot be re-enabled via the UI or API
+      if (req.body && req.body._isAvailableInEditor === true) {
+        database.getDatabase(function(err, db) {
+          if (err) return next(err);
+          db.retrieve(plugin.type, { _id: req.params.id }, function(err, results) {
+            if (err) return next(err);
+            var existing = results && results[0];
+            if (existing && getDeprecatedForType(plugin.type).indexOf(existing.name) !== -1) {
+              res.statusCode = 403;
+              return res.json({ success: false, message: 'Cannot re-enable a deprecated plugin' });
+            }
+            proceedWithUpdate();
+          });
+        }, configuration.getConfig('dbName'));
+      } else {
+        proceedWithUpdate();
+      }
 
-        if (plugin && plugin.updatePluginType) {
-          return plugin.updatePluginType(req, res, next);
-        }
-
-        return BowerPlugin.prototype.call(null, req, res, next);
-      });
+      function proceedWithUpdate() {
+        app.contentmanager.getContentPlugin(plugin.packageType, function (err, contentPlugin) {
+          if (err) return next(err);
+          if (contentPlugin && contentPlugin.updatePluginType) {
+            return contentPlugin.updatePluginType(req, res, next);
+          }
+          return BowerPlugin.prototype.call(null, req, res, next);
+        });
+      }
     });
 
     // check if a higher version is available for the plugin
@@ -563,6 +591,20 @@ BowerPlugin.prototype.initialize = function (plugin) {
         });
       }, configuration.getConfig('dbName'));
     });
+
+    // Startup sync: ensure every deprecated plugin is permanently locked in the DB
+    var deprecatedNames = getDeprecatedForType(plugin.type);
+    if (deprecatedNames.length > 0) {
+      database.getDatabase(function(err, db) {
+        if (err) return logger.log('error', 'deprecatedPlugins startup sync: DB error', err);
+        deprecatedNames.forEach(function(pluginName) {
+          db.update(plugin.type, { name: pluginName }, { _isAvailableInEditor: false }, function(syncErr) {
+            if (syncErr) logger.log('error', 'deprecatedPlugins startup sync failed for ' + pluginName, syncErr);
+            else logger.log('info', 'deprecatedPlugins startup sync: locked ' + pluginName + ' (' + plugin.type + ')');
+          });
+        });
+      }, configuration.getConfig('dbName'));
+    }
   });
 };
 
@@ -857,6 +899,9 @@ function addPackage (plugin, packageInfo, options, cb) {
 
             logger.log('info', 'Added package: ' + package.name);
 
+            // Deprecated plugins must never be enabled; compute once and apply in both paths below.
+            var isDeprecated = getDeprecatedForType(plugin.type).indexOf(pkgMeta.name) !== -1;
+
             // #509 update content targeted by previous versions of this package
             logger.log('info', 'searching old package types ... ');
             db.retrieve(plugin.type, { name: package.name, version: { $ne: newPlugin.version } }, function (err, results) {
@@ -878,15 +923,17 @@ function addPackage (plugin, packageInfo, options, cb) {
                   }
                 });
 
-                // Persist the _isAvailableInEditor flag.
+                // Persist the _isAvailableInEditor flag; deprecated plugins are always locked false.
                 db.update(plugin.type, {_id: newPlugin._id}, {
-                  _isAvailableInEditor: oldPlugin._isAvailableInEditor,
+                  _isAvailableInEditor: isDeprecated ? false : oldPlugin._isAvailableInEditor,
                   _isAddedByDefault: oldPlugin._isAddedByDefault
                 }, function(err, results) {
                   if (err) {
                     logger.log('error', err);
                     return addCb(err);
                   }
+
+                  if (isDeprecated) logger.log('info', 'Deprecated plugin locked after upload: ' + pkgMeta.name);
 
                   plugin.updateLegacyContent(newPlugin, oldPlugin, function (err) {
                     if (err) {
@@ -917,7 +964,14 @@ function addPackage (plugin, packageInfo, options, cb) {
 
                   logger.log('info', 'Successfully removed versions of ' + package.name + '(' + plugin.type + ') older than ' + newPlugin.version);
 
-                  return addCb(null, newPlugin);
+                  if (!isDeprecated) return addCb(null, newPlugin);
+
+                  // No old version to inherit flags from — lock explicitly.
+                  db.update(plugin.type, { _id: newPlugin._id }, { _isAvailableInEditor: false }, function(updateErr) {
+                    if (updateErr) logger.log('error', 'Failed to lock deprecated plugin after upload: ' + pkgMeta.name, updateErr);
+                    else logger.log('info', 'Deprecated plugin locked after upload: ' + pkgMeta.name);
+                    return addCb(null, newPlugin);
+                  });
                 });
               }
             });

--- a/plugins/content/extension/index.js
+++ b/plugins/content/extension/index.js
@@ -370,7 +370,7 @@ function toggleExtensions (courseId, action, extensions, cb) {
         var deprecated = (configuration.getConfig('deprecatedPlugins') || {}).extension || [];
         var blocked = results.filter(function(r) { return deprecated.indexOf(r.name) !== -1; });
         if (blocked.length > 0) {
-          return cb(new Error('Cannot enable deprecated extension(s): ' + blocked.map(function(r) { return r.name; }).join(', ')));
+          return cb(new ContentTypeError('Cannot enable deprecated extension(s): ' + blocked.map(function(r) { return r.name; }).join(', ')));
         }
       }
 

--- a/plugins/content/extension/index.js
+++ b/plugins/content/extension/index.js
@@ -141,7 +141,11 @@ function getEnabledExtensions(courseId, cb) {
       enabledExtensions && Object.keys(enabledExtensions).forEach(function (key) {
         extIds.push(enabledExtensions[key]._id);
       });
-      db.retrieve('extensiontype', { _id: { $in: extIds } }, cb);
+      var deprecated = (configuration.getConfig('deprecatedPlugins') || {}).extension || [];
+      db.retrieve('extensiontype', { _id: { $in: extIds } }, function(err, extResults) {
+        if (err) return cb(err);
+        cb(null, extResults.filter(function(ext) { return deprecated.indexOf(ext.name) === -1; }));
+      });
     });
   });
 }
@@ -359,6 +363,15 @@ function toggleExtensions (courseId, action, extensions, cb) {
     db.retrieve('extensiontype', { _id: { $in: extensions } }, function (err, results) {
       if (err) {
         return cb(err);
+      }
+
+      // Deprecated extensions cannot be re-enabled on any course
+      if (action === 'enable') {
+        var deprecated = (configuration.getConfig('deprecatedPlugins') || {}).extension || [];
+        var blocked = results.filter(function(r) { return deprecated.indexOf(r.name) !== -1; });
+        if (blocked.length > 0) {
+          return cb(new Error('Cannot enable deprecated extension(s): ' + blocked.map(function(r) { return r.name; }).join(', ')));
+        }
       }
 
       // Switch to the tenant database

--- a/plugins/output/adapt/importsource.js
+++ b/plugins/output/adapt/importsource.js
@@ -281,11 +281,17 @@ function ImportSource(req, done) {
     async.series([
       function enableExtensions(cb) {
         var includeExtensions = {};
+        var deprecatedExtensions = (configuration.getConfig('deprecatedPlugins') || {}).extension || [];
         async.eachSeries(plugindata.pluginIncludes, function (pluginData, doneItemIterator) {
           switch (pluginData.type) {
             case 'extension':
               fs.readJson(path.join(pluginData.location, Constants.Filenames.Bower), function (error, extensionJson) {
                 if (error) return cb(error);
+                // Do not re-enable deprecated extensions when importing courses
+                if (deprecatedExtensions.indexOf(extensionJson.name) !== -1) {
+                  logger.log('info', 'Import: skipping deprecated extension ' + extensionJson.name);
+                  return doneItemIterator();
+                }
                 includeExtensions[extensionJson.extension] = metadata.extensionMap[extensionJson.extension];
                 doneItemIterator();
               });
@@ -367,7 +373,11 @@ function ImportSource(req, done) {
         const dbUpdate = promisify(dbInstance.update.bind(dbInstance));
         const courseQuery = await dbRetrieve('course', { _id: courseId });
         const courseGlobals = courseQuery[0]._doc._globals || {};
-        await Promise.all(plugindata.pluginIncludes.map(async ({ type, name }) => {
+        const deprecatedByType = configuration.getConfig('deprecatedPlugins') || {};
+        const safeIncludes = plugindata.pluginIncludes.filter(function(p) {
+          return !(deprecatedByType[p.type] || []).includes(p.name);
+        });
+        await Promise.all(safeIncludes.map(async ({ type, name }) => {
           const pluginQuery = await dbRetrieve(`${type}type`, { name });
           const plugin = pluginQuery[0]._doc;
           const schemaGlobals = plugin.globals;


### PR DESCRIPTION
## Summary
Resolves [ADAPT-3648](https://laerdal.atlassian.net/browse/ADAPT-3648)

Centralized, config-driven mechanism to permanently disable deprecated plugins across all four plugin types (extension,  component, theme, menu). Deprecated plugins are hidden from non-admin users, blocked from re-enabling via UI or API, and skipped during course import so they cannot re-enter existing courses.

No changes to course rendering, build pipeline, or business logic.

## Changes

| Area | Change | Impact |
|---|---|---|
| Plugin Management UI | Non-admin GET list filters to `_isAvailableInEditor:true` and strips deprecated names | Deprecated plugins invisible to all non-admin users |
| Plugin Management UI | PUT route returns 403 if request tries to re-enable a deprecated plugin | Block via API and UI toggle |
| Plugin Management UI | Checkbox reverts on 403 + Warning notification shown to admin | Clear feedback without page reload |
| Course editor | `getEnabledExtensions()` filters deprecated from extensions panel | Deprecated extensions cannot be added to course content |
| Course import | `enableExtensions()` and `populateGlobals()` skip deprecated plugins | Importing old courses does not re-activate deprecated plugins |
| Plugin upload | `isDeprecated` flag locks `_isAvailableInEditor:false` in both version-upgrade and fresh-install paths | Race-condition-safe — version migration cannot overwrite the lock |
| Server startup | Startup sync locks all deprecated plugins in DB on every `serverStarted` | Self-healing — DB stays consistent across restarts |
| Database | Migration locks deprecated records, cleans `_enabledExtensions` on all course configs, removes orphaned extension refs | Existing courses with `adapt-laerdal-spoor` (no source files) no longer cause build failures |
| Configuration | `deprecatedPlugins` typed map in `conf/config.json` (never committed) | Single source of truth — add a name to the array and restart to deprecate any plugin |

## Commits
- 7fc06530 — Feature: ADAPT-3648 Permanently disable deprecated plugins in Authoring Tool

## Related
- ADAPT-3648
- Deprecated plugins: `adapt-laerdal-branching`, `adapt-inline-feedback`, `adapt-laerdal-spoor`
