### PR TITLE
Feature: ADAPT-3677 Preview Editor Extension to be replaced with a direct link from existing dashboard

### DIFF
--- a/frontend/src/modules/editor/global/views/editorView.js
+++ b/frontend/src/modules/editor/global/views/editorView.js
@@ -45,9 +45,9 @@ define(function(require) {
         'editorView:copyID': this.copyIdToClipboard,
         'editorView:paste': this.pasteFromClipboard,
         'editorCommon:download': this.downloadProject,
-        'editorCommon:preview': function(isForceRebuild) {
+        'editorCommon:preview': function(isForceRebuild, isStudio) {
           var previewWindow = window.open('loading', 'preview');
-          this.previewProject(previewWindow, isForceRebuild);
+          this.previewProject(previewWindow, isForceRebuild, isStudio);
         },
         'editorCommon:export': this.exportProject
       });
@@ -63,11 +63,12 @@ define(function(require) {
       this.renderCurrentEditorView();
     },
 
-    previewProject: function(previewWindow, forceRebuild) {
+    previewProject: function(previewWindow, forceRebuild, isStudio) {
       if(Origin.editor.isPreviewPending) {
         return;
       }
       Origin.editor.isPreviewPending = true;
+      this._isStudioPreview = isStudio === true;
       $('.navigation-loading-indicator').removeClass('display-none');
       $('.editor-common-sidebar-preview-inner').addClass('display-none');
       $('.editor-common-sidebar-previewing').removeClass('display-none');
@@ -241,7 +242,12 @@ define(function(require) {
     updateCoursePreview: function(previewWindow) {
       var courseId = Origin.editor.data.course.get('_id');
       var tenantId = Origin.sessionModel.get('tenantId');
-      previewWindow.location.href = 'preview/' + tenantId + '/' + courseId + '/';
+      var href = 'preview/' + tenantId + '/' + courseId + '/';
+      if (this._isStudioPreview) {
+        href += '?studio=true';
+      }
+      previewWindow.location.href = href;
+      this._isStudioPreview = false;
     },
 
     addToClipboard: function(model) {

--- a/frontend/src/modules/navigation/templates/navigation.hbs
+++ b/frontend/src/modules/navigation/templates/navigation.hbs
@@ -14,6 +14,11 @@
     {{/if}}
   </div>
   <div class="navigation-right">
+    {{#if inEditor}}
+      <a href="#" class="navigation-item navigation-studio" data-event="studio">
+        <span>Studio</span>
+      </a>
+    {{/if}}
     {{#if isAuthenticated}}
     <a href="#" class="navigation-item navigation-help" data-event="help">
       <span>{{t 'app.help'}}</span>

--- a/frontend/src/modules/navigation/views/navigationView.js
+++ b/frontend/src/modules/navigation/views/navigationView.js
@@ -9,6 +9,7 @@ define(function(require){
 
     initialize: function() {
       this.listenTo(Origin, 'login:changed', this.loginChanged);
+      this.listenTo(Origin, 'location:change', this.render);
       this.render();
     },
 
@@ -17,7 +18,10 @@ define(function(require){
     },
 
     render: function() {
-      var data = this.model ? this.model.toJSON() : null;
+      var data = this.model ? this.model.toJSON() : {};
+      data = $.extend({}, data, {
+        inEditor: Origin.location && Origin.location.module === 'editor'
+      });
       var template = Handlebars.templates[this.constructor.template];
       this.$el.html(template(data));
       return this;

--- a/frontend/src/modules/studio/index.js
+++ b/frontend/src/modules/studio/index.js
@@ -1,0 +1,125 @@
+define(function (require) {
+  var $ = require('jquery');
+  var Origin = require('core/origin');
+
+  var EXTENSION_KEY = 'preview-edit';
+  var TARGET_ATTRIBUTE = '_previewEdit';
+
+  /**
+   * Ensure course._extensions._previewEdit._isEnabled === true. The Preview Editor
+   * extension stores its settings under the course's _extensions map; if the course
+   * creator unchecked _isEnabled there, the runtime extension won't activate even
+   * though the extension is included in the build.
+   */
+  function ensurePreviewEditEnabled(course, cb) {
+    var extensions = course.get('_extensions') || {};
+    var current = extensions[TARGET_ATTRIBUTE] || {};
+    if (current._isEnabled === true) {
+      return cb();
+    }
+    var updatedPreviewEdit = $.extend({}, current, { _isEnabled: true });
+    var updatedExtensions = $.extend({}, extensions);
+    updatedExtensions[TARGET_ATTRIBUTE] = updatedPreviewEdit;
+    course.set('_extensions', updatedExtensions);
+    course.save(null, {
+      success: function () {
+        cb();
+      },
+      error: function (model, response) {
+        console.error('[Studio] failed to save _extensions._previewEdit', response);
+        var message = (response && response.responseJSON && response.responseJSON.message)
+          || 'Failed to enable the Preview Editor on this course.';
+        Origin.Notify.alert({ type: 'error', title: 'Studio', text: message });
+      }
+    });
+  }
+
+  function triggerStudioPreview(course) {
+    ensurePreviewEditEnabled(course, function () {
+      Origin.trigger('editorCommon:preview', true, true);
+    });
+  }
+
+  Origin.on('navigation:studio', function () {
+    var editor = Origin.editor;
+    var hasCourseContext = editor
+      && editor.data
+      && editor.data.course
+      && typeof editor.data.course.get === 'function'
+      && editor.data.course.get('_id');
+
+    if (!hasCourseContext) {
+      Origin.Notify.alert({
+        type: 'info',
+        title: 'Studio',
+        text: 'Open a course to preview it in Studio.'
+      });
+      return;
+    }
+
+    var course = editor.data.course;
+    var courseId = course.get('_id');
+    var config = editor.data.config;
+    var enabled = (config && config.get('_enabledExtensions')) || {};
+
+    // Already enabled on the course config - just make sure _isEnabled is on, then preview.
+    if (enabled[EXTENSION_KEY]) {
+      triggerStudioPreview(course);
+      return;
+    }
+
+    // Resolve the extensiontype _id from the editor's loaded collection.
+    var extensionTypes = editor.data.extensiontypes;
+    var previewEditType = extensionTypes && typeof extensionTypes.findWhere === 'function'
+      ? extensionTypes.findWhere({ extension: EXTENSION_KEY })
+      : null;
+
+    if (!previewEditType) {
+      Origin.Notify.alert({
+        type: 'error',
+        title: 'Studio',
+        text: 'The "preview-edit" extension is not installed on this tenant. Install it via Plugin Management and try again.'
+      });
+      return;
+    }
+
+    var extensionTypeId = previewEditType.get('_id');
+
+    // Enable the extension on this course, then trigger a force-rebuild preview.
+    $.post('api/extension/enable/' + courseId, { extensions: [extensionTypeId] })
+      .done(function (result) {
+        if (!result || !result.success) {
+          return Origin.Notify.alert({
+            type: 'error',
+            title: 'Studio',
+            text: 'Could not enable the Preview Editor extension on this course.'
+          });
+        }
+        // Refresh in-memory config so the editor sees the new extension before preview.
+        if (config && typeof config.fetch === 'function') {
+          config.fetch({
+            success: function () {
+              Origin.trigger('scaffold:updateSchemas', function () {
+                triggerStudioPreview(course);
+              });
+            },
+            error: function () {
+              // Even if config refetch fails, the server-side build will still pick up the new extension.
+              triggerStudioPreview(course);
+            }
+          });
+        } else {
+          triggerStudioPreview(course);
+        }
+      })
+      .fail(function (jqXHR) {
+        var message = (jqXHR && jqXHR.responseJSON && jqXHR.responseJSON.message)
+          || 'Failed to enable the Preview Editor extension.';
+        Origin.Notify.alert({
+          type: 'error',
+          title: 'Studio',
+          text: message
+        });
+      });
+  });
+});


### PR DESCRIPTION
## ✅ PR Completion Checklist

* [x] PR title follows format: `Prefix: ADAPT-XXXX Brief description`
  > e.g. `Feature: ADAPT-3648 Deprecate legacy plugins` · `Bugfix: ADAPT-2504 Failed import creates rogue course`
* [x] JIRA ID linked in the Context section below
* [ ] Plugin version updated in `bower.json` (if applicable) **(NA)**
* [ ] `npm run test-e2e-dev-pipeline` executed and passing **(NA)**
* [x] No new issues reported by SonarLint (attach screenshot if applicable)
* [x] Own diff reviewed before requesting review
* [x] At least two reviewers added (Copilot set as default)

---

## Context

#### Resolves [ADAPT-3677](https://laerdal.atlassian.net/browse/ADAPT-3677)
To connect preview-edit to the existing user journey by introducing a switch in the course dashboard to connect to Adapt Studio and link back to the tool.

This pull request introduces a new "Studio" preview feature in the course editor, allowing users to preview courses with the "preview-edit" extension enabled. The changes include UI updates to show a "Studio" button when editing, logic to ensure the required extension is enabled for the course, and modifications to the preview flow to support the new mode.

Key changes:

**Studio Preview Feature Implementation:**

* Added a new module `frontend/src/modules/studio/index.js` that handles enabling the "preview-edit" extension for a course, including updating the course's `_extensions` property and making API requests to enable the extension if needed. It then triggers a force-rebuild preview in Studio mode.

**Editor and Preview Flow Updates:**

* Modified the editor's preview logic in `editorView.js` to accept a new `isStudio` parameter, track whether the preview is in Studio mode, and append a `?studio=true` query parameter to the preview URL when appropriate.

**Navigation and UI Enhancements:**

* Updated the navigation template (`navigation.hbs`) to display a "Studio" button when the user is in the editor, and wired up a new `studio` event.
* Modified the navigation view (`navigationView.js`) to detect when the user is in the editor and re-render the navigation bar on location changes.