### PR TITLE
Bugfix: ADAPT-3700-Add optimist dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "node-fetch": "^3.3.2",
     "node-polyglot": "^2.4.2",
     "node-webvtt": "^1.9.4",
+    "optimist": "^0.6.1",
     "nodemailer": "^8.0.11",
     "passport": "^0.6.0",
     "passport-local": "^1.0.0",


### PR DESCRIPTION
Added the package dependence

## ✅ PR Completion Checklist

* [ ] PR title follows format: `Prefix: ADAPT-XXXX Brief description`
* [x] JIRA ID linked in the Context section below
* [x] Plugin version updated in `bower.json` (if applicable)
* [ ] `npm run test-e2e-dev-pipeline` executed and passing
* [ ] No new issues reported by SonarLint (attach screenshot if applicable)
* [ ] Own diff reviewed before requesting review
* [ ] At least two reviewers added (Copilot set as default)

---

## Context

#### Resolves / Addresses [ADAPT-3700](https://laerdal.atlassian.net/browse/ADAPT-3700)

Added the package dependence

---

<!-- Reference links — full JIRA URLs so shorthand links in the body above resolve correctly -->
[ADAPT-XXXX]: https://laerdal.atlassian.net/browse/ADAPT-XXXX
