### PR TITLE
Feature: ADAPT-3723 Normalize Pasted Content In ckEditor

### DIFF
--- a/frontend/src/modules/scaffold/backboneFormsOverrides.js
+++ b/frontend/src/modules/scaffold/backboneFormsOverrides.js
@@ -1422,7 +1422,9 @@ Samaritan Assistance</label><br>
         }
       }
 
-      function sanitizeNode(node, targetDoc) {
+      function sanitizeNode(node, targetDoc, context) {
+        context = context || {};
+
         if (!node) return null;
 
         if (node.nodeType === Node.TEXT_NODE) {
@@ -1441,14 +1443,25 @@ Samaritan Assistance</label><br>
         if (tag === 'b') tag = 'strong';
         if (tag === 'i') tag = 'em';
 
-        if (/^h[1-6]$/.test(tag)) {
+        var isHeadingTag = /^h[1-6]$/.test(tag);
+        if (isHeadingTag) {
           tag = 'p';
+        }
+
+        // Keep bold text only for content that came from heading tags.
+        if (tag === 'strong' && !context.allowStrong) {
+          var unwrappedStrongFragment = targetDoc.createDocumentFragment();
+          Array.prototype.forEach.call(node.childNodes, function(child) {
+            var sanitizedStrongChild = sanitizeNode(child, targetDoc, context);
+            if (sanitizedStrongChild) unwrappedStrongFragment.appendChild(sanitizedStrongChild);
+          });
+          return unwrappedStrongFragment;
         }
 
         if (!allowedTags[tag]) {
           var fragment = targetDoc.createDocumentFragment();
           Array.prototype.forEach.call(node.childNodes, function(child) {
-            var sanitizedChild = sanitizeNode(child, targetDoc);
+            var sanitizedChild = sanitizeNode(child, targetDoc, context);
             if (sanitizedChild) fragment.appendChild(sanitizedChild);
           });
           return fragment;
@@ -1458,16 +1471,25 @@ Samaritan Assistance</label><br>
         copyAllowedAttributes(node, cleanEl, tag);
 
         Array.prototype.forEach.call(node.childNodes, function(child) {
-          var sanitizedChild = sanitizeNode(child, targetDoc);
+          var childContext = isHeadingTag ? { allowStrong: false } : context;
+          var sanitizedChild = sanitizeNode(child, targetDoc, childContext);
           if (sanitizedChild) cleanEl.appendChild(sanitizedChild);
         });
+
+        if (isHeadingTag && cleanEl.childNodes.length) {
+          var strongHeadingWrapper = targetDoc.createElement('strong');
+          while (cleanEl.firstChild) {
+            strongHeadingWrapper.appendChild(cleanEl.firstChild);
+          }
+          cleanEl.appendChild(strongHeadingWrapper);
+        }
 
         return cleanEl;
       }
 
       var container = outDoc.createElement('div');
       Array.prototype.forEach.call(doc.body.childNodes, function(child) {
-        var sanitized = sanitizeNode(child, outDoc);
+        var sanitized = sanitizeNode(child, outDoc, { allowStrong: false });
         if (sanitized) container.appendChild(sanitized);
       });
 


### PR DESCRIPTION
## ✅ PR Completion Checklist

* [x] PR title follows format: `Prefix: ADAPT-XXXX Brief description`
* [x] JIRA ID linked in the Context section below
* [ ] Plugin version updated in `bower.json` (if applicable)
* [ ] `npm run test-e2e-dev-pipeline` executed and passing
* [ ] No new issues reported by SonarLint (attach screenshot if applicable)
* [x] Own diff reviewed before requesting review
* [x] At least two reviewers added (Copilot set as default)

---

## Context

#### Resolves / Addresses [ADAPT-3723](https://laerdal.atlassian.net/browse/ADAPT-3723)

<!--
  WHY is this change being made? Answer from a product or user perspective.
  - What problem does it solve, or what value does it add?
  - Add Figma links or screenshots where the change has visual impact.
  - Reference a test course if demo validation is needed.
-->

---

## Description

This is related to ADAPT-3723, there was a small bug that every pasted content was in bold, that bug is fixed.

<!--
  HOW is this accomplished technically?
  - What specific approach was taken and why?
  - Note any architecture decisions, trade-offs, or alternatives considered.
  - Mention DB changes, config updates, or breaking changes.
-->