### PR TITLE
Feature: ADAPT-3648 Show warning notification when import skips deprecated plugins.

### DIFF
--- a/frontend/src/modules/frameworkImport/views/frameworkImportView.js
+++ b/frontend/src/modules/frameworkImport/views/frameworkImportView.js
@@ -186,7 +186,18 @@ define(function(require){
     },
 
     onFormSubmitSuccess: function(data, importStatus, importXhr) {
-      Origin.router.navigateToHome();
+      if (data && data.deprecatedPlugins && data.deprecatedPlugins.length > 0) {
+        Origin.Notify.alert({
+          type: 'warning',
+          title: Origin.l10n.t('app.warningdefaulttitle'),
+          text: 'This course uses deprecated plugins, which may impact its functionality upon import. We recommend replacing or removing them to ensure the course works as expected.<br><br><strong>Deprecated plugin(s) found:</strong><br>' + data.deprecatedPlugins.join('<br>'),
+          callback: function() {
+            Origin.router.navigateToHome();
+          }
+        });
+      } else {
+        Origin.router.navigateToHome();
+      }
     },
 
     onAjaxError: function(data, status, error) {

--- a/plugins/output/adapt/importsource.js
+++ b/plugins/output/adapt/importsource.js
@@ -60,6 +60,7 @@ function ImportSource(req, done) {
   var assetFolders = [];
   var details = {};
   var cleanupDirs = [];
+  var skippedDeprecated = [];
 
   /**
   * Main process
@@ -73,7 +74,7 @@ function ImportSource(req, done) {
     cacheMetadata,
     importContent,
   ], (importErr, result) => { // cleanup should run regardless of import success
-    helpers.cleanUpImport(cleanupDirs, cleanUpErr => done(importErr || cleanUpErr));
+    helpers.cleanUpImport(cleanupDirs, cleanUpErr => done(importErr || cleanUpErr, { deprecatedPlugins: skippedDeprecated }));
   });
 
   function retrieveImportInfo(cb) {
@@ -290,6 +291,7 @@ function ImportSource(req, done) {
                 // Do not re-enable deprecated extensions when importing courses
                 if (deprecatedExtensions.indexOf(extensionJson.name) !== -1) {
                   logger.log('info', 'Import: skipping deprecated extension ' + extensionJson.name);
+                  skippedDeprecated.push(extensionJson.displayName || extensionJson.name);
                   return doneItemIterator();
                 }
                 includeExtensions[extensionJson.extension] = metadata.extensionMap[extensionJson.extension];

--- a/routes/import/index.js
+++ b/routes/import/index.js
@@ -30,10 +30,14 @@ server.post('/importsource', function (request, response, next) {
       logger.log('error', error);
       return response.status(500).send({ body: error.message });
     }
-    plugin.importsource(request, function (error) {
+    plugin.importsource(request, function (error, importResult) {
       if (!error) {
         logger.log('info', 'Course imported successfully');
-        return response.status(200).send({ body: app.polyglot.t('app.importcoursesuccess') });
+        var res = { body: app.polyglot.t('app.importcoursesuccess') };
+        if (importResult && importResult.deprecatedPlugins && importResult.deprecatedPlugins.length > 0) {
+          res.deprecatedPlugins = importResult.deprecatedPlugins;
+        }
+        return response.status(200).send(res);
       }
 
       if (error instanceof helpers.PartialImportError) {


### PR DESCRIPTION
## Summary
Resolves [ADAPT-3648](https://laerdal.atlassian.net/browse/ADAPT-3648) (follow-up to #235)

When a course is imported containing deprecated plugins, the import succeeds as before but a warning notification is now shown listing the skipped plugin(s) so the user is aware they may need to replace or remove them.

## Changes

| File | Change |
|---|---|
| `plugins/output/adapt/importsource.js` | Track skipped deprecated plugin names in `skippedDeprecated[]`; pass list to caller via `done` callback |
| `routes/import/index.js` | Include `deprecatedPlugins` array in HTTP 200 response when plugins were skipped |
| `frontend/src/modules/frameworkImport/views/frameworkImportView.js` | Show Warning alert after successful import if deprecated plugin(s) were skipped; navigate home only after user dismisses |

## Commits
- 6ed693ed — Feature: ADAPT-3648 Show warning notification when deprecated plugins are skipped on import

## Related
- #235 — core deprecation implementation
- ADAPT-3648
