### PR TITLE
Feature: ADAPT-2209 question state graphic only for question component

### DIFF
--- a/lib/bowermanager.js
+++ b/lib/bowermanager.js
@@ -6,6 +6,7 @@ var path = require('path');
 var semver = require('semver');
 
 var installHelpers = require('./installHelpers');
+var questionComponentHelper = require('./questionComponentHelper');
 var Constants = require('./outputmanager').Constants;
 var database = require('./database');
 var logger = require('./logger');
@@ -296,6 +297,11 @@ BowerManager.prototype.importPackage = function (plugin, packageInfo, options, c
 
             // Build the package information.
             var package = self.extractPackageInfo(plugin, pkgMeta, schema);
+
+            if (plugin.bowerConfig && plugin.bowerConfig.packageType === 'component') {
+              package._isQuestionType = questionComponentHelper.isQuestionComponentPlugin(packageInfo.canonicalDir);
+            }
+
             var db = app.db;
             var pluginString = package.name + ' (v' + package.version + ')';
 

--- a/lib/contentmanager.js
+++ b/lib/contentmanager.js
@@ -746,7 +746,7 @@ ContentManager.prototype.setupRoutes = function () {
           // FIXME #2025: components are treated differently
           var isComponentTypeSchema = (schema._doc && schema._doc.component) || schema.component;
           if(isComponentTypeSchema && schema.properties[plugin.settingsProperty]) {
-            memoData = Object.assign({}, memo.contentModelData[pluginType].component, memoData);
+            memoData = Object.assign({}, memo?.contentModelData[pluginType]?.component, memoData);
             if (pluginType === 'extension') {
               memoData = questionComponentHelper.filterQuestionOnlyExtensionProperties(memoData, schema);
             }

--- a/lib/contentmanager.js
+++ b/lib/contentmanager.js
@@ -18,6 +18,7 @@ var path = require('path'),
     usermanager = require('./usermanager'),
     _ = require('underscore'),
     helpers = require('./helpers'),
+    questionComponentHelper = require('./questionComponentHelper'),
     origin = require('../');
 
 /*
@@ -743,8 +744,12 @@ ContentManager.prototype.setupRoutes = function () {
           var pluginType = plugin.type;
           var memoData = memo.contentModelData[pluginType] && memo.contentModelData[pluginType][key] || {};
           // FIXME #2025: components are treated differently
-          if(schema._doc && schema._doc.component && schema.properties[plugin.settingsProperty]) {
+          var isComponentTypeSchema = (schema._doc && schema._doc.component) || schema.component;
+          if(isComponentTypeSchema && schema.properties[plugin.settingsProperty]) {
             memoData = Object.assign({}, memo.contentModelData[pluginType].component, memoData);
+            if (pluginType === 'extension') {
+              memoData = questionComponentHelper.filterQuestionOnlyExtensionProperties(memoData, schema);
+            }
           }
           if(_.isEmpty(memoData)) {
             return cb();

--- a/lib/questionComponentHelper.js
+++ b/lib/questionComponentHelper.js
@@ -29,9 +29,8 @@ function isQuestionComponentPlugin(pluginDir) {
     });
 }
 
-/**
- * Extension attributes that should only appear on question component schemas.
- */
+// List of extension attributes that should only appear on question
+// components — extend this list if more such extensions are added.
 var QUESTION_ONLY_EXTENSION_ATTRS = ['_questionStateGraphic'];
 
 /**
@@ -52,6 +51,7 @@ function isQuestionComponentSchemaRecord(schema) {
   }
 
   // Fallback for componenttypes installed before _isQuestionType was persisted.
+  // Walk nested properties to reach the component field definitions on a componenttype record.
   var componentProps = schema.properties &&
     schema.properties.properties &&
     schema.properties.properties.properties;
@@ -60,8 +60,7 @@ function isQuestionComponentSchemaRecord(schema) {
     return false;
   }
 
-  return Object.prototype.hasOwnProperty.call(componentProps, '_questionWeight') ||
-    Object.prototype.hasOwnProperty.call(componentProps, '_canShowMarking');
+  return Object.prototype.hasOwnProperty.call(componentProps, '_questionWeight');
 }
 
 /**

--- a/lib/questionComponentHelper.js
+++ b/lib/questionComponentHelper.js
@@ -20,13 +20,28 @@ function isQuestionComponentPlugin(pluginDir) {
     return false;
   }
 
-  return fs.readdirSync(jsDir)
-    .filter(function(file) { return file.endsWith('.js'); })
-    .some(function(file) {
-      return QUESTION_MODEL_PATTERN.test(
-        fs.readFileSync(path.join(jsDir, file), 'utf8')
-      );
-    });
+  try {
+    return fs.readdirSync(jsDir)
+      .filter(function(file) {
+        if (!file.endsWith('.js')) return false;
+        try {
+          return fs.statSync(path.join(jsDir, file)).isFile();
+        } catch (e) {
+          return false;
+        }
+      })
+      .some(function(file) {
+        try {
+          return QUESTION_MODEL_PATTERN.test(
+            fs.readFileSync(path.join(jsDir, file), 'utf8')
+          );
+        } catch (e) {
+          return false;
+        }
+      });
+  } catch (e) {
+    return false;
+  }
 }
 
 // List of extension attributes that should only appear on question

--- a/lib/questionComponentHelper.js
+++ b/lib/questionComponentHelper.js
@@ -1,0 +1,91 @@
+// LICENCE https://github.com/adaptlearning/adapt_authoring/blob/master/LICENSE
+/**
+ * Detects whether an Adapt component plugin extends the framework QuestionModel chain
+ * by scanning its js/ source files at install time.
+ */
+
+var fs = require('fs');
+var path = require('path');
+
+var QUESTION_MODEL_PATTERN = /(?:extends\s+\w*Question\w*|from\s+['"]core\/js\/models\/(?:items)?questionModel['"])/i;
+
+/**
+ * @param {string} pluginDir absolute path to the installed component package root
+ * @returns {boolean}
+ */
+function isQuestionComponentPlugin(pluginDir) {
+  var jsDir = path.join(pluginDir, 'js');
+
+  if (!fs.existsSync(jsDir)) {
+    return false;
+  }
+
+  return fs.readdirSync(jsDir)
+    .filter(function(file) { return file.endsWith('.js'); })
+    .some(function(file) {
+      return QUESTION_MODEL_PATTERN.test(
+        fs.readFileSync(path.join(jsDir, file), 'utf8')
+      );
+    });
+}
+
+/**
+ * Extension attributes that should only appear on question component schemas.
+ */
+var QUESTION_ONLY_EXTENSION_ATTRS = ['_questionStateGraphic'];
+
+/**
+ * @param {object} schema componenttype record or generated component schema
+ * @returns {boolean}
+ */
+function isQuestionComponentSchemaRecord(schema) {
+  if (!schema) {
+    return false;
+  }
+
+  if (schema._isQuestionType === true) {
+    return true;
+  }
+
+  if (schema._doc && schema._doc._isQuestionType === true) {
+    return true;
+  }
+
+  // Fallback for componenttypes installed before _isQuestionType was persisted.
+  var componentProps = schema.properties &&
+    schema.properties.properties &&
+    schema.properties.properties.properties;
+
+  if (!componentProps) {
+    return false;
+  }
+
+  return Object.prototype.hasOwnProperty.call(componentProps, '_questionWeight') ||
+    Object.prototype.hasOwnProperty.call(componentProps, '_canShowMarking');
+}
+
+/**
+ * @param {object} extensionProperties merged extension fields for a component schema
+ * @param {object} schema component schema record
+ * @returns {object}
+ */
+function filterQuestionOnlyExtensionProperties(extensionProperties, schema) {
+  if (!extensionProperties || isQuestionComponentSchemaRecord(schema)) {
+    return extensionProperties;
+  }
+
+  var filtered = Object.assign({}, extensionProperties);
+
+  QUESTION_ONLY_EXTENSION_ATTRS.forEach(function(attr) {
+    delete filtered[attr];
+  });
+
+  return filtered;
+}
+
+module.exports = {
+  isQuestionComponentPlugin: isQuestionComponentPlugin,
+  isQuestionComponentSchemaRecord: isQuestionComponentSchemaRecord,
+  filterQuestionOnlyExtensionProperties: filterQuestionOnlyExtensionProperties,
+  QUESTION_ONLY_EXTENSION_ATTRS: QUESTION_ONLY_EXTENSION_ATTRS
+};

--- a/plugins/content/bower/bowerplugin.schema
+++ b/plugins/content/bower/bowerplugin.schema
@@ -48,6 +48,11 @@
       "default": false,
       "editorOnly": true
     },
+    "_isQuestionType": {
+      "type": "boolean",
+      "default": false,
+      "editorOnly": true
+    },
     "targetAttribute": {
       "type": "string",
       "required": true,

--- a/plugins/content/bower/index.js
+++ b/plugins/content/bower/index.js
@@ -31,6 +31,7 @@ var origin = require('../../../'),
     exec = require('child_process').exec,
     IncomingForm = require('formidable').IncomingForm,
     installHelpers = require('../../../lib/installHelpers'),
+    questionComponentHelper = require('../../../lib/questionComponentHelper'),
     bytes = require('bytes');
 
 // errors
@@ -841,6 +842,11 @@ function addPackage (plugin, packageInfo, options, cb) {
   function addToDB(addCb) {
     // build the package information
     var package = extractPackageInfo(plugin, pkgMeta, schema);
+
+    if (plugin.packageType === 'component') {
+      package._isQuestionType = questionComponentHelper.isQuestionComponentPlugin(packageInfo.canonicalDir);
+    }
+
     // add the package to the modelname collection
     database.getDatabase(function (err, db) {
       if (err) {


### PR DESCRIPTION
## ✅ PR Completion Checklist

* [x] PR title follows format: `Prefix: ADAPT-XXXX Brief description`
  > e.g. `Feature: ADAPT-3648 Deprecate legacy plugins` · `Bugfix: ADAPT-2504 Failed import creates rogue course`
* [x] JIRA ID linked in the Context section below
* [ ] Plugin version updated in `bower.json` (if applicable)
* [ ] `npm run test-e2e-dev-pipeline` executed and passing (NA)
* [ ] No new issues reported by SonarLint (attach screenshot if applicable)
* [X] Own diff reviewed before requesting review
* [X] At least two reviewers added (Copilot set as default)

---

## Context

#### Resolves / Addresses [ADAPT-2209](https://laerdal.atlassian.net/browse/ADAPT-2209)

To make sure that "Question state graphic" extension should be visible only for question component and not for non-question component.

Question component means - MCQ, Graphic MCQ or Others.

These changes will make sure that "Question state graphic" component will not be visible in extension of non-question component.

<!--
  WHY is this change being made? Answer from a product or user perspective.
  - What problem does it solve, or what value does it add?
  - Add Figma links or screenshots where the change has visual impact.
  - Reference a test course if demo validation is needed.
-->

---

