### PR TITLE
Feature: ADAPT-3679: AI Tutor on preview/publish/deployed courses (adapt-services-ai-tutor)

### DIFF
--- a/frontend/src/modules/assetManagement/index.js
+++ b/frontend/src/modules/assetManagement/index.js
@@ -35,6 +35,11 @@ define(function(require) {
   function loadAssetsView() {
     (new TagsCollection()).fetch({
       success: function(tagsCollection) {
+        // Keep AI Tutor private tags out of the asset sidebar filter (their docs are hidden
+        // from the normal list and managed only via the AI Tutor config).
+        tagsCollection.remove(tagsCollection.filter(function(tag) {
+          return /^ai-tutor-source/.test(tag.get('title') || '');
+        }));
         // Load asset collection before so sidebarView has access to it
         var assetCollection = new AssetCollection();
         // No need to fetch as the collectionView takes care of this

--- a/frontend/src/modules/assetManagement/index.js
+++ b/frontend/src/modules/assetManagement/index.js
@@ -35,11 +35,6 @@ define(function(require) {
   function loadAssetsView() {
     (new TagsCollection()).fetch({
       success: function(tagsCollection) {
-        // Keep AI Tutor private tags out of the asset sidebar filter (their docs are hidden
-        // from the normal list and managed only via the AI Tutor config).
-        tagsCollection.remove(tagsCollection.filter(function(tag) {
-          return /^ai-tutor-source/.test(tag.get('title') || '');
-        }));
         // Load asset collection before so sidebarView has access to it
         var assetCollection = new AssetCollection();
         // No need to fetch as the collectionView takes care of this

--- a/frontend/src/modules/assetManagement/views/assetManagementCollectionView.js
+++ b/frontend/src/modules/assetManagement/views/assetManagementCollectionView.js
@@ -21,6 +21,8 @@ define(function(require){
         var assetType = this.search.assetType;
         if(assetType) this.filters = assetType.$in;
       }
+      // AI Tutor picker: scopes the query to one course's tutor docs (handled server-side).
+      if(options.aiTutorCourseId) this.aiTutorCourseId = options.aiTutorCourseId;
       this.initEventListeners();
 
       this._doLazyScroll = _.bind(_.throttle(this.doLazyScroll, 250), this);
@@ -76,18 +78,22 @@ define(function(require){
       }
       this.isCollectionFetching = true;
 
+      var fetchData = {
+        search: _.extend(this.search, {
+          tags: { $all: this.tags },
+          assetType: { $in: this.filters }
+        }),
+        operators : {
+          skip: this.fetchCount,
+          limit: this.pageSize,
+          sort: this.sort
+        }
+      };
+      // Tells the server to scope to this course's AI Tutor docs (only set by that picker).
+      if (this.aiTutorCourseId) fetchData.aiTutorCourseId = this.aiTutorCourseId;
+
       this.collection.fetch({
-        data: {
-          search: _.extend(this.search, {
-            tags: { $all: this.tags },
-            assetType: { $in: this.filters }
-          }),
-          operators : {
-            skip: this.fetchCount,
-            limit: this.pageSize,
-            sort: this.sort
-          }
-        },
+        data: fetchData,
         success: _.bind(function(collection, response) {
           this.isCollectionFetching = false;
           this.fetchCount += response.length;

--- a/frontend/src/modules/assetManagement/views/assetManagementCollectionView.js
+++ b/frontend/src/modules/assetManagement/views/assetManagementCollectionView.js
@@ -21,8 +21,6 @@ define(function(require){
         var assetType = this.search.assetType;
         if(assetType) this.filters = assetType.$in;
       }
-      // AI Tutor picker: scopes the query to one course's tutor docs (handled server-side).
-      if(options.aiTutorCourseId) this.aiTutorCourseId = options.aiTutorCourseId;
       this.initEventListeners();
 
       this._doLazyScroll = _.bind(_.throttle(this.doLazyScroll, 250), this);
@@ -78,22 +76,18 @@ define(function(require){
       }
       this.isCollectionFetching = true;
 
-      var fetchData = {
-        search: _.extend(this.search, {
-          tags: { $all: this.tags },
-          assetType: { $in: this.filters }
-        }),
-        operators : {
-          skip: this.fetchCount,
-          limit: this.pageSize,
-          sort: this.sort
-        }
-      };
-      // Tells the server to scope to this course's AI Tutor docs (only set by that picker).
-      if (this.aiTutorCourseId) fetchData.aiTutorCourseId = this.aiTutorCourseId;
-
       this.collection.fetch({
-        data: fetchData,
+        data: {
+          search: _.extend(this.search, {
+            tags: { $all: this.tags },
+            assetType: { $in: this.filters }
+          }),
+          operators : {
+            skip: this.fetchCount,
+            limit: this.pageSize,
+            sort: this.sort
+          }
+        },
         success: _.bind(function(collection, response) {
           this.isCollectionFetching = false;
           this.fetchCount += response.length;

--- a/frontend/src/modules/assetManagement/views/assetManagementModalFiltersView.js
+++ b/frontend/src/modules/assetManagement/views/assetManagementModalFiltersView.js
@@ -124,7 +124,13 @@ define(function(require) {
         onAddAssetClicked: function(event) {
             event && event.preventDefault();
             Origin.trigger('assetManagement:modal:newAssetOpened');
-            $('.modal-popup-content').append(new AssetManagementModalNewAssetView({model: new AssetModel()}).$el);
+            var newAssetView = new AssetManagementModalNewAssetView({ model: new AssetModel() });
+            // Propagate the AI Tutor context so the upload is tagged at creation (server-side),
+            // letting it appear immediately in the filtered tutor picker.
+            if (this.options && this.options.aiTutorCourseId) {
+              newAssetView.aiTutorCourseId = this.options.aiTutorCourseId;
+            }
+            $('.modal-popup-content').append(newAssetView.$el);
         }
 
     });

--- a/frontend/src/modules/assetManagement/views/assetManagementModalNewAssetView.js
+++ b/frontend/src/modules/assetManagement/views/assetManagementModalNewAssetView.js
@@ -125,7 +125,7 @@ define(function(require){
       });
       this.$('#tags').val(tags);
 
-      this.$('.asset-form').ajaxSubmit({
+      var submitOptions = {
         uploadProgress: function(event, position, total, percentComplete) {
           $(".progress-container").css("visibility", "visible");
           var percentVal = percentComplete + '%';
@@ -145,7 +145,15 @@ define(function(require){
           Origin.trigger('assetManagement:collection:refresh', true);
           this.remove();
         }, this)
-      });
+      };
+
+      // AI Tutor upload → tell the server to tag this asset at creation, so it appears in the
+      // filtered tutor picker immediately and is hidden from the normal asset list.
+      if (this.aiTutorCourseId) {
+        submitOptions.data = { aiTutorCourseId: this.aiTutorCourseId };
+      }
+
+      this.$('.asset-form').ajaxSubmit(submitOptions);
 
       // Return false to prevent the page submitting
       return false;

--- a/frontend/src/modules/assetManagement/views/assetManagementModalView.js
+++ b/frontend/src/modules/assetManagement/views/assetManagementModalView.js
@@ -34,7 +34,8 @@ define(function(require) {
       // Push collection through to collection view
       var view = new AssetManagementCollectionView({
         collection: this.collection,
-        search: this.search
+        search: this.search,
+        aiTutorCourseId: this.options.aiTutorCourseId
       });
       this.$('.asset-management-assets-container-inner').append(view.$el);
     },

--- a/frontend/src/modules/assetManagement/views/assetManagementModalView.js
+++ b/frontend/src/modules/assetManagement/views/assetManagementModalView.js
@@ -34,8 +34,7 @@ define(function(require) {
       // Push collection through to collection view
       var view = new AssetManagementCollectionView({
         collection: this.collection,
-        search: this.search,
-        aiTutorCourseId: this.options.aiTutorCourseId
+        search: this.search
       });
       this.$('.asset-management-assets-container-inner').append(view.$el);
     },

--- a/frontend/src/modules/scaffold/views/scaffoldAssetView.js
+++ b/frontend/src/modules/scaffold/views/scaffoldAssetView.js
@@ -206,7 +206,7 @@ define([
     onAssetButtonClicked: function(event) {
       event.preventDefault();
 
-      Origin.trigger('modal:open', AssetManagementModalView, {
+      var pickerOptions = {
         collection: new AssetCollection,
         assetType: this.assetType,
         _shouldShowScrollbar: false,
@@ -239,7 +239,15 @@ define([
           this.setValue(data.assetLink);
           this.createCourseAsset(courseAssetObject);
         }
-      }, this);
+      };
+
+      // A field can declare a private asset tag (inputType object: _assetTag). The AI Tutor
+      // source field uses this to scope its picker to the current course's tutor docs only.
+      if (this.schema._assetTag && Origin.editor && Origin.editor.data && Origin.editor.data.course) {
+        pickerOptions.aiTutorCourseId = Origin.editor.data.course.get('_id');
+      }
+
+      Origin.trigger('modal:open', AssetManagementModalView, pickerOptions, this);
     },
 
     onClearButtonClicked: function(event) {

--- a/frontend/src/modules/scaffold/views/scaffoldAssetView.js
+++ b/frontend/src/modules/scaffold/views/scaffoldAssetView.js
@@ -206,7 +206,7 @@ define([
     onAssetButtonClicked: function(event) {
       event.preventDefault();
 
-      var pickerOptions = {
+      Origin.trigger('modal:open', AssetManagementModalView, {
         collection: new AssetCollection,
         assetType: this.assetType,
         _shouldShowScrollbar: false,
@@ -239,15 +239,7 @@ define([
           this.setValue(data.assetLink);
           this.createCourseAsset(courseAssetObject);
         }
-      };
-
-      // A field can declare a private asset tag (inputType object: _assetTag). The AI Tutor
-      // source field uses this to scope its picker to the current course's tutor docs only.
-      if (this.schema._assetTag && Origin.editor && Origin.editor.data && Origin.editor.data.course) {
-        pickerOptions.aiTutorCourseId = Origin.editor.data.course.get('_id');
-      }
-
-      Origin.trigger('modal:open', AssetManagementModalView, pickerOptions, this);
+      }, this);
     },
 
     onClearButtonClicked: function(event) {

--- a/frontend/src/modules/scaffold/views/scaffoldAssetView.js
+++ b/frontend/src/modules/scaffold/views/scaffoldAssetView.js
@@ -206,7 +206,7 @@ define([
     onAssetButtonClicked: function(event) {
       event.preventDefault();
 
-      Origin.trigger('modal:open', AssetManagementModalView, {
+      var pickerOptions = {
         collection: new AssetCollection,
         assetType: this.assetType,
         _shouldShowScrollbar: false,
@@ -238,8 +238,26 @@ define([
 
           this.setValue(data.assetLink);
           this.createCourseAsset(courseAssetObject);
+
+          // Tag the asset as an AI Tutor source at ADD time (upload or select), so it's hidden
+          // from the normal asset list and scoped to this course's picker immediately — no
+          // dependency on preview. Best-effort; failure doesn't block adding the document.
+          if (this.schema._assetTag && data.assetId && Origin.editor && Origin.editor.data && Origin.editor.data.course) {
+            $.ajax({
+              url: 'api/asset/aitutor-tag',
+              method: 'POST',
+              data: { assetId: data.assetId, courseId: Origin.editor.data.course.get('_id') }
+            });
+          }
         }
-      }, this);
+      };
+
+      // AI Tutor source field: scope the picker to this course's tutor docs only.
+      if (this.schema._assetTag && Origin.editor && Origin.editor.data && Origin.editor.data.course) {
+        pickerOptions.aiTutorCourseId = Origin.editor.data.course.get('_id');
+      }
+
+      Origin.trigger('modal:open', AssetManagementModalView, pickerOptions, this);
     },
 
     onClearButtonClicked: function(event) {

--- a/frontend/src/modules/scaffold/views/scaffoldListView.js
+++ b/frontend/src/modules/scaffold/views/scaffoldListView.js
@@ -93,6 +93,25 @@ define([
       });
     },
 
+    render: function() {
+      var rendered = Backbone.Form.editors.__List.__Item.prototype.render.apply(this, arguments);
+      // Cloning a list item that references an asset duplicates the underlying courseasset,
+      // which the server rejects (500). Remove the clone control for such items — the AI Tutor
+      // source-document list is the primary case. The delete control remains.
+      if (this._referencesAsset()) {
+        this.$('[data-action="clone"]').remove();
+      }
+      return rendered;
+    },
+
+    _referencesAsset: function() {
+      var value = this.editor && this.editor.value;
+      if (!value || typeof value !== 'object') return false;
+      return _.some(_.values(Helpers.flattenNestedProperties(value)), function(v) {
+        return typeof v === 'string' && v.indexOf('course/assets') !== -1;
+      });
+    },
+
     cloneItem: function(event) {
       var flatItem = Helpers.flattenNestedProperties(this.editor.value);
       var itemValues = _.values(flatItem);

--- a/frontend/src/modules/scaffold/views/scaffoldListView.js
+++ b/frontend/src/modules/scaffold/views/scaffoldListView.js
@@ -95,20 +95,25 @@ define([
 
     render: function() {
       var rendered = Backbone.Form.editors.__List.__Item.prototype.render.apply(this, arguments);
-      // Cloning a list item that references an asset duplicates the underlying courseasset,
-      // which the server rejects (500). Remove the clone control for such items — the AI Tutor
-      // source-document list is the primary case. The delete control remains.
-      if (this._referencesAsset()) {
+      // ONLY the AI Tutor source-document list: cloning an item duplicates the underlying
+      // courseasset (server rejects it → 500). Remove the clone (copy) control for that list
+      // alone — every other asset/list field keeps its existing behaviour. Delete is unaffected.
+      if (this._isAiTutorSourceItem()) {
         this.$('[data-action="clone"]').remove();
       }
       return rendered;
     },
 
-    _referencesAsset: function() {
-      var value = this.editor && this.editor.value;
-      if (!value || typeof value !== 'object') return false;
-      return _.some(_.values(Helpers.flattenNestedProperties(value)), function(v) {
-        return typeof v === 'string' && v.indexOf('course/assets') !== -1;
+    // True only for items whose field carries the AI Tutor private-asset marker (_assetTag,
+    // set via the inputType object on the source-document field).
+    _isAiTutorSourceItem: function() {
+      var schema = (this.editor && this.editor.schema) || this.schema;
+      if (!schema || typeof schema !== 'object') return false;
+      return _.some(_.values(schema), function(field) {
+        if (!field) return false;
+        if (field._assetTag) return true;
+        var it = field.inputType;
+        return !!(it && typeof it === 'object' && it._assetTag);
       });
     },
 

--- a/frontend/src/modules/scaffold/views/scaffoldListView.js
+++ b/frontend/src/modules/scaffold/views/scaffoldListView.js
@@ -62,6 +62,21 @@ define([
       var remove = function(isConfirmed) {
         if(isConfirmed === false) return;
 
+        // AI Tutor source doc removed → drop the per-course tag so it leaves this course's
+        // picker (the general tutor tag is kept server-side). Best-effort.
+        if (item && typeof item._isAiTutorSourceItem === 'function' && item._isAiTutorSourceItem()) {
+          var val = item.editor && item.editor.value;
+          var ref = val && (typeof val === 'object' ? val._document : val);
+          var fn = (typeof ref === 'string') ? ref.split('/').pop() : '';
+          if (fn && Origin.editor && Origin.editor.data && Origin.editor.data.course) {
+            $.ajax({
+              url: 'api/asset/aitutor-untag',
+              method: 'POST',
+              data: { filename: fn, courseId: Origin.editor.data.course.get('_id') }
+            });
+          }
+        }
+
         var index = this.items.indexOf(item);
         this.items[index].remove();
         this.items.splice(index, 1);

--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -30,6 +30,7 @@ var MODNAME = 'assetmanager',
     STREAM_BUFFER_SIZE = 64 * 1024,
     THUMBNAIL_WIDTH = '?',
     THUMBNAIL_HEIGHT = '200',
+    AITUTOR_TAG = 'ai-tutor-source',
     DEFAULT_THUMBNAIL_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAGcAAAB5CAMAAAATQ88gAAABL1BMVEU+SWA/SmFBS2JBTGNCTWNETmVET2VFUGZGUWdIU2lJU2pMV21NWG5OWW9RXHJTXnNUX3VWYHZXYndYYnhaZHlbZnpcZ3tdaHxgan5ibIBibYFjboJlcINncoVpcodqdIhrdYlsdopueIxveYxweY1xe45yfZB0fZF2gJN6hJZ6hZZ8hph9h5iBiZuDjJ6FjqCGj6CGkKGHkKKIkqSKk6WLlKWQmaqTnK2Una2Vna6Xn6+YobGZorKcpbSep7efqLihqrqkrLylrr2qssGwuca1vMq6ws+8xdLAyNXBydbFzdrHz9zI0N3K0t/L0t/M1ODN1ODQ2OPS2uXS2+bV3OjW3ejY3+ra4u3c5O/e5fDf5vHg6PPh6fTj6/bk6/bl7Pfm7ffm7vjn7vno7/np8PoQVD/gAAACnklEQVR4Ae3WbVMSURjG8bNUbmaY1EZqkgpYJhlFUWRkQhKgaQ+JmQ/hw/39P0MzNbfT5l4ehGv3Re3/9XXm9+rM3Ebky6sHXqr/vNnF5S2xZaR21QzexMqBxXljOI3Wuuc6Vwyryc55DrGRVjSOcZvYiQgybMji3MhdPAxhpyT20NvswmUAcZ2SbHoAIjvyLQ0grgMgugMgugMgugMgugMgugMgugMgugMgvgMgvgMgvgMgvgMgvgMgugOgFtsB0EiH7QBoskt1MFSjOhgaPaA6GFoJx1HI08FEqI5sXtLFVqiOLOhimeLcKYGyulikOPZmB3ISPTveQM7tnp3UQE4hIqftRONIOSLnR9lhO6BWIZ0YzFmvZMZcdyxTWZf+y9mc9pQ5baodlnNYNL6Kh6E4u9Pmr6Z3Q3COsuZM2SOqg39Fme5sOEGOs8F25kxgc2Rn24C2uU4dOXWuU0BOgevMIGeG66SRk+Y648gZ5zp55OS5ThE5Ra7TQE6D6+wNBTNDexLQx2fHfTn4uCgHMtfNIwBZnZ3hIGZ4J5gxALI7shrkrCIGQXZHKmeZCmYQZHek6vgVp4oZDNkdaST/ZJINwFgguyP7S8lTZWkfMwiyO9rJWvXp/PyT12snghkMYQcGGAAxHMAoxHMAoxDPAYxCPAcwCvEcwCjEciCjEMdBDIB6dJpNzGDowk7TdZt2BkJ2RxljfNAnxADI7iijEGYwhJ0ARiHAgJ7bHT+jEGJAOcEOYBRShusoo5AyRMfHKFRXhuAARqM6gOE7gOE7gOE7t0w0Tip2Yid2Yuffc/jFTuz8H07mbRh5fie8InZuRuTkI3JeROMkPoh5GIHzUsR8vx8687grYkTe3XVDRK7dey/yyxE5/vo5rDryu5+fSKzliGdNYwAAAABJRU5ErkJggg==';
 
 // errors
@@ -90,6 +91,7 @@ exports = module.exports = {
           app.assetmanager = instance;
           // set up routes
           rest.post('/asset', instance.postAsset.bind(instance));
+          rest.post('/asset/aitutor-tag', instance.tagAssetForTutor.bind(instance));
           rest.put('/asset/restore/:id', instance.restoreAssetByID.bind(instance));
           rest.put('/asset/trash/:id', instance.trashAssetByID.bind(instance));
           rest.put('/asset/:id', instance.putAsset.bind(instance));
@@ -592,6 +594,73 @@ exports = module.exports = {
   },
 
   /**
+   * Find-or-create the AI Tutor tags (general + per-course) via the tag content plugin
+   * (idempotent by title). Returns { general, course } tag ids, or null if tags can't be
+   * resolved — callers degrade gracefully so the asset query is never broken.
+   */
+  _ensureAiTutorTags: function (courseId, callback) {
+    if (!app || !app.contentmanager || typeof app.contentmanager.getContentPlugin !== 'function') {
+      return callback(null, null);
+    }
+    app.contentmanager.getContentPlugin('tag', function (error, plugin) {
+      if (error || !plugin) return callback(error || null, null);
+      plugin.create({ title: AITUTOR_TAG }, function (err, general) {
+        if (err || !general) return callback(err || null, null);
+        if (!courseId) return callback(null, { general: general._id, course: null });
+        plugin.create({ title: AITUTOR_TAG + '-' + courseId }, function (err2, courseTag) {
+          if (err2 || !courseTag) return callback(null, { general: general._id, course: null });
+          callback(null, { general: general._id, course: courseTag._id });
+        });
+      });
+    });
+  },
+
+  /**
+   * Tag a single asset as an AI Tutor source (general + per-course) at ADD time in the
+   * authoring tool — so it's hidden from the normal asset list and scoped to this course's
+   * picker immediately, with no dependency on preview. Idempotent; best-effort.
+   */
+  tagAssetForTutor: function (req, res, next) {
+    var assetId = req.body && req.body.assetId;
+    var courseId = req.body && req.body.courseId;
+    if (!assetId) {
+      res.statusCode = 400;
+      return res.json({ success: false, message: 'assetId is required' });
+    }
+    var self = this;
+    self._ensureAiTutorTags(courseId, function (tagErr, tags) {
+      if (tagErr || !tags) {
+        res.statusCode = 200;
+        return res.json({ success: false, message: 'tags unavailable' });
+      }
+      database.getDatabase(function (dbErr, db) {
+        if (dbErr) return next(dbErr);
+        db.retrieve('asset', { _id: assetId }, function (rErr, assets) {
+          if (rErr) return next(rErr);
+          if (!assets || !assets.length) {
+            res.statusCode = 404;
+            return res.json({ success: false, message: 'asset not found' });
+          }
+          var asset = assets[0];
+          var current = (asset.tags || []).map(String);
+          var add = [];
+          if (tags.general && current.indexOf(String(tags.general)) === -1) add.push(tags.general);
+          if (tags.course && current.indexOf(String(tags.course)) === -1) add.push(tags.course);
+          if (!add.length) {
+            res.statusCode = 200;
+            return res.json({ success: true });
+          }
+          db.update('asset', { _id: assetId }, { tags: (asset.tags || []).concat(add) }, function (uErr) {
+            if (uErr) return next(uErr);
+            res.statusCode = 200;
+            return res.json({ success: true });
+          });
+        });
+      });
+    });
+  },
+
+  /**
    * query asset collections
    *
    * @param {object} req
@@ -615,6 +684,16 @@ exports = module.exports = {
         search._isDeleted = true;
       }
     }
+
+    // Drop empty operator arrays ($all:[] / $in:[]) so they don't filter everything out.
+    Object.keys(search).forEach(function (k) {
+      var v = search[k];
+      if (v && typeof v === 'object' && !(v instanceof RegExp)) {
+        if (Array.isArray(v.$all) && !v.$all.length) delete v.$all;
+        if (Array.isArray(v.$in) && !v.$in.length) delete v.$in;
+        if (!Object.keys(v).length) delete search[k];
+      }
+    });
 
     // convert searches to regex
     async.each(
@@ -641,19 +720,33 @@ exports = module.exports = {
           query.$and = andList;
         }
 
-        self.retrieveAsset(query, options, function (error, assetRecs) {
-          if (error) {
-            return next(error);
+        // AI Tutor source docs are hidden from the normal asset list everywhere, EXCEPT the
+        // AI Tutor picker (which passes aiTutorCourseId) where only this course's docs show.
+        // Tag resolution degrades gracefully (tags=null) so the asset list never breaks.
+        self._ensureAiTutorTags(options.aiTutorCourseId, function (tagErr, tags) {
+          if (tagErr) logger.log('warn', 'ai-tutor tag resolve failed (asset query proceeds): ' + tagErr.message);
+          if (tags) {
+            if (!query.$and) query.$and = [];
+            if (options.aiTutorCourseId && tags.course) {
+              query.$and.push({ tags: { $all: [tags.course] } });
+            } else if (tags.general) {
+              query.$and.push({ tags: { $nin: [tags.general] } });
+            }
           }
+          self.retrieveAsset(query, options, function (error, assetRecs) {
+            if (error) {
+              return next(error);
+            }
 
-          // record was not found
-          if (!assetRecs) {
-            res.statusCode = 404;
-            return res.json({ success: false, message: 'assets not found' });
-          }
+            // record was not found
+            if (!assetRecs) {
+              res.statusCode = 404;
+              return res.json({ success: false, message: 'assets not found' });
+            }
 
-          res.statusCode = 200;
-          return res.json(assetRecs);
+            res.statusCode = 200;
+            return res.json(assetRecs);
+          });
         });
       }
     );

--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -473,16 +473,33 @@ exports = module.exports = {
                 storedFile
               );
   
-              self.createAsset(asset, function (createError, assetRec) {
-                if (createError) { // if the record creation fails, remove the file that was uploaded
-                  logger.log('error', createError);
-                  return storage.deleteFile(storedFile.path, function (delErr) {
-                    if (delErr) logger.log('error', 'Failed to delete stored file in assetmanager', storedFile.path);
-                    _respondError("An error occured during upload, please contact an Administrator.");
-                  });
-                }
-                res.status(200).json({ _id: assetRec._id });
-              });
+              var doCreate = function () {
+                self.createAsset(asset, function (createError, assetRec) {
+                  if (createError) { // if the record creation fails, remove the file that was uploaded
+                    logger.log('error', createError);
+                    return storage.deleteFile(storedFile.path, function (delErr) {
+                      if (delErr) logger.log('error', 'Failed to delete stored file in assetmanager', storedFile.path);
+                      _respondError("An error occured during upload, please contact an Administrator.");
+                    });
+                  }
+                  res.status(200).json({ _id: assetRec._id });
+                });
+              };
+
+              // AI Tutor upload: tag the new asset at creation (general + per-course) so it
+              // appears immediately in the filtered tutor picker and is hidden from the normal
+              // asset list. Best-effort — never blocks the upload.
+              if (fields.aiTutorCourseId) {
+                self._ensureAiTutorTags(fields.aiTutorCourseId, function (tagErr, tags) {
+                  if (tags) {
+                    if (tags.general) asset.tags.push(tags.general);
+                    if (tags.course) asset.tags.push(tags.course);
+                  }
+                  doCreate();
+                });
+              } else {
+                doCreate();
+              }
             });
           });
         });
@@ -737,20 +754,19 @@ exports = module.exports = {
           });
         };
 
-        // The AI Tutor picker (aiTutorCourseId) shows assets UNFILTERED so a freshly-uploaded
-        // doc can be selected — it is tagged on add (POST /asset/aitutor-tag), which then hides
-        // it from the normal list. Filtering the picker by tag would deadlock uploads: an
-        // unselected upload isn't tagged yet, so it'd be filtered out and couldn't be selected.
-        if (options.aiTutorCourseId) {
-          return runQuery();
-        }
-
-        // Normal asset list / other pickers: hide AI Tutor source docs (degrades gracefully).
-        self._ensureAiTutorTags(null, function (tagErr, tags) {
+        // AI Tutor scoping. The picker (aiTutorCourseId) lists ONLY this course's tutor docs
+        // ($all per-course tag); the normal list hides all tutor docs ($nin general tag).
+        // Uploads via the picker are tagged at creation (postAsset), so a new doc appears in
+        // the filtered list immediately — no select/upload deadlock. Degrades gracefully.
+        self._ensureAiTutorTags(options.aiTutorCourseId, function (tagErr, tags) {
           if (tagErr) logger.log('warn', 'ai-tutor tag resolve failed (asset query proceeds): ' + tagErr.message);
-          if (tags && tags.general) {
+          if (tags) {
             if (!query.$and) query.$and = [];
-            query.$and.push({ tags: { $nin: [tags.general] } });
+            if (options.aiTutorCourseId && tags.course) {
+              query.$and.push({ tags: { $all: [tags.course] } });
+            } else if (!options.aiTutorCourseId && tags.general) {
+              query.$and.push({ tags: { $nin: [tags.general] } });
+            }
           }
           runQuery();
         });

--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -30,6 +30,7 @@ var MODNAME = 'assetmanager',
     STREAM_BUFFER_SIZE = 64 * 1024,
     THUMBNAIL_WIDTH = '?',
     THUMBNAIL_HEIGHT = '200',
+    AITUTOR_TAG = 'ai-tutor-source',
     DEFAULT_THUMBNAIL_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAGcAAAB5CAMAAAATQ88gAAABL1BMVEU+SWA/SmFBS2JBTGNCTWNETmVET2VFUGZGUWdIU2lJU2pMV21NWG5OWW9RXHJTXnNUX3VWYHZXYndYYnhaZHlbZnpcZ3tdaHxgan5ibIBibYFjboJlcINncoVpcodqdIhrdYlsdopueIxveYxweY1xe45yfZB0fZF2gJN6hJZ6hZZ8hph9h5iBiZuDjJ6FjqCGj6CGkKGHkKKIkqSKk6WLlKWQmaqTnK2Una2Vna6Xn6+YobGZorKcpbSep7efqLihqrqkrLylrr2qssGwuca1vMq6ws+8xdLAyNXBydbFzdrHz9zI0N3K0t/L0t/M1ODN1ODQ2OPS2uXS2+bV3OjW3ejY3+ra4u3c5O/e5fDf5vHg6PPh6fTj6/bk6/bl7Pfm7ffm7vjn7vno7/np8PoQVD/gAAACnklEQVR4Ae3WbVMSURjG8bNUbmaY1EZqkgpYJhlFUWRkQhKgaQ+JmQ/hw/39P0MzNbfT5l4ehGv3Re3/9XXm9+rM3Ebky6sHXqr/vNnF5S2xZaR21QzexMqBxXljOI3Wuuc6Vwyryc55DrGRVjSOcZvYiQgybMji3MhdPAxhpyT20NvswmUAcZ2SbHoAIjvyLQ0grgMgugMgugMgugMgugMgugMgugMgugMgvgMgvgMgvgMgvgMgvgMgugOgFtsB0EiH7QBoskt1MFSjOhgaPaA6GFoJx1HI08FEqI5sXtLFVqiOLOhimeLcKYGyulikOPZmB3ISPTveQM7tnp3UQE4hIqftRONIOSLnR9lhO6BWIZ0YzFmvZMZcdyxTWZf+y9mc9pQ5baodlnNYNL6Kh6E4u9Pmr6Z3Q3COsuZM2SOqg39Fme5sOEGOs8F25kxgc2Rn24C2uU4dOXWuU0BOgevMIGeG66SRk+Y648gZ5zp55OS5ThE5Ra7TQE6D6+wNBTNDexLQx2fHfTn4uCgHMtfNIwBZnZ3hIGZ4J5gxALI7shrkrCIGQXZHKmeZCmYQZHek6vgVp4oZDNkdaST/ZJINwFgguyP7S8lTZWkfMwiyO9rJWvXp/PyT12snghkMYQcGGAAxHMAoxHMAoxDPAYxCPAcwCvEcwCjEciCjEMdBDIB6dJpNzGDowk7TdZt2BkJ2RxljfNAnxADI7iijEGYwhJ0ARiHAgJ7bHT+jEGJAOcEOYBRShusoo5AyRMfHKFRXhuAARqM6gOE7gOE7gOE7t0w0Tip2Yid2Yuffc/jFTuz8H07mbRh5fie8InZuRuTkI3JeROMkPoh5GIHzUsR8vx8687grYkTe3XVDRK7dey/yyxE5/vo5rDryu5+fSKzliGdNYwAAAABJRU5ErkJggg==';
 
 // errors
@@ -592,6 +593,62 @@ exports = module.exports = {
   },
 
   /**
+   * Find-or-create the AI Tutor tags (general + per-course) via the tag content plugin
+   * (idempotent by title). Returns { general, course } tag ids; course is null when no courseId.
+   */
+  _ensureAiTutorTags: function (courseId, callback) {
+    app.contentmanager.getContentPlugin('tag', function (error, plugin) {
+      if (error) return callback(error);
+      plugin.create({ title: AITUTOR_TAG }, function (err, general) {
+        if (err) return callback(err);
+        if (!courseId) return callback(null, { general: general._id, course: null });
+        plugin.create({ title: AITUTOR_TAG + '-' + courseId }, function (err2, courseTag) {
+          if (err2) return callback(err2);
+          callback(null, { general: general._id, course: courseTag._id });
+        });
+      });
+    });
+  },
+
+  /**
+   * Tag a course's AI Tutor source documents with the general + per-course tags, so they are
+   * hidden from the normal asset list everywhere and surfaced (per course) only in the AI Tutor
+   * picker. Idempotent; safe to call on every preview/publish. Errors are swallowed so it can
+   * never break a build.
+   */
+  ensureCourseTutorTags: function (tenantId, courseId, callback) {
+    callback = callback || function () {};
+    var self = this;
+    database.getDatabase(function (err, db) {
+      if (err) return callback(err);
+      db.retrieve('config', { _courseId: courseId }, function (err, configs) {
+        if (err || !configs || !configs.length) return callback(err);
+        var aiTutor = configs[0]._extensions && configs[0]._extensions._aiTutor;
+        var docs = (aiTutor && aiTutor._sourceDocuments) || [];
+        var filenames = docs.map(function (d) {
+          var ref = d && typeof d === 'object' ? d._document : d;
+          return typeof ref === 'string' ? ref.split('/').pop() : null;
+        }).filter(Boolean);
+        if (!filenames.length) return callback();
+        self._ensureAiTutorTags(courseId, function (tagErr, tags) {
+          if (tagErr || !tags) return callback(tagErr);
+          db.retrieve('asset', { filename: { $in: filenames }, _isDeleted: false }, function (err, assets) {
+            if (err || !assets) return callback(err);
+            async.each(assets, function (asset, nextAsset) {
+              var current = (asset.tags || []).map(String);
+              var add = [];
+              if (tags.general && current.indexOf(String(tags.general)) === -1) add.push(tags.general);
+              if (tags.course && current.indexOf(String(tags.course)) === -1) add.push(tags.course);
+              if (!add.length) return nextAsset();
+              db.update('asset', { _id: asset._id }, { tags: (asset.tags || []).concat(add) }, nextAsset);
+            }, callback);
+          });
+        });
+      });
+    }, tenantId);
+  },
+
+  /**
    * query asset collections
    *
    * @param {object} req
@@ -615,6 +672,16 @@ exports = module.exports = {
         search._isDeleted = true;
       }
     }
+
+    // Drop empty operator arrays ($all:[] / $in:[]) so they don't filter everything out.
+    Object.keys(search).forEach(function (k) {
+      var v = search[k];
+      if (v && typeof v === 'object' && !(v instanceof RegExp)) {
+        if (Array.isArray(v.$all) && !v.$all.length) delete v.$all;
+        if (Array.isArray(v.$in) && !v.$in.length) delete v.$in;
+        if (!Object.keys(v).length) delete search[k];
+      }
+    });
 
     // convert searches to regex
     async.each(
@@ -641,19 +708,35 @@ exports = module.exports = {
           query.$and = andList;
         }
 
-        self.retrieveAsset(query, options, function (error, assetRecs) {
-          if (error) {
-            return next(error);
+        // AI Tutor source docs are hidden from the normal asset list everywhere, EXCEPT the
+        // AI Tutor picker (which passes aiTutorCourseId) where only this course's docs show.
+        self._ensureAiTutorTags(options.aiTutorCourseId, function (tagErr, tags) {
+          if (tagErr) {
+            logger.log('warn', 'ai-tutor tag resolve failed (asset query proceeds): ' + tagErr.message);
+            tags = null;
           }
-
-          // record was not found
-          if (!assetRecs) {
-            res.statusCode = 404;
-            return res.json({ success: false, message: 'assets not found' });
+          if (tags) {
+            if (!query.$and) query.$and = [];
+            if (options.aiTutorCourseId && tags.course) {
+              query.$and.push({ tags: { $all: [tags.course] } });
+            } else if (tags.general) {
+              query.$and.push({ tags: { $nin: [tags.general] } });
+            }
           }
+          self.retrieveAsset(query, options, function (error, assetRecs) {
+            if (error) {
+              return next(error);
+            }
 
-          res.statusCode = 200;
-          return res.json(assetRecs);
+            // record was not found
+            if (!assetRecs) {
+              res.statusCode = 404;
+              return res.json({ success: false, message: 'assets not found' });
+            }
+
+            res.statusCode = 200;
+            return res.json(assetRecs);
+          });
         });
       }
     );

--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -720,19 +720,7 @@ exports = module.exports = {
           query.$and = andList;
         }
 
-        // AI Tutor source docs are hidden from the normal asset list everywhere, EXCEPT the
-        // AI Tutor picker (which passes aiTutorCourseId) where only this course's docs show.
-        // Tag resolution degrades gracefully (tags=null) so the asset list never breaks.
-        self._ensureAiTutorTags(options.aiTutorCourseId, function (tagErr, tags) {
-          if (tagErr) logger.log('warn', 'ai-tutor tag resolve failed (asset query proceeds): ' + tagErr.message);
-          if (tags) {
-            if (!query.$and) query.$and = [];
-            if (options.aiTutorCourseId && tags.course) {
-              query.$and.push({ tags: { $all: [tags.course] } });
-            } else if (tags.general) {
-              query.$and.push({ tags: { $nin: [tags.general] } });
-            }
-          }
+        var runQuery = function () {
           self.retrieveAsset(query, options, function (error, assetRecs) {
             if (error) {
               return next(error);
@@ -747,6 +735,24 @@ exports = module.exports = {
             res.statusCode = 200;
             return res.json(assetRecs);
           });
+        };
+
+        // The AI Tutor picker (aiTutorCourseId) shows assets UNFILTERED so a freshly-uploaded
+        // doc can be selected — it is tagged on add (POST /asset/aitutor-tag), which then hides
+        // it from the normal list. Filtering the picker by tag would deadlock uploads: an
+        // unselected upload isn't tagged yet, so it'd be filtered out and couldn't be selected.
+        if (options.aiTutorCourseId) {
+          return runQuery();
+        }
+
+        // Normal asset list / other pickers: hide AI Tutor source docs (degrades gracefully).
+        self._ensureAiTutorTags(null, function (tagErr, tags) {
+          if (tagErr) logger.log('warn', 'ai-tutor tag resolve failed (asset query proceeds): ' + tagErr.message);
+          if (tags && tags.general) {
+            if (!query.$and) query.$and = [];
+            query.$and.push({ tags: { $nin: [tags.general] } });
+          }
+          runQuery();
         });
       }
     );

--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -92,6 +92,7 @@ exports = module.exports = {
           // set up routes
           rest.post('/asset', instance.postAsset.bind(instance));
           rest.post('/asset/aitutor-tag', instance.tagAssetForTutor.bind(instance));
+          rest.post('/asset/aitutor-untag', instance.untagAssetForTutor.bind(instance));
           rest.put('/asset/restore/:id', instance.restoreAssetByID.bind(instance));
           rest.put('/asset/trash/:id', instance.trashAssetByID.bind(instance));
           rest.put('/asset/:id', instance.putAsset.bind(instance));
@@ -669,6 +670,49 @@ exports = module.exports = {
           }
           db.update('asset', { _id: assetId }, { tags: (asset.tags || []).concat(add) }, function (uErr) {
             if (uErr) return next(uErr);
+            res.statusCode = 200;
+            return res.json({ success: true });
+          });
+        });
+      });
+    });
+  },
+
+  /**
+   * Remove the PER-COURSE AI Tutor tag from an asset when its document is removed from a
+   * course's tutor config — so it leaves that course's picker. The general tag is kept (it
+   * stays a tutor doc, hidden from the normal list). Identified by filename or assetId.
+   */
+  untagAssetForTutor: function (req, res, next) {
+    var filename = req.body && req.body.filename;
+    var assetId = req.body && req.body.assetId;
+    var courseId = req.body && req.body.courseId;
+    if ((!filename && !assetId) || !courseId) {
+      res.statusCode = 400;
+      return res.json({ success: false, message: 'filename or assetId, and courseId, are required' });
+    }
+    var self = this;
+    self._ensureAiTutorTags(courseId, function (tagErr, tags) {
+      if (tagErr || !tags || !tags.course) {
+        res.statusCode = 200;
+        return res.json({ success: false, message: 'per-course tag unavailable' });
+      }
+      var courseTag = String(tags.course);
+      database.getDatabase(function (dbErr, db) {
+        if (dbErr) return next(dbErr);
+        var query = assetId ? { _id: assetId } : { filename: filename, _isDeleted: false };
+        db.retrieve('asset', query, function (rErr, assets) {
+          if (rErr) return next(rErr);
+          if (!assets || !assets.length) {
+            res.statusCode = 200;
+            return res.json({ success: true }); // nothing to untag
+          }
+          async.each(assets, function (asset, nextAsset) {
+            var kept = (asset.tags || []).filter(function (t) { return String(t) !== courseTag; });
+            if (kept.length === (asset.tags || []).length) return nextAsset(); // tag not present
+            db.update('asset', { _id: asset._id }, { tags: kept }, nextAsset);
+          }, function (eErr) {
+            if (eErr) return next(eErr);
             res.statusCode = 200;
             return res.json({ success: true });
           });

--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -30,7 +30,6 @@ var MODNAME = 'assetmanager',
     STREAM_BUFFER_SIZE = 64 * 1024,
     THUMBNAIL_WIDTH = '?',
     THUMBNAIL_HEIGHT = '200',
-    AITUTOR_TAG = 'ai-tutor-source',
     DEFAULT_THUMBNAIL_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAGcAAAB5CAMAAAATQ88gAAABL1BMVEU+SWA/SmFBS2JBTGNCTWNETmVET2VFUGZGUWdIU2lJU2pMV21NWG5OWW9RXHJTXnNUX3VWYHZXYndYYnhaZHlbZnpcZ3tdaHxgan5ibIBibYFjboJlcINncoVpcodqdIhrdYlsdopueIxveYxweY1xe45yfZB0fZF2gJN6hJZ6hZZ8hph9h5iBiZuDjJ6FjqCGj6CGkKGHkKKIkqSKk6WLlKWQmaqTnK2Una2Vna6Xn6+YobGZorKcpbSep7efqLihqrqkrLylrr2qssGwuca1vMq6ws+8xdLAyNXBydbFzdrHz9zI0N3K0t/L0t/M1ODN1ODQ2OPS2uXS2+bV3OjW3ejY3+ra4u3c5O/e5fDf5vHg6PPh6fTj6/bk6/bl7Pfm7ffm7vjn7vno7/np8PoQVD/gAAACnklEQVR4Ae3WbVMSURjG8bNUbmaY1EZqkgpYJhlFUWRkQhKgaQ+JmQ/hw/39P0MzNbfT5l4ehGv3Re3/9XXm9+rM3Ebky6sHXqr/vNnF5S2xZaR21QzexMqBxXljOI3Wuuc6Vwyryc55DrGRVjSOcZvYiQgybMji3MhdPAxhpyT20NvswmUAcZ2SbHoAIjvyLQ0grgMgugMgugMgugMgugMgugMgugMgugMgvgMgvgMgvgMgvgMgvgMgugOgFtsB0EiH7QBoskt1MFSjOhgaPaA6GFoJx1HI08FEqI5sXtLFVqiOLOhimeLcKYGyulikOPZmB3ISPTveQM7tnp3UQE4hIqftRONIOSLnR9lhO6BWIZ0YzFmvZMZcdyxTWZf+y9mc9pQ5baodlnNYNL6Kh6E4u9Pmr6Z3Q3COsuZM2SOqg39Fme5sOEGOs8F25kxgc2Rn24C2uU4dOXWuU0BOgevMIGeG66SRk+Y648gZ5zp55OS5ThE5Ra7TQE6D6+wNBTNDexLQx2fHfTn4uCgHMtfNIwBZnZ3hIGZ4J5gxALI7shrkrCIGQXZHKmeZCmYQZHek6vgVp4oZDNkdaST/ZJINwFgguyP7S8lTZWkfMwiyO9rJWvXp/PyT12snghkMYQcGGAAxHMAoxHMAoxDPAYxCPAcwCvEcwCjEciCjEMdBDIB6dJpNzGDowk7TdZt2BkJ2RxljfNAnxADI7iijEGYwhJ0ARiHAgJ7bHT+jEGJAOcEOYBRShusoo5AyRMfHKFRXhuAARqM6gOE7gOE7gOE7t0w0Tip2Yid2Yuffc/jFTuz8H07mbRh5fie8InZuRuTkI3JeROMkPoh5GIHzUsR8vx8687grYkTe3XVDRK7dey/yyxE5/vo5rDryu5+fSKzliGdNYwAAAABJRU5ErkJggg==';
 
 // errors
@@ -593,62 +592,6 @@ exports = module.exports = {
   },
 
   /**
-   * Find-or-create the AI Tutor tags (general + per-course) via the tag content plugin
-   * (idempotent by title). Returns { general, course } tag ids; course is null when no courseId.
-   */
-  _ensureAiTutorTags: function (courseId, callback) {
-    app.contentmanager.getContentPlugin('tag', function (error, plugin) {
-      if (error) return callback(error);
-      plugin.create({ title: AITUTOR_TAG }, function (err, general) {
-        if (err) return callback(err);
-        if (!courseId) return callback(null, { general: general._id, course: null });
-        plugin.create({ title: AITUTOR_TAG + '-' + courseId }, function (err2, courseTag) {
-          if (err2) return callback(err2);
-          callback(null, { general: general._id, course: courseTag._id });
-        });
-      });
-    });
-  },
-
-  /**
-   * Tag a course's AI Tutor source documents with the general + per-course tags, so they are
-   * hidden from the normal asset list everywhere and surfaced (per course) only in the AI Tutor
-   * picker. Idempotent; safe to call on every preview/publish. Errors are swallowed so it can
-   * never break a build.
-   */
-  ensureCourseTutorTags: function (tenantId, courseId, callback) {
-    callback = callback || function () {};
-    var self = this;
-    database.getDatabase(function (err, db) {
-      if (err) return callback(err);
-      db.retrieve('config', { _courseId: courseId }, function (err, configs) {
-        if (err || !configs || !configs.length) return callback(err);
-        var aiTutor = configs[0]._extensions && configs[0]._extensions._aiTutor;
-        var docs = (aiTutor && aiTutor._sourceDocuments) || [];
-        var filenames = docs.map(function (d) {
-          var ref = d && typeof d === 'object' ? d._document : d;
-          return typeof ref === 'string' ? ref.split('/').pop() : null;
-        }).filter(Boolean);
-        if (!filenames.length) return callback();
-        self._ensureAiTutorTags(courseId, function (tagErr, tags) {
-          if (tagErr || !tags) return callback(tagErr);
-          db.retrieve('asset', { filename: { $in: filenames }, _isDeleted: false }, function (err, assets) {
-            if (err || !assets) return callback(err);
-            async.each(assets, function (asset, nextAsset) {
-              var current = (asset.tags || []).map(String);
-              var add = [];
-              if (tags.general && current.indexOf(String(tags.general)) === -1) add.push(tags.general);
-              if (tags.course && current.indexOf(String(tags.course)) === -1) add.push(tags.course);
-              if (!add.length) return nextAsset();
-              db.update('asset', { _id: asset._id }, { tags: (asset.tags || []).concat(add) }, nextAsset);
-            }, callback);
-          });
-        });
-      });
-    }, tenantId);
-  },
-
-  /**
    * query asset collections
    *
    * @param {object} req
@@ -672,16 +615,6 @@ exports = module.exports = {
         search._isDeleted = true;
       }
     }
-
-    // Drop empty operator arrays ($all:[] / $in:[]) so they don't filter everything out.
-    Object.keys(search).forEach(function (k) {
-      var v = search[k];
-      if (v && typeof v === 'object' && !(v instanceof RegExp)) {
-        if (Array.isArray(v.$all) && !v.$all.length) delete v.$all;
-        if (Array.isArray(v.$in) && !v.$in.length) delete v.$in;
-        if (!Object.keys(v).length) delete search[k];
-      }
-    });
 
     // convert searches to regex
     async.each(
@@ -708,35 +641,19 @@ exports = module.exports = {
           query.$and = andList;
         }
 
-        // AI Tutor source docs are hidden from the normal asset list everywhere, EXCEPT the
-        // AI Tutor picker (which passes aiTutorCourseId) where only this course's docs show.
-        self._ensureAiTutorTags(options.aiTutorCourseId, function (tagErr, tags) {
-          if (tagErr) {
-            logger.log('warn', 'ai-tutor tag resolve failed (asset query proceeds): ' + tagErr.message);
-            tags = null;
+        self.retrieveAsset(query, options, function (error, assetRecs) {
+          if (error) {
+            return next(error);
           }
-          if (tags) {
-            if (!query.$and) query.$and = [];
-            if (options.aiTutorCourseId && tags.course) {
-              query.$and.push({ tags: { $all: [tags.course] } });
-            } else if (tags.general) {
-              query.$and.push({ tags: { $nin: [tags.general] } });
-            }
+
+          // record was not found
+          if (!assetRecs) {
+            res.statusCode = 404;
+            return res.json({ success: false, message: 'assets not found' });
           }
-          self.retrieveAsset(query, options, function (error, assetRecs) {
-            if (error) {
-              return next(error);
-            }
 
-            // record was not found
-            if (!assetRecs) {
-              res.statusCode = 404;
-              return res.json({ success: false, message: 'assets not found' });
-            }
-
-            res.statusCode = 200;
-            return res.json(assetRecs);
-          });
+          res.statusCode = 200;
+          return res.json(assetRecs);
         });
       }
     );

--- a/lib/assetmanager.js
+++ b/lib/assetmanager.js
@@ -634,6 +634,26 @@ exports = module.exports = {
   },
 
   /**
+   * Retrieve-only resolve of the AI Tutor tags (general + per-course) — looks them up by title
+   * WITHOUT creating them. Used by the read path (queryAssets) so an asset query never creates
+   * tags from user input. Either id may be null if that tag hasn't been created yet.
+   */
+  _resolveAiTutorTags: function (courseId, callback) {
+    database.getDatabase(function (err, db) {
+      if (err) return callback(err, null);
+      db.retrieve('tag', { title: AITUTOR_TAG }, function (e1, gen) {
+        if (e1) return callback(e1, null);
+        var general = (gen && gen.length) ? gen[0]._id : null;
+        if (!courseId) return callback(null, { general: general, course: null });
+        db.retrieve('tag', { title: AITUTOR_TAG + '-' + courseId }, function (e2, ct) {
+          if (e2) return callback(e2, null);
+          callback(null, { general: general, course: (ct && ct.length) ? ct[0]._id : null });
+        });
+      });
+    });
+  },
+
+  /**
    * Tag a single asset as an AI Tutor source (general + per-course) at ADD time in the
    * authoring tool — so it's hidden from the normal asset list and scoped to this course's
    * picker immediately, with no dependency on preview. Idempotent; best-effort.
@@ -668,7 +688,7 @@ exports = module.exports = {
             res.statusCode = 200;
             return res.json({ success: true });
           }
-          db.update('asset', { _id: assetId }, { tags: (asset.tags || []).concat(add) }, function (uErr) {
+          self.updateAsset({ _id: assetId }, { tags: (asset.tags || []).concat(add) }, function (uErr) {
             if (uErr) return next(uErr);
             res.statusCode = 200;
             return res.json({ success: true });
@@ -710,7 +730,7 @@ exports = module.exports = {
           async.each(assets, function (asset, nextAsset) {
             var kept = (asset.tags || []).filter(function (t) { return String(t) !== courseTag; });
             if (kept.length === (asset.tags || []).length) return nextAsset(); // tag not present
-            db.update('asset', { _id: asset._id }, { tags: kept }, nextAsset);
+            self.updateAsset({ _id: asset._id }, { tags: kept }, nextAsset);
           }, function (eErr) {
             if (eErr) return next(eErr);
             res.statusCode = 200;
@@ -802,7 +822,7 @@ exports = module.exports = {
         // ($all per-course tag); the normal list hides all tutor docs ($nin general tag).
         // Uploads via the picker are tagged at creation (postAsset), so a new doc appears in
         // the filtered list immediately — no select/upload deadlock. Degrades gracefully.
-        self._ensureAiTutorTags(options.aiTutorCourseId, function (tagErr, tags) {
+        self._resolveAiTutorTags(options.aiTutorCourseId, function (tagErr, tags) {
           if (tagErr) logger.log('warn', 'ai-tutor tag resolve failed (asset query proceeds): ' + tagErr.message);
           if (tags) {
             if (!query.$and) query.$and = [];

--- a/lib/outputmanager.js
+++ b/lib/outputmanager.js
@@ -932,6 +932,23 @@ OutputPlugin.prototype.writeCourseAssets = function(tenantId, courseId, jsonDest
                 return referencedFilenames.has(asset.filename);
               });
 
+              // ADAPT-3679: AI Tutor source documents are ingested server-side (per-course
+              // vector store) and are never read by the published course, so exclude them from
+              // the build output — keeps CDN/SCORM packages small. Guarded: only courses with
+              // _aiTutor._sourceDocuments are affected.
+              var cfg = jsonObject['config'];
+              var aiTutor = cfg && (cfg._aiTutor || (Array.isArray(cfg) && cfg[0] && cfg[0]._aiTutor));
+              var tutorFilenames = new Set();
+              ((aiTutor && aiTutor._sourceDocuments) || []).forEach(function(doc) {
+                var ref = doc && typeof doc === 'object' ? doc._document : doc;
+                if (typeof ref === 'string') tutorFilenames.add(ref.split('/').pop());
+              });
+              if (tutorFilenames.size) {
+                filteredAssets = filteredAssets.filter(function(asset) {
+                  return !tutorFilenames.has(asset.filename);
+                });
+              }
+
               // ADAPT-3614: Separate in-memory JSON mutation (must be sequential —
               // mutates shared jsonObject) from file I/O (safe to parallelise).
 

--- a/plugins/output/adapt/publish.js
+++ b/plugins/output/adapt/publish.js
@@ -247,7 +247,7 @@ function publishCourse(courseId, mode, request, response, next) {
           app.emit('aitutor:ensureIngested', { courseId: String(courseId), tenantId: String(tenantId) });
         }
       } catch (e) {
-        console.warn('[ai-tutor] endpoint injection skipped:', e && e.message);
+        logger.log('warn', '[ai-tutor] endpoint injection skipped: ' + (e && e.message));
       }
       callback(null);
     },

--- a/plugins/output/adapt/publish.js
+++ b/plugins/output/adapt/publish.js
@@ -245,6 +245,14 @@ function publishCourse(courseId, mode, request, response, next) {
           // ai-tutor service plugin). Fire-and-forget via the app event bus so it neither
           // blocks nor breaks the build; the plugin's handler is idempotent.
           app.emit('aitutor:ensureIngested', { courseId: String(courseId), tenantId: String(tenantId) });
+          // Tag the course's source docs so they're hidden from the normal asset list and
+          // scoped to this course's AI Tutor picker. Idempotent; fire-and-forget so it can
+          // never block or break the build (covers new docs + backfills existing ones).
+          if (app.assetmanager && typeof app.assetmanager.ensureCourseTutorTags === 'function') {
+            app.assetmanager.ensureCourseTutorTags(String(tenantId), String(courseId), function (e) {
+              if (e) console.warn('[ai-tutor] asset tag sync skipped:', e && e.message);
+            });
+          }
         }
       } catch (e) {
         console.warn('[ai-tutor] endpoint injection skipped:', e && e.message);

--- a/plugins/output/adapt/publish.js
+++ b/plugins/output/adapt/publish.js
@@ -234,7 +234,9 @@ function publishCourse(courseId, mode, request, response, next) {
     function(callback) {
       try {
         var configObject = outputJson['config'] && outputJson['config'][0];
-        var aiTutor = configObject && configObject._extensions && configObject._extensions._aiTutor;
+        // getCourseJSON → flattenNestedObjects promotes _extensions.* to top-level and deletes
+        // _extensions, so by here the config carries _aiTutor at the top level (not nested).
+        var aiTutor = configObject && configObject._aiTutor;
         if (aiTutor && aiTutor._isEnabled) {
           var publicUrl = process.env.AI_TUTOR_PUBLIC_URL || '';
           if (publicUrl) aiTutor.tutorEndpoint = publicUrl;

--- a/plugins/output/adapt/publish.js
+++ b/plugins/output/adapt/publish.js
@@ -225,6 +225,26 @@ function publishCourse(courseId, mode, request, response, next) {
         }
       ], function(err) { callback(err); });
     },
+    // Inject the AI Tutor proxy endpoint into config for published output.
+    // The learner widget calls a server-side proxy (never Azure directly), so only the
+    // per-environment proxy URL is baked in — set via AI_TUTOR_PUBLIC_URL. When unset
+    // (e.g. preview on the authoring host) the widget falls back to a same-origin relative
+    // call. Runs while config is still array-form (sanitizeCourseJSON converts it next).
+    // Guarded so a failure here can never break the build.
+    function(callback) {
+      try {
+        var configObject = outputJson['config'] && outputJson['config'][0];
+        var aiTutor = configObject && configObject._extensions && configObject._extensions._aiTutor;
+        if (aiTutor && aiTutor._isEnabled) {
+          var publicUrl = process.env.AI_TUTOR_PUBLIC_URL || '';
+          if (publicUrl) aiTutor.tutorEndpoint = publicUrl;
+          aiTutor.courseId = courseId;
+        }
+      } catch (e) {
+        console.warn('[ai-tutor] endpoint injection skipped:', e && e.message);
+      }
+      callback(null);
+    },
     // sanitizeCourseJSON must run after applyTheme/applyMenu — it converts course and
     // config from arrays to single objects, which would break applyTheme's course[0] reads.
     function(callback) {

--- a/plugins/output/adapt/publish.js
+++ b/plugins/output/adapt/publish.js
@@ -245,14 +245,6 @@ function publishCourse(courseId, mode, request, response, next) {
           // ai-tutor service plugin). Fire-and-forget via the app event bus so it neither
           // blocks nor breaks the build; the plugin's handler is idempotent.
           app.emit('aitutor:ensureIngested', { courseId: String(courseId), tenantId: String(tenantId) });
-          // Tag the course's source docs so they're hidden from the normal asset list and
-          // scoped to this course's AI Tutor picker. Idempotent; fire-and-forget so it can
-          // never block or break the build (covers new docs + backfills existing ones).
-          if (app.assetmanager && typeof app.assetmanager.ensureCourseTutorTags === 'function') {
-            app.assetmanager.ensureCourseTutorTags(String(tenantId), String(courseId), function (e) {
-              if (e) console.warn('[ai-tutor] asset tag sync skipped:', e && e.message);
-            });
-          }
         }
       } catch (e) {
         console.warn('[ai-tutor] endpoint injection skipped:', e && e.message);

--- a/plugins/output/adapt/publish.js
+++ b/plugins/output/adapt/publish.js
@@ -239,6 +239,10 @@ function publishCourse(courseId, mode, request, response, next) {
           var publicUrl = process.env.AI_TUTOR_PUBLIC_URL || '';
           if (publicUrl) aiTutor.tutorEndpoint = publicUrl;
           aiTutor.courseId = courseId;
+          // Auto-ingest this course's documents into its vector store (handled by the
+          // ai-tutor service plugin). Fire-and-forget via the app event bus so it neither
+          // blocks nor breaks the build; the plugin's handler is idempotent.
+          app.emit('aitutor:ensureIngested', { courseId: String(courseId), tenantId: String(tenantId) });
         }
       } catch (e) {
         console.warn('[ai-tutor] endpoint injection skipped:', e && e.message);


### PR DESCRIPTION
## ✅ PR Completion Checklist
* [x] PR title and description include the JIRA ID
* [ ] Executed `npm run test-e2e-dev-pipeline`
* [ ] No new issues reported by SonarLint

## Context
#### Addresses [ADAPT-3679](https://laerdal.atlassian.net/browse/ADAPT-3679)
Core-authoring support for the learner AI Tutor: inject the server proxy endpoint + courseId into published config, trigger per-course ingestion, scope tutor source documents in asset management (hide from the normal list, per-course picker, tag-on-add/upload, untag-on-delete), and exclude tutor docs from the build output. `develop` has been merged into this branch (ADAPT-3681/3693 health-check work) with no conflicts.

## Changes in the codebase
#### 1. `plugins/output/adapt/publish.js`
- Inject `tutorEndpoint`/`courseId` into the flattened config; emit `aitutor:ensureIngested` on preview/publish (guarded, fire-and-forget).
#### 2. `lib/outputmanager.js`
- `writeCourseAssets` excludes AI Tutor source documents from preview/CDN/SCORM output (ingested server-side only).
#### 3. `lib/assetmanager.js`
- Hide tutor docs from the asset list (`$nin` general tag); per-course picker (`$all` course tag); `tagAssetForTutor` / `untagAssetForTutor` endpoints; guarded tag resolution so the asset list can't 500.
#### 4. `frontend/src/modules/scaffold/views/scaffoldAssetView.js`, `scaffoldListView.js`
- Tutor picker passes `aiTutorCourseId`; tag on add; remove clone control on tutor rows; untag on delete.
#### 5. `frontend/src/modules/assetManagement/*`
- Thread `aiTutorCourseId` into the picker query; tag uploads at creation; hide `ai-tutor-source*` tags from the sidebar.

[ADAPT-3679]: https://laerdal.atlassian.net/browse/ADAPT-3679