### PR TITLE
Bugfix: ADAPT-3747 Course Structure QA follow-up (inline rename, icon cleanup, tips)

### DIFF
--- a/new-ui-source/src/components/course/CourseStructureMapView.tsx
+++ b/new-ui-source/src/components/course/CourseStructureMapView.tsx
@@ -217,6 +217,16 @@ export default function CourseStructureMapView(props: Props) {
     </div>
   );
 
+  // Map view is a read-only visualization; editing/reordering lives in Tree view.
+  const mapNote = (
+    <div className="flex items-center gap-2 rounded-lg bg-[#eff6ff] border border-[#bfdbfe] px-3.5 py-2 text-sm text-[#1e5a91]">
+      <svg className="shrink-0" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="10" /><line x1="12" y1="16" x2="12" y2="12" /><line x1="12" y1="8" x2="12.01" y2="8" />
+      </svg>
+      <span>This Map shows your current course structure. Drag-and-drop reordering is available in <span className="font-medium">Tree view</span>.</span>
+    </div>
+  );
+
   return (
     <>
       <style>{TREE_CSS}</style>
@@ -234,6 +244,8 @@ export default function CourseStructureMapView(props: Props) {
           Fullscreen
         </button>
       </div>
+
+      <div className="mb-2">{mapNote}</div>
 
       <div className="w-full bg-[#fbfbfc] border border-[#e5e7eb] rounded-xl overflow-auto max-h-[560px]">
         {!fullscreen && treeBody}
@@ -259,6 +271,7 @@ export default function CourseStructureMapView(props: Props) {
               </svg>
             </button>
           </div>
+          <div className="px-4 pt-3">{mapNote}</div>
           <div className="flex-1 overflow-auto">{treeBody}</div>
         </div>
       )}

--- a/new-ui-source/src/components/course/CourseStructureMapView.tsx
+++ b/new-ui-source/src/components/course/CourseStructureMapView.tsx
@@ -245,8 +245,6 @@ export default function CourseStructureMapView(props: Props) {
         </button>
       </div>
 
-      <div className="mb-2">{mapNote}</div>
-
       <div className="w-full bg-[#fbfbfc] border border-[#e5e7eb] rounded-xl overflow-auto max-h-[560px]">
         {!fullscreen && treeBody}
       </div>

--- a/new-ui-source/src/components/course/CourseStructureTree.tsx
+++ b/new-ui-source/src/components/course/CourseStructureTree.tsx
@@ -31,7 +31,6 @@ export interface CourseStructureTreeProps {
   onRemove: (level: StructureLevel, id: string) => void;
   // Drag-and-drop: move `id` under `newParentId`, before `beforeId` (null = append).
   onMove: (level: StructureLevel, id: string, newParentId: string, beforeId: string | null) => void;
-  onOpenTopic: (topicId: string) => void;
 }
 
 interface Dragged { level: StructureLevel; id: string; }
@@ -78,13 +77,6 @@ function Grip() {
   return (
     <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" className="text-[#9ca3af]">
       <circle cx="9" cy="6" r="1.5" /><circle cx="15" cy="6" r="1.5" /><circle cx="9" cy="12" r="1.5" /><circle cx="15" cy="12" r="1.5" /><circle cx="9" cy="18" r="1.5" /><circle cx="15" cy="18" r="1.5" />
-    </svg>
-  );
-}
-function Pencil() {
-  return (
-    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
     </svg>
   );
 }
@@ -135,9 +127,6 @@ export default function CourseStructureTree(props: CourseStructureTreeProps) {
     parentId: string;
     parentLevel: ContainerLevel;
     expandable?: boolean;
-    navigateTopicId?: string;
-    quickAddLabel?: string;
-    onQuickAdd?: () => void;
     deleteWarning?: string;
   }
 
@@ -218,12 +207,15 @@ export default function CourseStructureTree(props: CourseStructureTreeProps) {
                 aria-label="Edit title"
                 className="flex-1 min-w-0 text-sm border border-[#2d6fa8] rounded px-1.5 py-0.5 focus:outline-none focus:ring-2 focus:ring-blue-500"
               />
-            ) : p.navigateTopicId ? (
-              <button type="button" onClick={() => props.onOpenTopic(p.navigateTopicId!)} className="min-w-0 truncate text-left text-sm font-semibold text-[#111827] hover:text-[#2d6fa8] hover:underline" title="Open in editor">
+            ) : (
+              <button
+                type="button"
+                onClick={() => startRename(p.id, p.title)}
+                title="Click to rename"
+                className={`min-w-0 truncate text-left text-sm hover:text-[#2d6fa8] ${isModule ? 'font-bold uppercase tracking-wide text-[#374151]' : p.level === 'topic' ? 'font-semibold text-[#111827]' : 'text-[#374151]'}`}
+              >
                 {p.title}
               </button>
-            ) : (
-              <span className={`min-w-0 truncate text-sm ${isModule ? 'font-bold uppercase tracking-wide text-[#374151]' : 'text-[#374151]'}`}>{p.title}</span>
             )}
 
             {!editing && (isModule ? (
@@ -234,14 +226,6 @@ export default function CourseStructureTree(props: CourseStructureTreeProps) {
           </div>
 
           <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
-            {p.onQuickAdd && (
-              <button type="button" aria-label={p.quickAddLabel} title={p.quickAddLabel} onClick={p.onQuickAdd} className="p-1 rounded hover:bg-[#e5e7eb] text-[#9ca3af] hover:text-[#2d6fa8]">
-                <Plus />
-              </button>
-            )}
-            <button type="button" aria-label={`Rename ${p.title}`} onClick={() => startRename(p.id, p.title)} className="p-1 rounded hover:bg-[#e5e7eb] text-[#9ca3af] hover:text-[#2d6fa8]">
-              <Pencil />
-            </button>
             <button type="button" aria-label={`Delete ${p.title}`} onClick={() => setDeleteId(p.id)} className="p-1 rounded hover:bg-[#fee2e2] text-[#9ca3af] hover:text-[#dc2626]">
               <Trash />
             </button>
@@ -282,7 +266,7 @@ export default function CourseStructureTree(props: CourseStructureTreeProps) {
       <div className={indent}>
         {groups.map((cg) => (
           <div key={cg.id}>
-            {renderRow({ level: 'contentGroup', id: cg.id, title: cg.title, parentId: sectionId, parentLevel: 'section', expandable: true, quickAddLabel: `Add ${labels.component}`, onQuickAdd: cg.components.length < 2 ? () => props.onAddComponent(cg.id) : undefined })}
+            {renderRow({ level: 'contentGroup', id: cg.id, title: cg.title, parentId: sectionId, parentLevel: 'section', expandable: true })}
             {isOpen(cg.id) && renderComponents(cg.components, cg.id)}
           </div>
         ))}
@@ -296,7 +280,7 @@ export default function CourseStructureTree(props: CourseStructureTreeProps) {
       <div className={indent}>
         {sections.map((sec) => (
           <div key={sec.id}>
-            {renderRow({ level: 'section', id: sec.id, title: sec.title, parentId: topicId, parentLevel: 'topic', navigateTopicId: topicId, expandable: true, quickAddLabel: `Add ${labels.contentGroup}`, onQuickAdd: () => props.onAddContentGroup(sec.id) })}
+            {renderRow({ level: 'section', id: sec.id, title: sec.title, parentId: topicId, parentLevel: 'topic', expandable: true })}
             {isOpen(sec.id) && renderContentGroups(sec.contentGroups, sec.id)}
           </div>
         ))}
@@ -308,7 +292,7 @@ export default function CourseStructureTree(props: CourseStructureTreeProps) {
   function renderTopic(topic: STopic, containerId: string, parentLevel: ContainerLevel) {
     return (
       <div key={topic.id}>
-        {renderRow({ level: 'topic', id: topic.id, title: topic.title, parentId: containerId, parentLevel, navigateTopicId: topic.id, expandable: true, quickAddLabel: `Add ${labels.section}`, onQuickAdd: () => props.onAddSection(topic.id) })}
+        {renderRow({ level: 'topic', id: topic.id, title: topic.title, parentId: containerId, parentLevel, expandable: true })}
         {isOpen(topic.id) && renderSections(topic.sections, topic.id)}
       </div>
     );
@@ -317,7 +301,7 @@ export default function CourseStructureTree(props: CourseStructureTreeProps) {
   function renderModule(mod: SModule, containerId: string, parentLevel: ContainerLevel) {
     return (
       <div key={mod.id}>
-        {renderRow({ level: 'module', id: mod.id, title: mod.title, parentId: containerId, parentLevel, expandable: true, quickAddLabel: `Add ${labels.topic}`, onQuickAdd: () => props.onAddTopic(mod.id) })}
+        {renderRow({ level: 'module', id: mod.id, title: mod.title, parentId: containerId, parentLevel, expandable: true })}
         {isOpen(mod.id) && (
           <div className={indent}>
             {renderChildren(mod.id, mod.modules, mod.topics, 'module')}

--- a/new-ui-source/src/components/course/CourseStructureTree.tsx
+++ b/new-ui-source/src/components/course/CourseStructureTree.tsx
@@ -31,6 +31,8 @@ export interface CourseStructureTreeProps {
   onRemove: (level: StructureLevel, id: string) => void;
   // Drag-and-drop: move `id` under `newParentId`, before `beforeId` (null = append).
   onMove: (level: StructureLevel, id: string, newParentId: string, beforeId: string | null) => void;
+  // Open a topic in the Page Editor (the "→" affordance on topic rows).
+  onOpenTopic: (topicId: string) => void;
 }
 
 interface Dragged { level: StructureLevel; id: string; }
@@ -94,6 +96,13 @@ function Plus({ size = 13 }: { size?: number }) {
     </svg>
   );
 }
+function ArrowRight() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" />
+    </svg>
+  );
+}
 
 // ─── Component ──────────────────────────────────────────────────────────────
 
@@ -128,6 +137,7 @@ export default function CourseStructureTree(props: CourseStructureTreeProps) {
     parentLevel: ContainerLevel;
     expandable?: boolean;
     deleteWarning?: string;
+    onOpen?: () => void;
   }
 
   // Plain render function (not a nested component) so the inline <input> keeps
@@ -226,6 +236,11 @@ export default function CourseStructureTree(props: CourseStructureTreeProps) {
           </div>
 
           <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+            {p.onOpen && (
+              <button type="button" aria-label={`Open ${p.title} in Page Editor`} title="Open in Page Editor" onClick={p.onOpen} className="p-1 rounded hover:bg-[#e5e7eb] text-[#9ca3af] hover:text-[#2d6fa8]">
+                <ArrowRight />
+              </button>
+            )}
             <button type="button" aria-label={`Delete ${p.title}`} onClick={() => setDeleteId(p.id)} className="p-1 rounded hover:bg-[#fee2e2] text-[#9ca3af] hover:text-[#dc2626]">
               <Trash />
             </button>
@@ -292,7 +307,7 @@ export default function CourseStructureTree(props: CourseStructureTreeProps) {
   function renderTopic(topic: STopic, containerId: string, parentLevel: ContainerLevel) {
     return (
       <div key={topic.id}>
-        {renderRow({ level: 'topic', id: topic.id, title: topic.title, parentId: containerId, parentLevel, expandable: true })}
+        {renderRow({ level: 'topic', id: topic.id, title: topic.title, parentId: containerId, parentLevel, expandable: true, onOpen: () => props.onOpenTopic(topic.id) })}
         {isOpen(topic.id) && renderSections(topic.sections, topic.id)}
       </div>
     );

--- a/new-ui-source/src/pages/SetupPage.tsx
+++ b/new-ui-source/src/pages/SetupPage.tsx
@@ -413,7 +413,6 @@ function CourseStructurePanel({
               onRename={rename}
               onRemove={remove}
               onMove={moveNode}
-              onOpenTopic={onOpenEditor}
             />
           ) : (
             <CourseStructureMapView
@@ -431,6 +430,18 @@ function CourseStructurePanel({
           )}
         </div>
       )}
+
+      {/* Tip — guide next steps (bottom of the Course Structure page) */}
+      <div className="mt-5 flex items-start gap-2 rounded-lg bg-[#f8fafc] border border-[#e5e7eb] px-3.5 py-2.5 text-sm text-[#6b7280]">
+        <svg className="shrink-0 mt-0.5 text-[#f0b429]" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M9 18h6M10 22h4M12 2a7 7 0 0 0-4 12.74V17h8v-2.26A7 7 0 0 0 12 2z" />
+        </svg>
+        <span>
+          <span className="font-medium text-[#374151]">Tip:</span> Click an item’s title to rename it. In Tree view,
+          drag items to reorder or move them across the hierarchy. Use the <span className="font-medium">+ Add</span> links
+          to build out your structure, then open a topic to add content in the editor.
+        </span>
+      </div>
 
       {addComponentBlockId && (
         <AddComponentDrawer

--- a/new-ui-source/src/pages/SetupPage.tsx
+++ b/new-ui-source/src/pages/SetupPage.tsx
@@ -299,14 +299,17 @@ function CourseStructurePanel({
   courseId,
   courseTitle,
   onOpenEditor,
+  onOpenStoryboard,
 }: {
   courseId: string;
   courseTitle: string;
   onOpenEditor: (topicId: string) => void;
+  onOpenStoryboard: () => void;
 }) {
   const [viewMode, setViewMode] = useState<"tree" | "map">("tree");
   // Content-group id whose Add Component drawer is open (null = closed).
   const [addComponentBlockId, setAddComponentBlockId] = useState<string | null>(null);
+  const [hintDismissed, setHintDismissed] = useState(false);
   const {
     state,
     loading,
@@ -374,10 +377,21 @@ function CourseStructurePanel({
         </div>
       </div>
 
-      {/* Info / rules banner */}
-      <div className="mb-5 p-3.5 rounded-lg bg-[#f0faf8] border border-[#99e6de] text-sm text-[#0d7377]">
+      {/* Rules banner (top) */}
+      <div className="mb-3 p-3.5 rounded-lg bg-[#f0faf8] border border-[#99e6de] text-sm text-[#0d7377]">
         Organize your course into modules, topics, sections, content groups and components. At least one topic
         is mandatory at the course level, and every module must contain at least one topic.
+      </div>
+
+      {/* Tip (top) — view-specific info text, styled like the app's Tip callouts */}
+      <div className="mb-5 flex items-start gap-2.5 rounded-lg bg-[#fff7ed] border border-[#fed7aa] px-4 py-3">
+        <span className="text-base leading-none mt-0.5" aria-hidden="true">💡</span>
+        <p className="text-sm text-[#9a3412] leading-snug">
+          <span className="font-semibold">Tip:</span>{" "}
+          {viewMode === "tree"
+            ? "Create and organize the learning journey using the tree view. Click any field to edit content directly, and open a topic in the Page Editor (→) for advanced editing and settings."
+            : "Explore the entire course structure in a visual format. Use Map View to review content coverage and learning flow across topics. To create, edit, or reorganize content, switch to Tree View."}
+        </p>
       </div>
 
       {error && (
@@ -413,6 +427,7 @@ function CourseStructurePanel({
               onRename={rename}
               onRemove={remove}
               onMove={moveNode}
+              onOpenTopic={onOpenEditor}
             />
           ) : (
             <CourseStructureMapView
@@ -431,17 +446,43 @@ function CourseStructurePanel({
         </div>
       )}
 
-      {/* Tip — guide next steps (bottom of the Course Structure page) */}
-      <div className="mt-5 flex items-start gap-2 rounded-lg bg-[#f8fafc] border border-[#e5e7eb] px-3.5 py-2.5 text-sm text-[#6b7280]">
-        <svg className="shrink-0 mt-0.5 text-[#f0b429]" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-          <path d="M9 18h6M10 22h4M12 2a7 7 0 0 0-4 12.74V17h8v-2.26A7 7 0 0 0 12 2z" />
-        </svg>
-        <span>
-          <span className="font-medium text-[#374151]">Tip:</span> Click an item’s title to rename it. In Tree view,
-          drag items to reorder or move them across the hierarchy. Use the <span className="font-medium">+ Add</span> links
-          to build out your structure, then open a topic to add content in the editor.
-        </span>
-      </div>
+      {/* Hint (bottom, dismissible) — styled per design */}
+      {!hintDismissed && (
+        <div className="relative mt-5 rounded-xl border border-[#bfdbeb] bg-[#eaf4fb] p-4 pr-10">
+          <button
+            type="button"
+            onClick={() => setHintDismissed(true)}
+            aria-label="Dismiss"
+            className="absolute top-3 right-3 p-1 rounded text-[#9ca3af] hover:text-[#374151] hover:bg-white/60 transition-colors"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+          <div className="flex items-start gap-3">
+            <svg className="shrink-0 mt-0.5 text-[#2d6fa8]" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+              <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+            </svg>
+            <div>
+              <p className="text-sm font-semibold text-[#111827]">Your structure is ready</p>
+              <p className="text-sm text-[#5b7c93] mt-1">
+                Open Storyboard to review and refine the content flow, or select a topic to continue building in the
+                Page Editor with content, layouts, interactions, and learner experience settings.
+              </p>
+              <button
+                type="button"
+                onClick={onOpenStoryboard}
+                className="mt-3 inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold text-white bg-[#2d6fa8] rounded-lg hover:bg-[#255d8f] transition-colors"
+              >
+                Open Storyboard
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {addComponentBlockId && (
         <AddComponentDrawer
@@ -5564,6 +5605,7 @@ function CourseCreationCenterContent() {
           onOpenEditor={(pageId) =>
             navigate(`/course/${courseId}`, { state: { pageId } })
           }
+          onOpenStoryboard={() => setActiveNav("storyboarding")}
         />
       );
     if (activeNav === "theme") return <ThemePanel initialThemeName={savedThemeName} />;


### PR DESCRIPTION
## ✅ PR Completion Checklist

* [x] PR title follows format: `Prefix: ADAPT-XXXX Brief description`
* [ ] JIRA ID linked in the Context section below
* [x] Plugin version updated in `bower.json` (if applicable)
* [ ] `npm run test-e2e-dev-pipeline` executed and passing
* [ ] No new issues reported by SonarLint (attach screenshot if applicable)
* [ ] Own diff reviewed before requesting review
* [x] At least two reviewers added (Copilot set as default)

---

## Context

#### Resolves / Addresses [ADAPT-3747](https://laerdal.atlassian.net/browse/ADAPT-3747)

Follow-up to the merged Course Structure page (#270), addressing QA feedback.
Scope: New UI only (`new-ui-source`, served at `/new`) — source changes only;
build artifacts (`public/new`, `dist`) are pipeline-generated.

## What changed

Applies the four QA items raised after testing the Course Structure page:

- **Removed the extra Add (+) and Edit (pencil) icons** on each structure row.
  Only **Delete** remains. Adding is available where the design puts it — the
  inline **+ Add …** links under each container and the course-level
  **+ Add Topic / + Add Module / + Add Sub-Module** buttons.
- **Rename by clicking the title.** Clicking a Module/Topic/Section/Content
  Group/Component title now starts inline rename (tooltip "Click to rename"),
  replacing the separate edit icon.
- **Guidance tip** added at the **bottom** of the Course Structure page to guide
  next steps (rename, drag to reorder/move, use + Add, then open a topic to edit).
- **Map view note** clearly states that drag-and-drop reordering is available in
  **Tree view** — the Map shows the current structure but isn't draggable
  (shown in both normal and fullscreen Map).

## Files

- `new-ui-source/src/components/course/CourseStructureTree.tsx` — remove +/pencil
  icons, click-title-to-rename, drop unused `onOpenTopic` prop
- `new-ui-source/src/components/course/CourseStructureMapView.tsx` — "drag in Tree
  view" note
- `new-ui-source/src/pages/SetupPage.tsx` — bottom tip; drop `onOpenTopic` from the
  Tree usage

## Testing

- `npx tsc --noEmit` — clean
- Manual (New UI → Course Setup → Course Structure):
  - Rows show only a Delete icon on hover; no + or pencil
  - Clicking any item title renames it inline (Enter to save, Esc to cancel)
  - Adding still works via the inline "+ Add …" links and course-level buttons
  - Tip appears at the bottom of the page
  - Map view (normal and fullscreen) shows the "drag-and-drop is available in
    Tree view" note

## Notes

- Title click now renames in Tree view; opening a topic in the editor is still
  available from the Map's Topic cards.
- Behavioral rules from earlier iterations are unchanged (mandatory-topic guards,
  2-component cap, warn-and-allow on last-component delete, drag-and-drop
  validation).

 
<img width="614" height="415" alt="image" src="https://github.com/user-attachments/assets/e4722f80-5bb6-431a-b1a8-501ecced727c" />
<img width="428" height="401" alt="image" src="https://github.com/user-attachments/assets/eb648f38-6074-4a93-af83-a27584e25dbb" />


