### PR TITLE
Feature: ADAPT-3760 Storyboard Authoring in Adapt Studio (initial testing release)

### DIFF
--- a/migrations/20260807120000-create-storyboard-collections.js
+++ b/migrations/20260807120000-create-storyboard-collections.js
@@ -1,0 +1,71 @@
+/**
+ * Migration: Create storyboard collections (ADAPT-3779, Phase 1)
+ *
+ * Additive only — creates the three collections backing the Storyboard
+ * Authoring feature and their indexes. Collection names match Mongoose's
+ * pluralised model names (model 'storyboard' → collection 'storyboards', etc.)
+ * so the app and the migration agree.
+ *
+ *   storyboards         — one document per course (documentJson, status, version,
+ *                         _generatedContentMap)                            (AC8)
+ *   storyboardcomments  — block-anchored comments + threaded replies       (AC9)
+ *   storyboardaudits    — append-only workflow event trail                 (AC8)
+ *
+ * Non-destructive: up() only creates (guarded by an existence check) and never
+ * drops. Rollback (down) drops the three collections, guarded with .catch().
+ */
+
+const COLLECTIONS = ['storyboards', 'storyboardcomments', 'storyboardaudits'];
+
+module.exports = {
+  async up(db) {
+    const existing = (await db.listCollections().toArray()).map((c) => c.name);
+
+    async function ensureCollection(name) {
+      if (existing.includes(name)) {
+        console.log(`• ${name} already exists — leaving as is`);
+        return;
+      }
+      await db.createCollection(name);
+      console.log(`✓ created collection ${name}`);
+    }
+
+    for (const name of COLLECTIONS) {
+      await ensureCollection(name);
+    }
+
+    // storyboards — looked up by course; filtered by status.
+    await db.collection('storyboards').createIndex({ _courseId: 1 }, { name: 'storyboard_courseId' });
+    await db.collection('storyboards').createIndex({ status: 1 }, { name: 'storyboard_status' });
+
+    // storyboardcomments — listed per storyboard; filtered by resolved; threaded.
+    await db
+      .collection('storyboardcomments')
+      .createIndex({ _storyboardId: 1 }, { name: 'comment_storyboardId' });
+    await db
+      .collection('storyboardcomments')
+      .createIndex({ _storyboardId: 1, resolved: 1 }, { name: 'comment_storyboard_resolved' });
+    await db
+      .collection('storyboardcomments')
+      .createIndex({ _parentCommentId: 1 }, { name: 'comment_parent' });
+
+    // storyboardaudits — listed per storyboard, newest first.
+    await db
+      .collection('storyboardaudits')
+      .createIndex({ _storyboardId: 1, createdAt: -1 }, { name: 'audit_storyboard_createdAt' });
+
+    console.log('✓ storyboard collections + indexes created');
+    return { collections: COLLECTIONS };
+  },
+
+  async down(db) {
+    for (const name of COLLECTIONS) {
+      await db
+        .collection(name)
+        .drop()
+        .then(() => console.log(`✓ dropped ${name}`))
+        .catch((err) => console.log(`• ${name} not dropped: ${err.message}`));
+    }
+    return { collections: COLLECTIONS, action: 'dropped' };
+  },
+};

--- a/migrations/20260807120000-create-storyboard-collections.js
+++ b/migrations/20260807120000-create-storyboard-collections.js
@@ -34,8 +34,36 @@ module.exports = {
       await ensureCollection(name);
     }
 
-    // storyboards — looked up by course; filtered by status.
-    await db.collection('storyboards').createIndex({ _courseId: 1 }, { name: 'storyboard_courseId' });
+    // storyboards — exactly ONE document per course (getStoryboardByCourse
+    // relies on this), so the course index is UNIQUE. Clean up any pre-existing
+    // duplicates first (keep the most recently updated) so the unique index can
+    // build, and drop a prior non-unique index of the same name if present.
+    const dupeGroups = await db
+      .collection('storyboards')
+      .aggregate([
+        { $group: { _id: '$_courseId', ids: { $push: '$_id' }, count: { $sum: 1 } } },
+        { $match: { count: { $gt: 1 } } },
+      ])
+      .toArray();
+    for (const g of dupeGroups) {
+      const docs = await db
+        .collection('storyboards')
+        .find({ _courseId: g._id })
+        .sort({ updatedAt: -1, version: -1, _id: -1 })
+        .toArray();
+      const remove = docs.slice(1).map((d) => d._id); // keep docs[0] (newest)
+      if (remove.length) {
+        await db.collection('storyboards').deleteMany({ _id: { $in: remove } });
+        console.log(`• removed ${remove.length} duplicate storyboard(s) for course ${g._id}`);
+      }
+    }
+    await db
+      .collection('storyboards')
+      .dropIndex('storyboard_courseId')
+      .catch(() => {}); // no-op if it doesn't exist yet
+    await db
+      .collection('storyboards')
+      .createIndex({ _courseId: 1 }, { name: 'storyboard_courseId', unique: true });
     await db.collection('storyboards').createIndex({ status: 1 }, { name: 'storyboard_status' });
 
     // storyboardcomments — listed per storyboard; filtered by resolved; threaded.

--- a/new-ui-source/package.json
+++ b/new-ui-source/package.json
@@ -10,7 +10,11 @@
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives"
   },
   "dependencies": {
+    "@blocknote/core": "^0.52.1",
+    "@blocknote/mantine": "^0.52.1",
+    "@blocknote/react": "^0.52.1",
     "headroom-ai": "^0.22.4",
+    "lucide-react": "^1.29.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-router-dom": "^7.0.0",

--- a/new-ui-source/package.json
+++ b/new-ui-source/package.json
@@ -13,7 +13,6 @@
     "@blocknote/core": "^0.52.1",
     "@blocknote/mantine": "^0.52.1",
     "@blocknote/react": "^0.52.1",
-    "headroom-ai": "^0.22.4",
     "lucide-react": "^1.29.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/new-ui-source/src/api/adaptAuthoring.ts
+++ b/new-ui-source/src/api/adaptAuthoring.ts
@@ -6,13 +6,21 @@
 import { apiClient } from "./client";
 import {
   buildGraphicField,
+  buildImageAsMedia,
   buildMediaField,
+  classifyLaerdalMedia,
   filenameFromLink,
   imageFromGraphic,
+  imageFromMediaPoster,
+  LAERDAL_MEDIA_COMPONENT,
   mediaFromComponent,
+  mergeProperties,
+  resolveAssetUrl,
   type ImageData,
   type MediaData,
 } from "@/components/storyboard/mediaMapping";
+import { reverseKind, isAssessmentComponentKind } from "./componentMapping";
+import { parseAssessmentData, type AssessmentKind } from "@/types/storyboard";
 export {
   TRACKING_ANALYTICS_EXTENSION_NAME_BY_KEY,
   defaultTrackingAnalyticsSettings,
@@ -1300,6 +1308,7 @@ interface EngineContentNode {
   body?: string;
   _graphic?: Record<string, unknown>;
   _media?: Record<string, unknown>;
+  properties?: Record<string, unknown>;
 }
 
 // A component type installed on the instance (GET /api/componenttype).
@@ -1466,6 +1475,10 @@ export async function getCourseStoryboardBlocks(courseId: string): Promise<unkno
   ]);
 
   const label = (n: EngineContentNode) => n.displayTitle || n.title || "Untitled";
+  // Plugin fields live under `properties`; fall back to the top level for any
+  // legacy data written before that was fixed.
+  const propOf = (n: EngineContentNode, key: "_graphic" | "_media") =>
+    ((n.properties as Record<string, unknown> | undefined)?.[key] ?? n[key]) as Record<string, unknown> | undefined;
   const childrenOf = (rows: EngineContentNode[], parentId: string) =>
     rows.filter((r) => r._parentId === parentId).sort(bySortOrder);
   const pages = contentObjects.filter((c) => c._type === "page");
@@ -1476,36 +1489,106 @@ export async function getCourseStoryboardBlocks(courseId: string): Promise<unkno
   // Graphic/media components project as rich sbComponent cards (so the chosen
   // asset renders + round-trips); every other component stays as an H4 heading
   // + body paragraph (keeps the text write-back contract intact).
-  const emitComponent = (comp: EngineContentNode) => {
-    const kindOf = comp._component;
-    if (kindOf === "graphic") {
-      const image = imageFromGraphic(comp._graphic, assetIdMap);
+  const emitMediaCard = (comp: EngineContentNode, mediaKind: "image" | "video" | "audio") => {
+    if (mediaKind === "image") {
+      const image = imageFromMediaPoster(propOf(comp, "_media"), assetIdMap);
       out.push({
         id: comp._id,
         type: "sbComponent",
         props: {
           kind: "image",
           title: label(comp),
-          adaptComponent: "graphic",
+          adaptComponent: LAERDAL_MEDIA_COMPONENT,
           data: JSON.stringify({ showTitle: true, description: "", instruction: "", image }),
         },
       });
       return;
     }
+    const { data } = mediaFromComponent(propOf(comp, "_media"), assetIdMap);
+    out.push({
+      id: comp._id,
+      type: "sbComponent",
+      props: {
+        kind: mediaKind,
+        title: label(comp),
+        adaptComponent: LAERDAL_MEDIA_COMPONENT,
+        data: JSON.stringify({ showTitle: true, description: "", instruction: "", media: data }),
+      },
+    });
+  };
+
+  const emitCard = (comp: EngineContentNode, kind: string, data: Record<string, unknown>) => {
+    out.push({
+      id: comp._id,
+      type: "sbComponent",
+      props: { kind, title: label(comp), adaptComponent: comp._component || kind, data: JSON.stringify(data) },
+    });
+  };
+
+  const emitComponent = (comp: EngineContentNode) => {
+    const kindOf = comp._component;
+    const props = (comp.properties as Record<string, unknown>) || {};
+    const sbKind = reverseKind(kindOf);
+
+    // Media (laerdal-media / contrib media) → image/video/audio, classified by
+    // which `_media` fields are set.
+    if (kindOf === LAERDAL_MEDIA_COMPONENT) {
+      emitMediaCard(comp, classifyLaerdalMedia(propOf(comp, "_media")));
+      return;
+    }
     if (kindOf === "media") {
-      const { kind, data } = mediaFromComponent(comp._media, assetIdMap);
-      out.push({
-        id: comp._id,
-        type: "sbComponent",
-        props: {
-          kind,
-          title: label(comp),
-          adaptComponent: "media",
-          data: JSON.stringify({ showTitle: true, description: "", instruction: "", media: data }),
-        },
+      const { kind } = mediaFromComponent(propOf(comp, "_media"), assetIdMap);
+      emitMediaCard(comp, kind);
+      return;
+    }
+    // Graphic → Image card.
+    if (kindOf === "graphic") {
+      const image = imageFromGraphic(propOf(comp, "_graphic"), assetIdMap);
+      emitCard(comp, "image", { showTitle: true, description: "", instruction: "", image });
+      return;
+    }
+    // Accordion / Narrative → Grouped Content card. Items round-trip via
+    // `_items[].{title, body, _graphic.src}` (accept legacy `.small`).
+    if (sbKind === "groupedContent") {
+      const rawItems = Array.isArray(props._items) ? (props._items as Array<Record<string, unknown>>) : [];
+      const items = rawItems.map((it) => {
+        const g = (it._graphic as { src?: string; small?: string } | undefined) || {};
+        const link = g.src || g.small || "";
+        return {
+          title: String(it.title || ""),
+          body: stripHtml(String(it.body || "")),
+          image: link, // persisted link (course/assets/<file> or external URL)
+          imageUrl: resolveAssetUrl(link, assetIdMap), // servable preview
+        };
+      });
+      emitCard(comp, "groupedContent", {
+        showTitle: true,
+        description: stripHtml(comp.body || ""),
+        instruction: comp.instruction || "",
+        items,
       });
       return;
     }
+    // Assessment question components → assessment card (options + feedback).
+    if (sbKind && isAssessmentComponentKind(sbKind)) {
+      const data = parseAssessmentData(sbKind as AssessmentKind, props, stripHtml(comp.body || ""));
+      out.push({
+        id: comp._id,
+        type: "sbAssessment",
+        props: { kind: sbKind, title: label(comp), adaptComponent: kindOf, data: JSON.stringify(data) },
+      });
+      return;
+    }
+    // H5P and Laerdal Form → their own cards (config round-trips minimally).
+    if (sbKind === "h5p") {
+      emitCard(comp, "h5p", { showTitle: true, description: stripHtml(comp.body || ""), instruction: "" });
+      return;
+    }
+    if (sbKind === "laerdalForm") {
+      emitCard(comp, "laerdalForm", { showTitle: true, description: stripHtml(comp.body || ""), instruction: "" });
+      return;
+    }
+    // Unknown / text → H4 heading + body paragraph (text write-back contract).
     out.push({ id: comp._id, type: "heading", props: { level: 4 }, content: label(comp) });
     const bodyText = stripHtml(comp.body || "");
     if (bodyText) out.push({ id: `${comp._id}${BODY_SUFFIX}`, type: "paragraph", content: bodyText });
@@ -1606,7 +1689,12 @@ export async function saveStoryboardToCourse(
     // asset fields (+ title) and (re)link the courseasset for publish.
     if (raw.type === "sbComponent" && info.level === "component") {
       const kind = raw.props?.kind;
-      let parsed: { image?: ImageData; media?: MediaData } = {};
+      let parsed: {
+        image?: ImageData;
+        media?: MediaData;
+        description?: string;
+        items?: Array<{ title?: string; body?: string; image?: string; imageAssetId?: string }>;
+      } = {};
       try {
         parsed = raw.props?.data ? JSON.parse(raw.props.data) : {};
       } catch {
@@ -1621,14 +1709,47 @@ export async function saveStoryboardToCourse(
       }
       let assetLink: string | undefined;
       let assetId: string | undefined;
-      if (kind === "image" && info.component === "graphic") {
-        Object.assign(patch, buildGraphicField(parsed.image));
+      const isLaerdalMedia = info.component === LAERDAL_MEDIA_COMPONENT;
+      const isGrouped =
+        info.component === "accordion" ||
+        info.component === "laerdal-narrative" ||
+        info.component === "narrative";
+      if (kind === "image" && (info.component === "graphic" || isLaerdalMedia)) {
+        // Image → _graphic (or legacy laerdal-media poster if the existing comp
+        // is a laerdal-media from a course generated before this change).
+        // Plugin fields nest under `properties` (top-level is dropped by the
+        // content model).
+        mergeProperties(patch, isLaerdalMedia ? buildImageAsMedia(parsed.image) : buildGraphicField(parsed.image));
         assetLink = parsed.image?.link;
         assetId = parsed.image?.assetId;
-      } else if ((kind === "video" || kind === "audio") && info.component === "media") {
-        Object.assign(patch, buildMediaField(kind, parsed.media));
+      } else if ((kind === "video" || kind === "audio") && (isLaerdalMedia || info.component === "media")) {
+        mergeProperties(patch, buildMediaField(kind, parsed.media));
         assetLink = parsed.media?.asset?.link;
         assetId = parsed.media?.asset?.assetId;
+      } else if (kind === "groupedContent" && isGrouped) {
+        // Grouped Content → accordion / narrative `properties._items` with
+        // `_graphic.src` (matches the installed schemas). Persist any link
+        // (course/assets/<file> or external URL).
+        const items = Array.isArray(parsed.items) ? parsed.items : [];
+        mergeProperties(patch, {
+          _items: items.map((it) => {
+            const rawBody = (it?.body || "").trim();
+            const body = rawBody
+              ? rawBody.startsWith("<")
+                ? rawBody
+                : `<p>${escapeHtml(rawBody)}</p>`
+              : "";
+            const imgLink = (it?.image || "").trim();
+            return { title: it?.title || "", body, _graphic: { alt: "", src: imgLink, attribution: "" } };
+          }),
+        });
+        // Each item image needs its own courseasset link for publish.
+        for (const it of items) {
+          const fn = filenameFromLink((it?.image || "").trim());
+          if (fn && it?.imageAssetId) {
+            tasks.push(linkContentAsset(courseId, "component", id, info.parentId || "", fn, it.imageAssetId));
+          }
+        }
       }
       if (Object.keys(patch).length) {
         tasks.push(apiClient.put(`/api/content/component/${id}`, patch));
@@ -2401,12 +2522,22 @@ export function addStoryboardAudit(
 // Import / Export (AC10) — binary exchanged as base64 through the JSON client.
 export type ImportFormat = "word" | "pdf" | "pptx";
 
-export function exportStoryboardWord(id: string): Promise<{ filename: string; mime: string; dataBase64: string }> {
-  return apiClient.get<{ filename: string; mime: string; dataBase64: string }>(`${SB_DOCS}/${id}/export/word`);
+// `title` (the course title) drives both the in-document heading and the
+// download filename server-side; falls back to the storyboard record title.
+export function exportStoryboardWord(
+  id: string,
+  title?: string
+): Promise<{ filename: string; mime: string; dataBase64: string }> {
+  const q = title ? `?title=${encodeURIComponent(title)}` : "";
+  return apiClient.get<{ filename: string; mime: string; dataBase64: string }>(`${SB_DOCS}/${id}/export/word${q}`);
 }
 
-export function exportStoryboardPdf(id: string): Promise<{ filename: string; mime: string; dataBase64: string }> {
-  return apiClient.get<{ filename: string; mime: string; dataBase64: string }>(`${SB_DOCS}/${id}/export/pdf`);
+export function exportStoryboardPdf(
+  id: string,
+  title?: string
+): Promise<{ filename: string; mime: string; dataBase64: string }> {
+  const q = title ? `?title=${encodeURIComponent(title)}` : "";
+  return apiClient.get<{ filename: string; mime: string; dataBase64: string }>(`${SB_DOCS}/${id}/export/pdf${q}`);
 }
 
 export function importStoryboardDocument(

--- a/new-ui-source/src/api/adaptAuthoring.ts
+++ b/new-ui-source/src/api/adaptAuthoring.ts
@@ -4,6 +4,15 @@
 // keep engine-specific endpoint knowledge here, not in the pages.
 
 import { apiClient } from "./client";
+import {
+  buildGraphicField,
+  buildMediaField,
+  filenameFromLink,
+  imageFromGraphic,
+  mediaFromComponent,
+  type ImageData,
+  type MediaData,
+} from "@/components/storyboard/mediaMapping";
 export {
   TRACKING_ANALYTICS_EXTENSION_NAME_BY_KEY,
   defaultTrackingAnalyticsSettings,
@@ -138,10 +147,12 @@ export interface Asset {
   path?: string;
 }
 
-// Query image assets from the engine asset manager.
-// GET /api/asset/query?search[mimeType]=image
-export async function queryImages(search?: string): Promise<Asset[]> {
-  const params = new URLSearchParams({ "search[mimeType]": "image" });
+export type AssetKind = "image" | "audio" | "video";
+
+// Query assets of a given kind from the engine asset manager.
+// GET /api/asset/query?search[mimeType]=<kind>
+export async function queryAssets(kind: AssetKind, search?: string): Promise<Asset[]> {
+  const params = new URLSearchParams({ "search[mimeType]": kind });
   if (search) params.append("search[title]", search);
   try {
     const result = await apiClient.get<Asset[]>(`/api/asset/query?${params}`);
@@ -149,6 +160,11 @@ export async function queryImages(search?: string): Promise<Asset[]> {
   } catch {
     return [];
   }
+}
+
+// Query image assets (back-compat wrapper used by the cover-image picker).
+export async function queryImages(search?: string): Promise<Asset[]> {
+  return queryAssets("image", search);
 }
 
 // Upload a file as a new asset. Returns the new asset's _id.
@@ -1180,6 +1196,57 @@ export async function createCourseAssetMapping(courseId: string, fieldName: stri
   });
 }
 
+// All courseasset links for a course, keyed by filename (`_fieldName`) → asset
+// `_id`. Used to resolve a stored `course/assets/<filename>` reference back to a
+// servable `/api/asset/serve/<id>` URL when projecting course media into the
+// storyboard.
+export async function getCourseAssetIdMap(courseId: string): Promise<Record<string, string>> {
+  try {
+    const records = await apiClient.get<CourseAssetRecord[]>(
+      `/api/content/courseasset?_courseId=${encodeURIComponent(courseId)}`
+    );
+    if (!Array.isArray(records)) return {};
+    const map: Record<string, string> = {};
+    for (const r of records) {
+      if (r?._fieldName && r?._assetId) map[r._fieldName] = r._assetId;
+    }
+    return map;
+  } catch {
+    return {};
+  }
+}
+
+// Link a DAM asset to a specific content node's field (component-scoped
+// courseasset), mirroring the legacy scaffoldAssetView contract so publish
+// asset-copy resolves. `filename` is the `course/assets/<filename>` basename.
+export async function linkContentAsset(
+  courseId: string,
+  contentType: string,
+  contentId: string,
+  parentId: string,
+  filename: string,
+  assetId: string
+): Promise<void> {
+  if (!filename || !assetId) return;
+  try {
+    // Avoid duplicate link records for the same node+field.
+    const existing = await apiClient.get<CourseAssetRecord[]>(
+      `/api/content/courseasset?_courseId=${encodeURIComponent(courseId)}&_contentTypeId=${encodeURIComponent(contentId)}&_fieldName=${encodeURIComponent(filename)}`
+    );
+    if (Array.isArray(existing) && existing.length) return;
+  } catch {
+    /* fall through and attempt to create */
+  }
+  await apiClient.post("/api/content/courseasset", {
+    _courseId: courseId,
+    _contentType: contentType,
+    _contentTypeId: contentId,
+    _fieldName: filename,
+    _assetId: assetId,
+    _contentTypeParentId: parentId,
+  });
+}
+
 export async function removeCourseAssetMappings(courseId: string, fieldName: string): Promise<void> {
   const records = await apiClient.get<CourseAssetRecord[]>(
     `/api/content/courseasset?_contentTypeId=${encodeURIComponent(courseId)}&_contentType=course&_fieldName=${encodeURIComponent(fieldName)}`
@@ -1230,6 +1297,9 @@ interface EngineContentNode {
   _componentType?: string;
   _layout?: string;
   url?: string;
+  body?: string;
+  _graphic?: Record<string, unknown>;
+  _media?: Record<string, unknown>;
 }
 
 // A component type installed on the instance (GET /api/componenttype).
@@ -1246,7 +1316,7 @@ export interface ComponentTypeOption {
 const bySortOrder = (a: EngineContentNode, b: EngineContentNode): number =>
   (a._sortOrder ?? 0) - (b._sortOrder ?? 0);
 
-async function getContentByCourse(
+export async function getContentByCourse(
   type: string,
   courseId: string
 ): Promise<EngineContentNode[]> {
@@ -1329,6 +1399,250 @@ export async function getCourseStructure(
     modules: childMenus(courseId).map(buildModule),
     topics: childPages(courseId).map(buildTopic),
   };
+}
+
+// ── Storyboard ⇄ course content bridge (ADAPT-3760, AC4/AC11) ───────────────
+// Read: project the live course hierarchy into a BlockNote document so the
+// storyboard reflects the real course. Each block's `id` is set to the source
+// content `_id` (a component's body paragraph uses `<id>::body`) so edits can
+// be written back to the exact node. Write: update titles/bodies of existing
+// nodes matched by those ids. Structural create/delete/move is deferred to the
+// Phase 4 generation engine and reported (never silently dropped).
+
+const BODY_SUFFIX = "::body";
+
+function stripHtml(html: string): string {
+  return (html || "")
+    .replace(/<\s*br\s*\/?>/gi, "\n")
+    .replace(/<\/(p|div|li|h[1-6])>/gi, "\n")
+    .replace(/<[^>]*>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function escapeHtml(s: string): string {
+  return (s || "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+// A BlockNote block's inline content → plain text.
+function inlineToText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((n) => (n && typeof (n as { text?: unknown }).text === "string" ? (n as { text: string }).text : ""))
+    .join("");
+}
+
+interface StoryboardBlock {
+  id?: string;
+  type?: string;
+  props?: { level?: number; kind?: string; title?: string; adaptComponent?: string; data?: string };
+  content?: unknown;
+}
+
+export interface CourseWriteBackResult {
+  updatedTitles: number;
+  updatedBodies: number;
+  /** Blocks in the doc with no matching course node (new structure — Phase 4). */
+  unmapped: number;
+}
+
+// READ: course hierarchy → ordered BlockNote blocks (H1 Topic / H2 Section /
+// H3 Content Group / H4 Component + body paragraph). Modules (menus) are
+// flattened (implicit-single-Module mapping) — their pages emit as topics.
+export async function getCourseStoryboardBlocks(courseId: string): Promise<unknown[]> {
+  const [contentObjects, articles, blocks, components, assetIdMap] = await Promise.all([
+    getContentByCourse("contentobject", courseId),
+    getContentByCourse("article", courseId),
+    getContentByCourse("block", courseId),
+    getContentByCourse("component", courseId),
+    getCourseAssetIdMap(courseId),
+  ]);
+
+  const label = (n: EngineContentNode) => n.displayTitle || n.title || "Untitled";
+  const childrenOf = (rows: EngineContentNode[], parentId: string) =>
+    rows.filter((r) => r._parentId === parentId).sort(bySortOrder);
+  const pages = contentObjects.filter((c) => c._type === "page");
+  const menus = contentObjects.filter((c) => c._type === "menu");
+
+  const out: StoryboardBlock[] = [];
+
+  // Graphic/media components project as rich sbComponent cards (so the chosen
+  // asset renders + round-trips); every other component stays as an H4 heading
+  // + body paragraph (keeps the text write-back contract intact).
+  const emitComponent = (comp: EngineContentNode) => {
+    const kindOf = comp._component;
+    if (kindOf === "graphic") {
+      const image = imageFromGraphic(comp._graphic, assetIdMap);
+      out.push({
+        id: comp._id,
+        type: "sbComponent",
+        props: {
+          kind: "image",
+          title: label(comp),
+          adaptComponent: "graphic",
+          data: JSON.stringify({ showTitle: true, description: "", instruction: "", image }),
+        },
+      });
+      return;
+    }
+    if (kindOf === "media") {
+      const { kind, data } = mediaFromComponent(comp._media, assetIdMap);
+      out.push({
+        id: comp._id,
+        type: "sbComponent",
+        props: {
+          kind,
+          title: label(comp),
+          adaptComponent: "media",
+          data: JSON.stringify({ showTitle: true, description: "", instruction: "", media: data }),
+        },
+      });
+      return;
+    }
+    out.push({ id: comp._id, type: "heading", props: { level: 4 }, content: label(comp) });
+    const bodyText = stripHtml(comp.body || "");
+    if (bodyText) out.push({ id: `${comp._id}${BODY_SUFFIX}`, type: "paragraph", content: bodyText });
+  };
+  const emitTopic = (page: EngineContentNode) => {
+    out.push({ id: page._id, type: "heading", props: { level: 1 }, content: label(page) });
+    for (const article of childrenOf(articles, page._id)) {
+      out.push({ id: article._id, type: "heading", props: { level: 2 }, content: label(article) });
+      for (const blk of childrenOf(blocks, article._id)) {
+        out.push({ id: blk._id, type: "heading", props: { level: 3 }, content: label(blk) });
+        for (const comp of childrenOf(components, blk._id)) emitComponent(comp);
+      }
+    }
+  };
+  const emitMenu = (menu: EngineContentNode) => {
+    for (const page of childrenOf(pages, menu._id)) emitTopic(page);
+    for (const sub of childrenOf(menus, menu._id)) emitMenu(sub);
+  };
+
+  for (const page of childrenOf(pages, courseId)) emitTopic(page);
+  for (const menu of childrenOf(menus, courseId)) emitMenu(menu);
+
+  return out;
+}
+
+// WRITE: persist edits of EXISTING nodes (titles + text bodies) back to course
+// content. New/removed/moved structure is NOT reconciled here (Phase 4) — such
+// blocks are counted as `unmapped` and left for the generation engine.
+export async function saveStoryboardToCourse(
+  courseId: string,
+  doc: unknown[]
+): Promise<CourseWriteBackResult> {
+  const [contentObjects, articles, blocks, components] = await Promise.all([
+    getContentByCourse("contentobject", courseId),
+    getContentByCourse("article", courseId),
+    getContentByCourse("block", courseId),
+    getContentByCourse("component", courseId),
+  ]);
+
+  const label = (n: EngineContentNode) => n.displayTitle || n.title || "Untitled";
+  const index = new Map<
+    string,
+    { level: StructureLevel; title: string; body?: string; component?: string; parentId?: string }
+  >();
+  contentObjects.forEach((c) =>
+    index.set(c._id, { level: c._type === "menu" ? "module" : "topic", title: label(c) })
+  );
+  articles.forEach((a) => index.set(a._id, { level: "section", title: label(a) }));
+  blocks.forEach((b) => index.set(b._id, { level: "contentGroup", title: label(b) }));
+  components.forEach((c) =>
+    index.set(c._id, {
+      level: "component",
+      title: label(c),
+      body: c.body || "",
+      component: c._component,
+      parentId: c._parentId,
+    })
+  );
+
+  let updatedTitles = 0;
+  let updatedBodies = 0;
+  let unmapped = 0;
+  const tasks: Promise<unknown>[] = [];
+
+  for (const raw of doc as StoryboardBlock[]) {
+    const id = raw && typeof raw.id === "string" ? raw.id : undefined;
+    if (!id) continue;
+
+    if (id.endsWith(BODY_SUFFIX)) {
+      const compId = id.slice(0, -BODY_SUFFIX.length);
+      const info = index.get(compId);
+      if (!info || info.level !== "component") {
+        unmapped += 1;
+        continue;
+      }
+      const nextText = inlineToText(raw.content);
+      if (nextText !== stripHtml(info.body || "")) {
+        tasks.push(apiClient.put(`/api/content/component/${compId}`, { body: `<p>${escapeHtml(nextText)}</p>` }));
+        updatedBodies += 1;
+      }
+      continue;
+    }
+
+    const info = index.get(id);
+    if (!info) {
+      unmapped += 1; // new block — structural create is Phase 4
+      continue;
+    }
+    if (raw.type === "heading") {
+      const nextTitle = inlineToText(raw.content).trim();
+      if (nextTitle && nextTitle !== info.title) {
+        tasks.push(renameStructureNode(info.level, id, nextTitle));
+        updatedTitles += 1;
+      }
+      continue;
+    }
+    // Media card mapped to an existing graphic/media component → write its
+    // asset fields (+ title) and (re)link the courseasset for publish.
+    if (raw.type === "sbComponent" && info.level === "component") {
+      const kind = raw.props?.kind;
+      let parsed: { image?: ImageData; media?: MediaData } = {};
+      try {
+        parsed = raw.props?.data ? JSON.parse(raw.props.data) : {};
+      } catch {
+        parsed = {};
+      }
+      const patch: Record<string, unknown> = {};
+      const nextTitle = (raw.props?.title || "").trim();
+      if (nextTitle && nextTitle !== info.title) {
+        patch.title = nextTitle;
+        patch.displayTitle = nextTitle;
+        updatedTitles += 1;
+      }
+      let assetLink: string | undefined;
+      let assetId: string | undefined;
+      if (kind === "image" && info.component === "graphic") {
+        Object.assign(patch, buildGraphicField(parsed.image));
+        assetLink = parsed.image?.link;
+        assetId = parsed.image?.assetId;
+      } else if ((kind === "video" || kind === "audio") && info.component === "media") {
+        Object.assign(patch, buildMediaField(kind, parsed.media));
+        assetLink = parsed.media?.asset?.link;
+        assetId = parsed.media?.asset?.assetId;
+      }
+      if (Object.keys(patch).length) {
+        tasks.push(apiClient.put(`/api/content/component/${id}`, patch));
+        updatedBodies += 1;
+        if (assetId && assetLink) {
+          const fn = filenameFromLink(assetLink);
+          if (fn) tasks.push(linkContentAsset(courseId, "component", id, info.parentId || "", fn, assetId));
+        }
+      }
+    }
+  }
+
+  await Promise.all(tasks);
+  return { updatedTitles, updatedBodies, unmapped };
 }
 
 // ── Component types (Add Component drawer) ──────────────────────────────────
@@ -1955,4 +2269,149 @@ export async function getPlugins(): Promise<DashboardPlugin[]> {
     status: p._isAvailableInEditor === false ? "Disabled" : "Enabled",
     installedDate: fmtDate(p.createdAt),
   }));
+}
+
+// ── Storyboard Authoring (ADAPT-3760 / ADAPT-3779) ──────────────────────────
+// CRUD over /api/storyboard/{documents,comments,audit}. documentJson and
+// _generatedContentMap are exchanged as parsed JSON (the backend stores them as
+// strings and (de)serialises at the route boundary).
+
+export type StoryboardStatus = "draft" | "in_review" | "approved";
+
+export interface StoryboardRecord {
+  _id: string;
+  _courseId: string;
+  title: string;
+  status: StoryboardStatus;
+  version: number;
+  documentJson: unknown[];
+  _generatedContentMap: Record<string, string>;
+  createdBy?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface StoryboardComment {
+  _id: string;
+  _storyboardId: string;
+  _courseId?: string;
+  blockId: string;
+  _parentCommentId?: string;
+  body: string;
+  resolved: boolean;
+  createdBy?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface StoryboardAuditEvent {
+  _id: string;
+  _storyboardId: string;
+  _courseId?: string;
+  event: "status_change" | "generated" | "imported";
+  fromStatus?: string;
+  toStatus?: string;
+  meta?: Record<string, unknown>;
+  createdBy?: string;
+  createdAt?: string;
+}
+
+const SB_DOCS = "/api/storyboard/documents";
+const SB_COMMENTS = "/api/storyboard/comments";
+
+// Storyboard documents ------------------------------------------------------
+
+// Returns null when the course has no storyboard yet.
+export function getStoryboardByCourse(courseId: string): Promise<StoryboardRecord | null> {
+  return apiClient.get<StoryboardRecord | null>(`${SB_DOCS}/course/${courseId}`);
+}
+
+export function getStoryboard(id: string): Promise<StoryboardRecord> {
+  return apiClient.get<StoryboardRecord>(`${SB_DOCS}/${id}`);
+}
+
+export function createStoryboard(input: {
+  _courseId: string;
+  title?: string;
+  documentJson?: unknown[];
+  status?: StoryboardStatus;
+}): Promise<StoryboardRecord> {
+  return apiClient.post<StoryboardRecord>(SB_DOCS, input);
+}
+
+export function updateStoryboard(
+  id: string,
+  patch: Partial<Pick<StoryboardRecord, "title" | "status" | "version" | "documentJson" | "_generatedContentMap">>
+): Promise<StoryboardRecord> {
+  return apiClient.put<StoryboardRecord>(`${SB_DOCS}/${id}`, patch);
+}
+
+// Changes status and appends a status_change audit event server-side.
+export function setStoryboardStatus(id: string, status: StoryboardStatus): Promise<StoryboardRecord> {
+  return apiClient.put<StoryboardRecord>(`${SB_DOCS}/${id}/status`, { status });
+}
+
+export function deleteStoryboard(id: string): Promise<{ success: boolean }> {
+  return apiClient.delete<{ success: boolean }>(`${SB_DOCS}/${id}`);
+}
+
+// Comments ------------------------------------------------------------------
+
+export function listStoryboardComments(id: string): Promise<StoryboardComment[]> {
+  return apiClient.get<StoryboardComment[]>(`${SB_DOCS}/${id}/comments`);
+}
+
+export function addStoryboardComment(
+  id: string,
+  input: { blockId: string; body: string; _parentCommentId?: string; _courseId?: string }
+): Promise<StoryboardComment> {
+  return apiClient.post<StoryboardComment>(`${SB_DOCS}/${id}/comments`, input);
+}
+
+export function updateStoryboardComment(
+  commentId: string,
+  patch: { body?: string; resolved?: boolean }
+): Promise<StoryboardComment> {
+  return apiClient.put<StoryboardComment>(`${SB_COMMENTS}/${commentId}`, patch);
+}
+
+export function deleteStoryboardComment(commentId: string): Promise<{ success: boolean }> {
+  return apiClient.delete<{ success: boolean }>(`${SB_COMMENTS}/${commentId}`);
+}
+
+// Audit ---------------------------------------------------------------------
+
+export function listStoryboardAudit(id: string): Promise<StoryboardAuditEvent[]> {
+  return apiClient.get<StoryboardAuditEvent[]>(`${SB_DOCS}/${id}/audit`);
+}
+
+export function addStoryboardAudit(
+  id: string,
+  input: {
+    event: StoryboardAuditEvent["event"];
+    fromStatus?: string;
+    toStatus?: string;
+    meta?: Record<string, unknown>;
+    _courseId?: string;
+  }
+): Promise<StoryboardAuditEvent> {
+  return apiClient.post<StoryboardAuditEvent>(`${SB_DOCS}/${id}/audit`, input);
+}
+
+// Import / Export (AC10) — binary exchanged as base64 through the JSON client.
+export type ImportFormat = "word" | "pdf" | "pptx";
+
+export function exportStoryboardWord(id: string): Promise<{ filename: string; mime: string; dataBase64: string }> {
+  return apiClient.get<{ filename: string; mime: string; dataBase64: string }>(`${SB_DOCS}/${id}/export/word`);
+}
+
+export function exportStoryboardPdf(id: string): Promise<{ filename: string; mime: string; dataBase64: string }> {
+  return apiClient.get<{ filename: string; mime: string; dataBase64: string }>(`${SB_DOCS}/${id}/export/pdf`);
+}
+
+export function importStoryboardDocument(
+  format: ImportFormat,
+  dataBase64: string
+): Promise<{ blocks: unknown[] }> {
+  return apiClient.post<{ blocks: unknown[] }>(`/api/storyboard/import/${format}`, { dataBase64 });
 }

--- a/new-ui-source/src/api/ai.ts
+++ b/new-ui-source/src/api/ai.ts
@@ -10,6 +10,10 @@ import { apiClient } from "./client";
 
 export type StoryboardAiAction = "improve" | "rewrite" | "summarize" | "suggest";
 
+// Samaritan Assistance actions (parity with the legacy CKEditor tool). `custom`
+// carries a free-text instruction. All share the same server proxy.
+export type SamaritanAction = "improve" | "shorten" | "lengthen" | "spelling" | "custom";
+
 // Run an AI action on a piece of text via the server proxy. Returns the result.
 export async function storyboardAi(
   action: StoryboardAiAction,
@@ -17,6 +21,24 @@ export async function storyboardAi(
   context?: string
 ): Promise<string> {
   const res = await apiClient.post<{ text: string }>("/api/storyboard/ai", { action, text, context });
+  return res.text ?? "";
+}
+
+// Samaritan Assistance call: a fixed action (improve/shorten/lengthen/spelling)
+// or a free-text `custom` instruction. `text` is the content to operate on (may
+// be empty for generate-from-scratch). `context` is the course title. Keys stay
+// server-side — same /api/storyboard/ai proxy.
+export async function samaritanAssist(
+  action: SamaritanAction,
+  text: string,
+  opts?: { instruction?: string; context?: string }
+): Promise<string> {
+  const res = await apiClient.post<{ text: string }>("/api/storyboard/ai", {
+    action,
+    text,
+    instruction: opts?.instruction,
+    context: opts?.context,
+  });
   return res.text ?? "";
 }
 

--- a/new-ui-source/src/api/ai.ts
+++ b/new-ui-source/src/api/ai.ts
@@ -1,91 +1,38 @@
-// AI service — wraps compress() from headroom-ai around Anthropic fetch calls.
-// headroom-ai intercepts messages before they reach Claude, compressing
-// repeated course context, conversation history, and tool outputs.
+// AI service (ADAPT-3760, AC7).
+//
+// The browser no longer holds any LLM key. All AI calls go through the engine's
+// server-side proxy (POST /api/storyboard/ai), which talks to Azure OpenAI with
+// credentials that stay on the server (see plugins/content/storyboard/utils/
+// aiClient.js). VITE_ANTHROPIC_API_KEY and the direct Anthropic call have been
+// removed.
 
-import { compress } from 'headroom-ai';
+import { apiClient } from "./client";
+
+export type StoryboardAiAction = "improve" | "rewrite" | "summarize" | "suggest";
+
+// Run an AI action on a piece of text via the server proxy. Returns the result.
+export async function storyboardAi(
+  action: StoryboardAiAction,
+  text: string,
+  context?: string
+): Promise<string> {
+  const res = await apiClient.post<{ text: string }>("/api/storyboard/ai", { action, text, context });
+  return res.text ?? "";
+}
 
 export interface ChatMessage {
-  role: 'user' | 'assistant';
+  role: "user" | "assistant";
   content: string;
 }
 
-export interface SendMessageOptions {
+// Back-compat helper for the (placeholder) AiAssistant chat widget: routes the
+// latest user turn through the server proxy. No client-side key.
+export async function sendMessage(opts: {
   messages: ChatMessage[];
-  systemPrompt?: string;
   courseContext?: unknown;
-  model?: string;
-  maxTokens?: number;
-}
-
-export interface SendMessageResult {
-  text: string;
-  tokensBefore: number;
-  tokensAfter: number;
-  tokensSaved: number;
-}
-
-const HEADROOM_BASE_URL = import.meta.env.VITE_HEADROOM_URL ?? 'http://localhost:8787';
-const ANTHROPIC_API_KEY = import.meta.env.VITE_ANTHROPIC_API_KEY ?? '';
-const DEFAULT_MODEL = 'claude-sonnet-4-6';
-
-export async function sendMessage(opts: SendMessageOptions): Promise<SendMessageResult> {
-  const { messages, systemPrompt, courseContext, model = DEFAULT_MODEL, maxTokens = 1024 } = opts;
-
-  // Build the raw messages array in Anthropic format
-  const rawMessages: Array<{ role: string; content: string }> = [];
-
-  // Inline course context into the first user turn if provided
-  if (courseContext && messages.length > 0) {
-    const [first, ...rest] = messages;
-    rawMessages.push({
-      role: 'user',
-      content: `Course context:\n${JSON.stringify(courseContext)}\n\n${first.content}`,
-    });
-    rawMessages.push(...rest);
-  } else {
-    rawMessages.push(...messages);
-  }
-
-  // Compress with Headroom before sending to Anthropic
-  const result = await compress(rawMessages, {
-    model,
-    baseUrl: HEADROOM_BASE_URL,
-    fallback: true, // pass through uncompressed if proxy is unreachable
-  });
-
-  // Build Anthropic messages API request
-  const body: Record<string, unknown> = {
-    model,
-    max_tokens: maxTokens,
-    messages: result.messages,
-  };
-
-  if (systemPrompt) {
-    body.system = systemPrompt;
-  }
-
-  const response = await fetch('https://api.anthropic.com/v1/messages', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'x-api-key': ANTHROPIC_API_KEY,
-      'anthropic-version': '2023-06-01',
-    },
-    body: JSON.stringify(body),
-  });
-
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: { message: response.statusText } }));
-    throw new Error(error?.error?.message ?? `Anthropic API error ${response.status}`);
-  }
-
-  const data = await response.json();
-  const text: string = data.content?.[0]?.text ?? '';
-
-  return {
-    text,
-    tokensBefore: result.tokensBefore,
-    tokensAfter: result.tokensAfter,
-    tokensSaved: result.tokensSaved,
-  };
+}): Promise<{ text: string }> {
+  const lastUser = [...opts.messages].reverse().find((m) => m.role === "user");
+  const context = opts.courseContext ? JSON.stringify(opts.courseContext) : undefined;
+  const text = await storyboardAi("suggest", lastUser?.content ?? "", context);
+  return { text };
 }

--- a/new-ui-source/src/api/componentMapping.ts
+++ b/new-ui-source/src/api/componentMapping.ts
@@ -1,0 +1,101 @@
+// Single source of truth for Storyboard ↔ Adapt component mapping (ADAPT-3760).
+//
+// Storyboard kind → ordered list of acceptable Adapt `_component` values. The
+// FIRST candidate that is actually installed on the tenant (present in
+// /api/componenttype) is used. There is deliberately NO "text" fallback: if a
+// kind maps to no installed plugin it is reported as unsupported so the author
+// can install it — we never silently persist the wrong component type.
+//
+// All `_component` strings are verbatim from the installed plugins' bower.json
+// (audited 2026-08): note the odd casings — `textinput` (lowercase),
+// `sentenceOrdering`, `laerdal-*`.
+
+export type StoryboardComponentKind =
+  | 'text'
+  | 'groupedContent'
+  | 'image'
+  | 'video'
+  | 'audio'
+  | 'h5p'
+  | 'laerdalForm'
+  | 'mcq'
+  | 'gmcq'
+  | 'matching'
+  | 'reorder'
+  | 'textInput'
+  | 'slider'
+  | 'hotgraphic'
+  | 'hotgrid'
+  | 'actionplan'
+  | 'instruction';
+
+// Ordered candidate `_component` values per storyboard kind.
+export const COMPONENT_CANDIDATES: Record<StoryboardComponentKind, string[]> = {
+  text: ['text', 'laerdal-text'],
+  groupedContent: ['accordion', 'laerdal-narrative', 'narrative'],
+  image: ['graphic'],
+  video: ['media', 'laerdal-media'],
+  audio: ['media', 'laerdal-media'],
+  h5p: ['laerdal-h5p', 'h5p'],
+  laerdalForm: ['laerdal-form'],
+  mcq: ['mcq'],
+  gmcq: ['gmcq'],
+  matching: ['matching'],
+  reorder: ['sentenceOrdering'],
+  textInput: ['textinput'],
+  slider: ['slider'],
+  hotgraphic: ['laerdal-hotgraphic', 'hotgraphic'],
+  hotgrid: ['hotgrid'],
+  actionplan: ['actionplan', 'laerdal-actionplan'],
+  instruction: ['text', 'laerdal-text'],
+};
+
+// Resolve a storyboard kind to an installed Adapt `_component`, or null if none
+// of its candidates are installed. `installed` is the set of `_component`
+// values returned by /api/componenttype.
+export function resolveAdaptComponent(
+  kind: string,
+  installed: Set<string>
+): string | null {
+  const candidates = COMPONENT_CANDIDATES[kind as StoryboardComponentKind];
+  if (!candidates) return null;
+  for (const c of candidates) if (installed.has(c)) return c;
+  return null;
+}
+
+// Reverse: Adapt `_component` → storyboard kind (for reload / read-back). Media
+// (`media`/`laerdal-media`) is ambiguous between image/video/audio and must be
+// disambiguated from its `_media` fields by the caller — so it maps to a
+// sentinel 'media' handled specially.
+const REVERSE: Record<string, StoryboardComponentKind | 'media'> = {
+  text: 'text',
+  'laerdal-text': 'text',
+  graphic: 'image',
+  media: 'media',
+  'laerdal-media': 'media',
+  accordion: 'groupedContent',
+  'laerdal-narrative': 'groupedContent',
+  narrative: 'groupedContent',
+  'laerdal-h5p': 'h5p',
+  h5p: 'h5p',
+  'laerdal-form': 'laerdalForm',
+  mcq: 'mcq',
+  gmcq: 'gmcq',
+  matching: 'matching',
+  sentenceOrdering: 'reorder',
+  textinput: 'textInput',
+  slider: 'slider',
+  'laerdal-hotgraphic': 'hotgraphic',
+  hotgraphic: 'hotgraphic',
+  hotgrid: 'hotgrid',
+  actionplan: 'actionplan',
+  'laerdal-actionplan': 'actionplan',
+};
+
+export function reverseKind(component?: string): StoryboardComponentKind | 'media' | null {
+  if (!component) return null;
+  return REVERSE[component] ?? null;
+}
+
+export const ASSESSMENT_KINDS = new Set<string>(['mcq', 'gmcq', 'matching', 'reorder', 'textInput', 'slider']);
+export const isAssessmentComponentKind = (k: string): boolean => ASSESSMENT_KINDS.has(k);

--- a/new-ui-source/src/api/storyboardGeneration.ts
+++ b/new-ui-source/src/api/storyboardGeneration.ts
@@ -19,14 +19,30 @@ import {
   createComponent,
   linkContentAsset,
 } from "./adaptAuthoring";
-import { isAssessmentKind, validateAssessment, type AssessmentData } from "@/types/storyboard";
+import {
+  buildAssessmentFields,
+  isAssessmentKind,
+  validateAssessment,
+  INSERT_META,
+  type AssessmentData,
+  type AssessmentKind,
+} from "@/types/storyboard";
 import {
   buildGraphicField,
+  buildImageAsMedia,
   buildMediaField,
   filenameFromLink,
+  mergeProperties,
   type ImageData,
   type MediaData,
 } from "@/components/storyboard/mediaMapping";
+import { resolveAdaptComponent } from "./componentMapping";
+
+// sbPlaceholder blocks store the human label; map it back to the storyboard
+// kind so it can be resolved to a component (or reported unsupported).
+const PLACEHOLDER_LABEL_TO_KIND: Record<string, string> = Object.fromEntries(
+  (Object.keys(INSERT_META) as (keyof typeof INSERT_META)[]).map((k) => [INSERT_META[k].label, k])
+);
 
 export interface GenerationPlan {
   topics: number;
@@ -43,36 +59,16 @@ export interface GenerationResult {
   updated: number;
   deleted: number;
   blockToContent: Record<string, string>;
+  /** Storyboard kinds that map to NO installed Adapt plugin — reported so the
+   *  author can install the plugin. These are SKIPPED during generation (never
+   *  silently persisted as Text); their content remains in the storyboard. */
+  missingTypes: string[];
 }
 
-// Neutral kind → Adapt component key (`_component`) for creation.
-const ASSESS_KEY: Record<string, string> = {
-  mcq: "mcq",
-  gmcq: "gmcq",
-  matching: "matching",
-  reorder: "textInput",
-  textInput: "textInput",
-  slider: "slider",
-};
-const PLACEHOLDER_KEY: Record<string, string> = {
-  hotgraphic: "hotgraphic",
-  hotgrid: "hotgrid",
-  h5p: "h5p",
-  actionplan: "actionplan",
-  groupedContent: "text",
-  laerdalForm: "text",
-  instruction: "text",
-};
-// Rich component-card kind → Adapt component key.
-const COMPONENT_KEY: Record<string, string> = {
-  text: "text",
-  groupedContent: "text",
-  image: "graphic",
-  video: "media",
-  audio: "media",
-  h5p: "h5p",
-  laerdalForm: "text",
-};
+// Storyboard kind → Adapt `_component` is resolved at generation time against
+// the tenant's installed component types via resolveAdaptComponent (see
+// api/componentMapping.ts) — the single source of truth. No hard-coded key maps
+// live here anymore, and there is NO silent "text" fallback for unmapped kinds.
 
 interface ContentNode {
   _id: string;
@@ -98,6 +94,15 @@ interface GenComponent {
   mediaPatch?: Record<string, unknown>;
   assetLink?: string;
   assetId?: string;
+  // Assessment components: `_items` + `_feedback` + per-kind extras.
+  assessmentPatch?: Record<string, unknown>;
+  // Original storyboard kind + parsed data, retained so we can rebuild the
+  // persistence patch once we know which Adapt component-type the generator
+  // resolves to (e.g. image can persist to graphic OR laerdal-media OR media).
+  pendingKind?: "image" | "video" | "audio" | "groupedContent";
+  pendingImage?: ImageData;
+  pendingMedia?: MediaData;
+  pendingItems?: Array<{ title?: string; body?: string; image?: string; imageAssetId?: string }>;
 }
 interface GenGroup {
   sourceBlockId?: string;
@@ -137,6 +142,36 @@ function safeParseJson<T>(value: unknown, fallback: T): T {
   } catch {
     return fallback;
   }
+}
+
+// Grouped Content items → laerdal-narrative `properties._items`. The item's
+// Grouped Content items → `_items[]` for the Accordion / Narrative components.
+// Both accordion and (laerdal-)narrative use `_items[].{title, body, _graphic:
+// {src, alt, attribution}}` (verbatim from the installed schemas). A course
+// asset persists as `_graphic.src`; otherwise `_graphic` is left empty.
+// Returns a RAW plugin-field patch (`{_items: [...]}`) — the caller nests it
+// under `properties` via mergeProperties.
+function buildGroupedItemsPatch(
+  items?: Array<{ title?: string; body?: string; image?: string }>
+): { _items: Array<Record<string, unknown>> } {
+  const list = Array.isArray(items) ? items : [];
+  return {
+    _items: list.map((it) => {
+      const rawBody = (it?.body || "").trim();
+      const body = rawBody
+        ? rawBody.startsWith("<")
+          ? rawBody
+          : `<p>${escapeHtml(rawBody)}</p>`
+        : "";
+      // `image` is the persisted link (course/assets/<file> or an external URL).
+      const imgLink = (it?.image || "").trim();
+      return {
+        title: it?.title || "",
+        body,
+        _graphic: { alt: "", src: imgLink, attribution: "" },
+      };
+    }),
+  };
 }
 
 // Parse the ordered document into the intended course tree.
@@ -209,6 +244,12 @@ function parseDocToTree(doc: unknown[], resolveExisting: (id: string) => string 
 
     if (type === "paragraph") {
       const text = inlineToText(raw.content);
+      // Blank spacer paragraphs (BlockNote inserts them around cards, and the
+      // starter/seed docs contain a trailing one) must NOT become Text
+      // components — that was the phantom "extra Text component". A Text
+      // component is created ONLY from a paragraph the author actually typed
+      // into, or the H4-heading body below.
+      if (!text.trim()) continue;
       if (pending && pending.componentKey === "text") {
         pending.body = (pending.body ? `${pending.body}\n` : "") + text;
         if (id && !id.endsWith("::body") && !pending.sourceBlockId) pending.sourceBlockId = id;
@@ -232,47 +273,59 @@ function parseDocToTree(doc: unknown[], resolveExisting: (id: string) => string 
     let comp: GenComponent | null = null;
     if (type === "sbComponent") {
       const kind = (raw.props && raw.props.kind) || "text";
-      const data = safeParseJson<{ description?: string; image?: ImageData; media?: MediaData }>(
-        raw.props && raw.props.data,
-        {}
-      );
+      const data = safeParseJson<{
+        description?: string;
+        image?: ImageData;
+        media?: MediaData;
+        items?: Array<{ title?: string; body?: string; image?: string }>;
+      }>(raw.props && raw.props.data, {});
+      // `componentKey` now holds the STORYBOARD KIND; the Adapt _component is
+      // resolved later via resolveAdaptComponent against installed types.
       comp = {
         sourceBlockId: id,
         existingId,
-        componentKey: COMPONENT_KEY[kind] || "text",
+        componentKey: kind,
         title: ((raw.props && raw.props.title) || "").trim() || "Component",
         body: data.description || "",
       };
       if (kind === "image") {
-        comp.mediaPatch = buildGraphicField(data.image);
+        comp.pendingKind = "image";
+        comp.pendingImage = data.image;
         comp.assetLink = data.image?.link;
         comp.assetId = data.image?.assetId;
       } else if (kind === "video" || kind === "audio") {
-        comp.mediaPatch = buildMediaField(kind, data.media);
+        comp.pendingKind = kind;
+        comp.pendingMedia = data.media;
         comp.assetLink = data.media?.asset?.link;
         comp.assetId = data.media?.asset?.assetId;
+      } else if (kind === "groupedContent") {
+        comp.pendingKind = "groupedContent";
+        comp.pendingItems = data.items;
       }
     } else if (type === "sbAssessment") {
-      const kind = (raw.props && raw.props.kind) || "mcq";
-      const data = safeParseJson<{ question?: string }>(raw.props && raw.props.data, {});
+      const kind = ((raw.props && raw.props.kind) || "mcq") as AssessmentKind;
+      const data = safeParseJson<AssessmentData>(raw.props && raw.props.data, { question: "" });
       comp = {
         sourceBlockId: id,
         existingId,
-        componentKey: ASSESS_KEY[kind] || "mcq",
-        title: (data.question || "").trim() || "Question",
+        componentKey: kind,
+        title: ((raw.props && raw.props.title) || data.question || "").trim() || "Question",
+        body: data.question || "",
+        assessmentPatch: buildAssessmentFields(kind, data),
       };
     } else if (type === "sbPlaceholder") {
       const label = (raw.props && (raw.props.title || raw.props.label)) || "Placeholder";
+      const rawLabel = (raw.props && raw.props.label) || "";
       comp = {
         sourceBlockId: id,
         existingId,
-        componentKey: PLACEHOLDER_KEY[(raw.props && raw.props.label) || ""] || "text",
+        componentKey: PLACEHOLDER_LABEL_TO_KIND[rawLabel] || "instruction",
         title: label,
       };
     } else if (type === "image") {
-      comp = { sourceBlockId: id, existingId, componentKey: "graphic", title: "Image" };
+      comp = { sourceBlockId: id, existingId, componentKey: "image", title: "Image" };
     } else if (type === "video" || type === "audio") {
-      comp = { sourceBlockId: id, existingId, componentKey: "media", title: type };
+      comp = { sourceBlockId: id, existingId, componentKey: type, title: type };
     }
     if (comp) {
       group!.components.push(comp);
@@ -402,11 +455,14 @@ export async function planStoryboardGeneration(
   return { topics: tree.length, sections, groups, components, willDelete, issues, warnings };
 }
 
-/** Apply the storyboard to the course: create/update/reparent/reorder/delete. */
+/** Apply the storyboard to the course: create/update/reparent/reorder/delete.
+ *  `options.skipDeletes` (used by Save) reconciles additively — it never removes
+ *  course content, only creates/updates/reorders. */
 export async function generateStoryboardCourse(
   courseId: string,
   doc: unknown[],
-  generatedContentMap: Record<string, string> = {}
+  generatedContentMap: Record<string, string> = {},
+  options: { skipDeletes?: boolean } = {}
 ): Promise<GenerationResult> {
   const [index, availableTypes] = await Promise.all([fetchCourseIndex(courseId), getAvailableComponents()]);
   const { resolve } = makeResolver(index as never, generatedContentMap);
@@ -414,7 +470,55 @@ export async function generateStoryboardCourse(
   enforceMaxComponentsPerBlock(tree);
 
   const typeByKey = new Map(availableTypes.map((t) => [t.component, t]));
-  const getType = (key: string) => typeByKey.get(key) || typeByKey.get("text") || null;
+  const installed = new Set(availableTypes.map((t) => t.component));
+  // Storyboard kinds that map to NO installed Adapt plugin. These are reported
+  // (never silently persisted as Text) so the author can install the plugin.
+  const unsupported = new Set<string>();
+
+  // Resolve a storyboard KIND to an installed Adapt component-type (the single
+  // source of truth is /api/componenttype via componentMapping). Returns null
+  // (and records the kind as unsupported) when no candidate is installed — there
+  // is NO "text" fallback.
+  const getType = (kind: string): { type: ReturnType<typeof typeByKey.get>; component: string } | null => {
+    const component = resolveAdaptComponent(kind, installed);
+    if (!component) {
+      unsupported.add(kind);
+      return null;
+    }
+    const type = typeByKey.get(component);
+    if (!type) {
+      unsupported.add(kind);
+      return null;
+    }
+    return { type, component };
+  };
+
+  // Build the plugin-property patch for a media/grouped component, shaped to the
+  // ACTUAL resolved Adapt `_component`. Called for both new and existing nodes.
+  const buildPatchFor = (c: GenComponent, component: string): void => {
+    if (!c.pendingKind) return;
+    if (c.pendingKind === "image") {
+      c.mediaPatch = component === "graphic" ? buildGraphicField(c.pendingImage) : buildImageAsMedia(c.pendingImage);
+      return;
+    }
+    if (c.pendingKind === "video" || c.pendingKind === "audio") {
+      if (component === "graphic") {
+        c.mediaPatch = buildGraphicField({
+          link: c.pendingMedia?.poster?.link || "",
+          url: c.pendingMedia?.poster?.url || "",
+          alt: "",
+        });
+      } else {
+        c.mediaPatch = buildMediaField(c.pendingKind, c.pendingMedia);
+      }
+      return;
+    }
+    if (c.pendingKind === "groupedContent") {
+      // accordion / narrative / laerdal-narrative all take `_items[]` with a
+      // `_graphic.src` image (verbatim from the installed schemas).
+      c.mediaPatch = buildGroupedItemsPatch(c.pendingItems);
+    }
+  };
 
   const resolved = new Set<string>();
   const blockToContent: Record<string, string> = {};
@@ -474,23 +578,35 @@ export async function generateStoryboardCourse(
           // Default component alignment is Right (spec: newly generated blocks
           // hold up to 2 right-aligned components).
           const layout: "right" = "right";
+          // Resolve the storyboard kind → installed Adapt component (source of
+          // truth). null = unsupported (NO text fallback).
+          const resolvedType = getType(c.componentKey);
+          // Shape the media/grouped patch to the resolved `_component`.
+          if (resolvedType) buildPatchFor(c, resolvedType.component);
           let compId = c.existingId;
           if (compId) {
+            // Existing node: always keep title/body; only write plugin fields
+            // when the kind resolves to an installed component.
             const upd: Record<string, unknown> = { title: c.title, displayTitle: c.title, _parentId: grpId, _sortOrder: cSort, _layout: layout };
             if (bodyHtml !== undefined) upd.body = bodyHtml;
-            if (c.mediaPatch) Object.assign(upd, c.mediaPatch);
+            // Plugin fields (_graphic/_media/_items/_feedback) nest under
+            // `properties` — top-level would be dropped by the content model.
+            if (resolvedType && c.mediaPatch) mergeProperties(upd, c.mediaPatch);
+            if (resolvedType && c.assessmentPatch) mergeProperties(upd, c.assessmentPatch);
             await put("component", compId, upd);
             updated += 1;
           } else {
-            const ctype = getType(c.componentKey);
-            if (!ctype) {
+            if (!resolvedType || !resolvedType.type) {
+              // Unsupported: report it (see `unsupported`), never create a Text
+              // stand-in. The content stays in the storyboard (source of truth).
               cSort += 1;
-              continue; // no installed component type and no text fallback
+              continue;
             }
-            compId = await createComponent(courseId, grpId, ctype, cSort, layout);
+            compId = await createComponent(courseId, grpId, resolvedType.type, cSort, layout);
             const upd: Record<string, unknown> = { title: c.title, displayTitle: c.title, _layout: layout };
             if (bodyHtml !== undefined) upd.body = bodyHtml;
-            if (c.mediaPatch) Object.assign(upd, c.mediaPatch);
+            if (c.mediaPatch) mergeProperties(upd, c.mediaPatch);
+            if (c.assessmentPatch) mergeProperties(upd, c.assessmentPatch);
             await put("component", compId, upd);
             created += 1;
           }
@@ -507,6 +623,20 @@ export async function generateStoryboardCourse(
               }
             }
           }
+          // Grouped Content / Accordion item images each need their own
+          // courseasset link (multiple images per component).
+          if (c.pendingKind === "groupedContent" && Array.isArray(c.pendingItems)) {
+            for (const it of c.pendingItems) {
+              const fn = filenameFromLink(it?.image);
+              if (fn && it?.imageAssetId) {
+                try {
+                  await linkContentAsset(courseId, "component", compId, grpId, fn, it.imageAssetId);
+                } catch {
+                  /* best-effort */
+                }
+              }
+            }
+          }
           cSort += 1;
         }
       }
@@ -515,21 +645,24 @@ export async function generateStoryboardCourse(
 
   // Delete pages/articles/blocks/components removed from the storyboard
   // (leaves first; page deletes cascade — 404s on already-removed are ignored).
-  const pages = index.contentObjects.filter((c) => c._type === "page");
-  const removals: Array<[string, string]> = [
-    ...index.components.filter((c) => !resolved.has(c._id)).map((c) => ["component", c._id] as [string, string]),
-    ...index.blocks.filter((b) => !resolved.has(b._id)).map((b) => ["block", b._id] as [string, string]),
-    ...index.articles.filter((a) => !resolved.has(a._id)).map((a) => ["article", a._id] as [string, string]),
-    ...pages.filter((p) => !resolved.has(p._id)).map((p) => ["contentobject", p._id] as [string, string]),
-  ];
-  for (const [type, id] of removals) {
-    try {
-      await apiClient.delete(`/api/content/${type}/${id}`);
-      deleted += 1;
-    } catch {
-      /* already removed by a cascade */
+  // Skipped for additive Save reconciliation.
+  if (!options.skipDeletes) {
+    const pages = index.contentObjects.filter((c) => c._type === "page");
+    const removals: Array<[string, string]> = [
+      ...index.components.filter((c) => !resolved.has(c._id)).map((c) => ["component", c._id] as [string, string]),
+      ...index.blocks.filter((b) => !resolved.has(b._id)).map((b) => ["block", b._id] as [string, string]),
+      ...index.articles.filter((a) => !resolved.has(a._id)).map((a) => ["article", a._id] as [string, string]),
+      ...pages.filter((p) => !resolved.has(p._id)).map((p) => ["contentobject", p._id] as [string, string]),
+    ];
+    for (const [type, id] of removals) {
+      try {
+        await apiClient.delete(`/api/content/${type}/${id}`);
+        deleted += 1;
+      } catch {
+        /* already removed by a cascade */
+      }
     }
   }
 
-  return { created, updated, deleted, blockToContent };
+  return { created, updated, deleted, blockToContent, missingTypes: [...unsupported] };
 }

--- a/new-ui-source/src/api/storyboardGeneration.ts
+++ b/new-ui-source/src/api/storyboardGeneration.ts
@@ -1,0 +1,535 @@
+// Course generation engine (ADAPT-3760, Phase 4 / AC4 / AC11).
+//
+// Reconciles a storyboard document into real Adapt course content. The document
+// is parsed into an intended Topic→Section→Content Group→Component tree (H1–H4,
+// with implicit parents for edge cases such as content-before-H1 or skipped
+// levels), diffed against the live course by block-id ↔ content-id, and applied
+// via the existing content CRUD: existing nodes are updated + reparented +
+// reordered, new nodes created, removed nodes deleted. Idempotent — the caller
+// re-seeds the document from the course afterwards so every block carries a
+// content id, so a second run is a no-op.
+
+import { apiClient } from "./client";
+import {
+  getContentByCourse,
+  getAvailableComponents,
+  createTopic,
+  createArticle,
+  createBlock,
+  createComponent,
+  linkContentAsset,
+} from "./adaptAuthoring";
+import { isAssessmentKind, validateAssessment, type AssessmentData } from "@/types/storyboard";
+import {
+  buildGraphicField,
+  buildMediaField,
+  filenameFromLink,
+  type ImageData,
+  type MediaData,
+} from "@/components/storyboard/mediaMapping";
+
+export interface GenerationPlan {
+  topics: number;
+  sections: number;
+  groups: number;
+  components: number;
+  willDelete: number;
+  issues: string[]; // blocking
+  warnings: string[]; // non-blocking (e.g. incomplete assessments)
+}
+
+export interface GenerationResult {
+  created: number;
+  updated: number;
+  deleted: number;
+  blockToContent: Record<string, string>;
+}
+
+// Neutral kind → Adapt component key (`_component`) for creation.
+const ASSESS_KEY: Record<string, string> = {
+  mcq: "mcq",
+  gmcq: "gmcq",
+  matching: "matching",
+  reorder: "textInput",
+  textInput: "textInput",
+  slider: "slider",
+};
+const PLACEHOLDER_KEY: Record<string, string> = {
+  hotgraphic: "hotgraphic",
+  hotgrid: "hotgrid",
+  h5p: "h5p",
+  actionplan: "actionplan",
+  groupedContent: "text",
+  laerdalForm: "text",
+  instruction: "text",
+};
+// Rich component-card kind → Adapt component key.
+const COMPONENT_KEY: Record<string, string> = {
+  text: "text",
+  groupedContent: "text",
+  image: "graphic",
+  video: "media",
+  audio: "media",
+  h5p: "h5p",
+  laerdalForm: "text",
+};
+
+interface ContentNode {
+  _id: string;
+  _type?: string;
+  _parentId?: string;
+}
+
+interface GenBlock {
+  id?: string;
+  type?: string;
+  props?: { level?: number; kind?: string; data?: string; title?: string; label?: string };
+  content?: unknown;
+}
+
+interface GenComponent {
+  sourceBlockId?: string;
+  existingId?: string;
+  componentKey: string;
+  title: string;
+  body?: string;
+  // Media components: the `_graphic`/`_media` patch + the chosen asset, so
+  // generation writes the asset fields and links the courseasset for publish.
+  mediaPatch?: Record<string, unknown>;
+  assetLink?: string;
+  assetId?: string;
+}
+interface GenGroup {
+  sourceBlockId?: string;
+  existingId?: string;
+  title: string;
+  components: GenComponent[];
+}
+interface GenSection {
+  sourceBlockId?: string;
+  existingId?: string;
+  title: string;
+  groups: GenGroup[];
+}
+interface GenTopic {
+  sourceBlockId?: string;
+  existingId?: string;
+  title: string;
+  sections: GenSection[];
+}
+
+function inlineToText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((n) => (n && typeof (n as { text?: unknown }).text === "string" ? (n as { text: string }).text : ""))
+    .join("");
+}
+
+function escapeHtml(s: string): string {
+  return (s || "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function safeParseJson<T>(value: unknown, fallback: T): T {
+  if (typeof value !== "string") return (value as T) ?? fallback;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+// Parse the ordered document into the intended course tree.
+function parseDocToTree(doc: unknown[], resolveExisting: (id: string) => string | undefined): GenTopic[] {
+  const topics: GenTopic[] = [];
+  let topic: GenTopic | null = null;
+  let section: GenSection | null = null;
+  let group: GenGroup | null = null;
+  let pending: GenComponent | null = null;
+
+  const ensureTopic = () => {
+    if (!topic) {
+      topic = { title: "Untitled Topic", sections: [] };
+      topics.push(topic);
+      section = null;
+      group = null;
+    }
+    return topic;
+  };
+  const ensureSection = () => {
+    ensureTopic();
+    if (!section) {
+      section = { title: "Untitled Section", groups: [] };
+      topic!.sections.push(section);
+      group = null;
+    }
+    return section;
+  };
+  const ensureGroup = () => {
+    ensureSection();
+    if (!group) {
+      group = { title: "Untitled Content Group", components: [] };
+      section!.groups.push(group);
+    }
+    return group;
+  };
+
+  for (const raw of doc as GenBlock[]) {
+    const id = typeof raw.id === "string" ? raw.id : undefined;
+    const type = raw.type;
+    const existingId = id ? resolveExisting(id) : undefined;
+
+    if (type === "heading") {
+      const level = (raw.props && raw.props.level) || 1;
+      const title = inlineToText(raw.content).trim() || "Untitled";
+      if (level <= 1) {
+        topic = { sourceBlockId: id, existingId, title, sections: [] };
+        topics.push(topic);
+        section = null;
+        group = null;
+        pending = null;
+      } else if (level === 2) {
+        ensureTopic();
+        section = { sourceBlockId: id, existingId, title, groups: [] };
+        topic!.sections.push(section);
+        group = null;
+        pending = null;
+      } else if (level === 3) {
+        ensureSection();
+        group = { sourceBlockId: id, existingId, title, components: [] };
+        section!.groups.push(group);
+        pending = null;
+      } else {
+        ensureGroup();
+        pending = { sourceBlockId: id, existingId, componentKey: "text", title, body: "" };
+        group!.components.push(pending);
+      }
+      continue;
+    }
+
+    if (type === "paragraph") {
+      const text = inlineToText(raw.content);
+      if (pending && pending.componentKey === "text") {
+        pending.body = (pending.body ? `${pending.body}\n` : "") + text;
+        if (id && !id.endsWith("::body") && !pending.sourceBlockId) pending.sourceBlockId = id;
+        continue;
+      }
+      ensureGroup();
+      const comp: GenComponent = {
+        sourceBlockId: id,
+        existingId,
+        componentKey: "text",
+        title: text.slice(0, 40) || "Text",
+        body: text,
+      };
+      group!.components.push(comp);
+      pending = comp;
+      continue;
+    }
+
+    // Non-text content → its own component.
+    ensureGroup();
+    let comp: GenComponent | null = null;
+    if (type === "sbComponent") {
+      const kind = (raw.props && raw.props.kind) || "text";
+      const data = safeParseJson<{ description?: string; image?: ImageData; media?: MediaData }>(
+        raw.props && raw.props.data,
+        {}
+      );
+      comp = {
+        sourceBlockId: id,
+        existingId,
+        componentKey: COMPONENT_KEY[kind] || "text",
+        title: ((raw.props && raw.props.title) || "").trim() || "Component",
+        body: data.description || "",
+      };
+      if (kind === "image") {
+        comp.mediaPatch = buildGraphicField(data.image);
+        comp.assetLink = data.image?.link;
+        comp.assetId = data.image?.assetId;
+      } else if (kind === "video" || kind === "audio") {
+        comp.mediaPatch = buildMediaField(kind, data.media);
+        comp.assetLink = data.media?.asset?.link;
+        comp.assetId = data.media?.asset?.assetId;
+      }
+    } else if (type === "sbAssessment") {
+      const kind = (raw.props && raw.props.kind) || "mcq";
+      const data = safeParseJson<{ question?: string }>(raw.props && raw.props.data, {});
+      comp = {
+        sourceBlockId: id,
+        existingId,
+        componentKey: ASSESS_KEY[kind] || "mcq",
+        title: (data.question || "").trim() || "Question",
+      };
+    } else if (type === "sbPlaceholder") {
+      const label = (raw.props && (raw.props.title || raw.props.label)) || "Placeholder";
+      comp = {
+        sourceBlockId: id,
+        existingId,
+        componentKey: PLACEHOLDER_KEY[(raw.props && raw.props.label) || ""] || "text",
+        title: label,
+      };
+    } else if (type === "image") {
+      comp = { sourceBlockId: id, existingId, componentKey: "graphic", title: "Image" };
+    } else if (type === "video" || type === "audio") {
+      comp = { sourceBlockId: id, existingId, componentKey: "media", title: type };
+    }
+    if (comp) {
+      group!.components.push(comp);
+      pending = null;
+    }
+  }
+
+  return topics;
+}
+
+// Adapt blocks hold at most 2 components. If the author put more components
+// under one Content Group (H3), split them across additional blocks — each a
+// Content Group Heading carrying the same title — keeping ≤2 per block. The
+// first chunk keeps the original group (its source/existing id); overflow
+// blocks are synthetic (recreated each generation until re-seeded from course).
+const MAX_COMPONENTS_PER_BLOCK = 2;
+
+function enforceMaxComponentsPerBlock(topics: GenTopic[]): void {
+  for (const t of topics) {
+    for (const s of t.sections) {
+      const out: GenGroup[] = [];
+      for (const g of s.groups) {
+        if (g.components.length <= MAX_COMPONENTS_PER_BLOCK) {
+          out.push(g);
+          continue;
+        }
+        const rest = g.components.slice(MAX_COMPONENTS_PER_BLOCK);
+        g.components = g.components.slice(0, MAX_COMPONENTS_PER_BLOCK);
+        out.push(g);
+        for (let i = 0; i < rest.length; i += MAX_COMPONENTS_PER_BLOCK) {
+          out.push({
+            // Continuation Content Group Heading — same title so it stays
+            // associated with the same group of components.
+            title: g.title,
+            components: rest.slice(i, i + MAX_COMPONENTS_PER_BLOCK),
+          });
+        }
+      }
+      s.groups = out;
+    }
+  }
+}
+
+async function fetchCourseIndex(courseId: string) {
+  const [contentObjects, articles, blocks, components] = await Promise.all([
+    getContentByCourse("contentobject", courseId),
+    getContentByCourse("article", courseId),
+    getContentByCourse("block", courseId),
+    getContentByCourse("component", courseId),
+  ]);
+  return {
+    contentObjects: contentObjects as unknown as ContentNode[],
+    articles: articles as unknown as ContentNode[],
+    blocks: blocks as unknown as ContentNode[],
+    components: components as unknown as ContentNode[],
+  };
+}
+
+function makeResolver(index: { [k: string]: ContentNode[] }, map: Record<string, string>) {
+  const existingIds = new Set<string>(
+    [...index.contentObjects, ...index.articles, ...index.blocks, ...index.components].map((n) => n._id)
+  );
+  return {
+    existingIds,
+    resolve: (blockId: string) =>
+      existingIds.has(blockId)
+        ? blockId
+        : map[blockId] && existingIds.has(map[blockId])
+          ? map[blockId]
+          : undefined,
+  };
+}
+
+/** Validate + summarise what generation would do — shown before applying. */
+export async function planStoryboardGeneration(
+  courseId: string,
+  doc: unknown[],
+  generatedContentMap: Record<string, string> = {}
+): Promise<GenerationPlan> {
+  const index = await fetchCourseIndex(courseId);
+  const { resolve } = makeResolver(index as never, generatedContentMap);
+  const tree = parseDocToTree(doc, resolve);
+  enforceMaxComponentsPerBlock(tree);
+
+  let sections = 0;
+  let groups = 0;
+  let components = 0;
+  const referenced = new Set<string>();
+  for (const t of tree) {
+    if (t.existingId) referenced.add(t.existingId);
+    for (const s of t.sections) {
+      sections += 1;
+      if (s.existingId) referenced.add(s.existingId);
+      for (const g of s.groups) {
+        groups += 1;
+        if (g.existingId) referenced.add(g.existingId);
+        for (const c of g.components) {
+          components += 1;
+          if (c.existingId) referenced.add(c.existingId);
+        }
+      }
+    }
+  }
+
+  const pages = index.contentObjects.filter((c) => c._type === "page");
+  const willDelete =
+    pages.filter((p) => !referenced.has(p._id)).length +
+    index.articles.filter((a) => !referenced.has(a._id)).length +
+    index.blocks.filter((b) => !referenced.has(b._id)).length +
+    index.components.filter((c) => !referenced.has(c._id)).length;
+
+  const issues: string[] = [];
+  const warnings: string[] = [];
+  if (tree.length === 0) issues.push("Add at least one H1 heading (a Topic) before generating.");
+
+  for (const raw of doc as GenBlock[]) {
+    if (raw.type === "sbAssessment") {
+      const kind = (raw.props && raw.props.kind) || "";
+      const data = safeParseJson<AssessmentData>(raw.props && raw.props.data, { question: "" });
+      if (isAssessmentKind(kind)) {
+        const problems = validateAssessment(kind, data);
+        if (problems.length) warnings.push(`Assessment "${data.question || kind}": ${problems[0]}`);
+      }
+    }
+  }
+
+  return { topics: tree.length, sections, groups, components, willDelete, issues, warnings };
+}
+
+/** Apply the storyboard to the course: create/update/reparent/reorder/delete. */
+export async function generateStoryboardCourse(
+  courseId: string,
+  doc: unknown[],
+  generatedContentMap: Record<string, string> = {}
+): Promise<GenerationResult> {
+  const [index, availableTypes] = await Promise.all([fetchCourseIndex(courseId), getAvailableComponents()]);
+  const { resolve } = makeResolver(index as never, generatedContentMap);
+  const tree = parseDocToTree(doc, resolve);
+  enforceMaxComponentsPerBlock(tree);
+
+  const typeByKey = new Map(availableTypes.map((t) => [t.component, t]));
+  const getType = (key: string) => typeByKey.get(key) || typeByKey.get("text") || null;
+
+  const resolved = new Set<string>();
+  const blockToContent: Record<string, string> = {};
+  let created = 0;
+  let updated = 0;
+  let deleted = 0;
+
+  const put = (type: string, id: string, body: Record<string, unknown>) =>
+    apiClient.put(`/api/content/${type}/${id}`, body);
+  const bodyHtmlOf = (c: GenComponent) => (c.body && c.body.trim() ? `<p>${escapeHtml(c.body.trim())}</p>` : undefined);
+
+  let tSort = 1;
+  for (const t of tree) {
+    let topicId = t.existingId;
+    if (topicId) {
+      await put("contentobject", topicId, { title: t.title, displayTitle: t.title, _parentId: courseId, _sortOrder: tSort });
+      updated += 1;
+    } else {
+      topicId = await createTopic(courseId, courseId, t.title, tSort);
+      created += 1;
+    }
+    resolved.add(topicId);
+    if (t.sourceBlockId) blockToContent[t.sourceBlockId] = topicId;
+    tSort += 1;
+
+    let sSort = 1;
+    for (const s of t.sections) {
+      let secId = s.existingId;
+      if (secId) {
+        await put("article", secId, { title: s.title, displayTitle: s.title, _parentId: topicId, _sortOrder: sSort });
+        updated += 1;
+      } else {
+        secId = await createArticle(courseId, topicId, s.title, sSort);
+        created += 1;
+      }
+      resolved.add(secId);
+      if (s.sourceBlockId) blockToContent[s.sourceBlockId] = secId;
+      sSort += 1;
+
+      let gSort = 1;
+      for (const g of s.groups) {
+        let grpId = g.existingId;
+        if (grpId) {
+          await put("block", grpId, { title: g.title, displayTitle: g.title, _parentId: secId, _sortOrder: gSort });
+          updated += 1;
+        } else {
+          grpId = await createBlock(courseId, secId, g.title, gSort);
+          created += 1;
+        }
+        resolved.add(grpId);
+        if (g.sourceBlockId) blockToContent[g.sourceBlockId] = grpId;
+        gSort += 1;
+
+        let cSort = 1;
+        for (const c of g.components) {
+          const bodyHtml = bodyHtmlOf(c);
+          // Default component alignment is Right (spec: newly generated blocks
+          // hold up to 2 right-aligned components).
+          const layout: "right" = "right";
+          let compId = c.existingId;
+          if (compId) {
+            const upd: Record<string, unknown> = { title: c.title, displayTitle: c.title, _parentId: grpId, _sortOrder: cSort, _layout: layout };
+            if (bodyHtml !== undefined) upd.body = bodyHtml;
+            if (c.mediaPatch) Object.assign(upd, c.mediaPatch);
+            await put("component", compId, upd);
+            updated += 1;
+          } else {
+            const ctype = getType(c.componentKey);
+            if (!ctype) {
+              cSort += 1;
+              continue; // no installed component type and no text fallback
+            }
+            compId = await createComponent(courseId, grpId, ctype, cSort, layout);
+            const upd: Record<string, unknown> = { title: c.title, displayTitle: c.title, _layout: layout };
+            if (bodyHtml !== undefined) upd.body = bodyHtml;
+            if (c.mediaPatch) Object.assign(upd, c.mediaPatch);
+            await put("component", compId, upd);
+            created += 1;
+          }
+          resolved.add(compId);
+          if (c.sourceBlockId) blockToContent[c.sourceBlockId] = compId;
+          // Link the chosen DAM asset to this component so publish resolves it.
+          if (c.assetId && c.assetLink) {
+            const fn = filenameFromLink(c.assetLink);
+            if (fn) {
+              try {
+                await linkContentAsset(courseId, "component", compId, grpId, fn, c.assetId);
+              } catch {
+                /* non-fatal: publish asset-copy link is best-effort */
+              }
+            }
+          }
+          cSort += 1;
+        }
+      }
+    }
+  }
+
+  // Delete pages/articles/blocks/components removed from the storyboard
+  // (leaves first; page deletes cascade — 404s on already-removed are ignored).
+  const pages = index.contentObjects.filter((c) => c._type === "page");
+  const removals: Array<[string, string]> = [
+    ...index.components.filter((c) => !resolved.has(c._id)).map((c) => ["component", c._id] as [string, string]),
+    ...index.blocks.filter((b) => !resolved.has(b._id)).map((b) => ["block", b._id] as [string, string]),
+    ...index.articles.filter((a) => !resolved.has(a._id)).map((a) => ["article", a._id] as [string, string]),
+    ...pages.filter((p) => !resolved.has(p._id)).map((p) => ["contentobject", p._id] as [string, string]),
+  ];
+  for (const [type, id] of removals) {
+    try {
+      await apiClient.delete(`/api/content/${type}/${id}`);
+      deleted += 1;
+    } catch {
+      /* already removed by a cascade */
+    }
+  }
+
+  return { created, updated, deleted, blockToContent };
+}

--- a/new-ui-source/src/components/common/AssetPickerModal.tsx
+++ b/new-ui-source/src/components/common/AssetPickerModal.tsx
@@ -1,11 +1,19 @@
 import { useState, useEffect, useRef } from "react";
-import { queryImages, uploadAsset } from "@/api/adaptAuthoring";
-import type { Asset } from "@/api/adaptAuthoring";
+import { queryAssets, uploadAsset } from "@/api/adaptAuthoring";
+import type { Asset, AssetKind } from "@/api/adaptAuthoring";
 
 interface AssetPickerModalProps {
   onSelect: (asset: { id: string; url: string; assetLink: string }) => void;
   onClose: () => void;
+  // Which media kind to browse/upload. Defaults to image (cover-image picker).
+  assetType?: AssetKind;
 }
+
+const KIND_TEXT: Record<AssetKind, { heading: string; confirm: string; noun: string; accept: string }> = {
+  image: { heading: "Select an Image", confirm: "Select Image", noun: "image", accept: "image/*" },
+  audio: { heading: "Select an Audio File", confirm: "Select Audio", noun: "audio file", accept: "audio/*" },
+  video: { heading: "Select a Video", confirm: "Select Video", noun: "video", accept: "video/*" },
+};
 
 function toAssetLink(asset: Asset): string {
   const path = (asset.path || "").trim().replace(/^\/+/, "");
@@ -14,7 +22,8 @@ function toAssetLink(asset: Asset): string {
   return `/api/asset/serve/${asset._id}`;
 }
 
-export default function AssetPickerModal({ onSelect, onClose }: AssetPickerModalProps) {
+export default function AssetPickerModal({ onSelect, onClose, assetType = "image" }: AssetPickerModalProps) {
+  const t = KIND_TEXT[assetType];
   const [assets, setAssets]         = useState<Asset[]>([]);
   const [loading, setLoading]       = useState(true);
   const [search, setSearch]         = useState("");
@@ -26,7 +35,7 @@ export default function AssetPickerModal({ onSelect, onClose }: AssetPickerModal
 
   async function loadAssets(term?: string) {
     setLoading(true);
-    const results = await queryImages(term);
+    const results = await queryAssets(assetType, term);
     setAssets(results);
     setLoading(false);
   }
@@ -98,7 +107,7 @@ export default function AssetPickerModal({ onSelect, onClose }: AssetPickerModal
       <div className="bg-white rounded-2xl shadow-2xl w-full max-w-2xl flex flex-col overflow-hidden" style={{ maxHeight: "85vh" }}>
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-[#e5e7eb] shrink-0">
-          <h2 className="font-semibold text-[#111827] text-base">Select Cover Image</h2>
+          <h2 className="font-semibold text-[#111827] text-base">{t.heading}</h2>
           <button type="button" onClick={onClose} className="p-1.5 rounded-lg hover:bg-[#f3f4f6] text-[#6b7280] transition-colors" aria-label="Close">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
@@ -116,7 +125,7 @@ export default function AssetPickerModal({ onSelect, onClose }: AssetPickerModal
               type="text"
               value={search}
               onChange={handleSearchChange}
-              placeholder="Search images..."
+              placeholder={`Search ${t.noun}s...`}
               className="w-full pl-9 pr-3 py-2 text-sm border border-[#d1d5db] rounded-lg focus:outline-none focus:ring-2 focus:ring-[#2d6fa8] focus:border-transparent text-[#111827]"
             />
           </div>
@@ -137,7 +146,7 @@ export default function AssetPickerModal({ onSelect, onClose }: AssetPickerModal
             )}
             {uploading ? "Uploading…" : "Upload New"}
           </button>
-          <input ref={fileInputRef} type="file" accept="image/*" className="hidden" title="Upload image" onChange={handleUpload} />
+          <input ref={fileInputRef} type="file" accept={t.accept} className="hidden" title={`Upload ${t.noun}`} onChange={handleUpload} />
         </div>
 
         {uploadError && (
@@ -151,14 +160,14 @@ export default function AssetPickerModal({ onSelect, onClose }: AssetPickerModal
               <svg className="animate-spin mr-2" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M21 12a9 9 0 1 1-6.219-8.56" />
               </svg>
-              Loading images…
+              Loading {t.noun}s…
             </div>
           ) : assets.length === 0 ? (
             <div className="flex flex-col items-center justify-center h-48 text-sm text-[#6b7280] gap-2">
               <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="#d1d5db" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
                 <rect x="3" y="3" width="18" height="18" rx="2" ry="2" /><circle cx="8.5" cy="8.5" r="1.5" /><polyline points="21 15 16 10 5 21" />
               </svg>
-              <p>No images found. Upload one to get started.</p>
+              <p>No {t.noun}s found. Upload one to get started.</p>
             </div>
           ) : (
             <div className="grid grid-cols-3 gap-3 sm:grid-cols-4">
@@ -176,15 +185,32 @@ export default function AssetPickerModal({ onSelect, onClose }: AssetPickerModal
                         : "border-transparent hover:border-[#93c5fd]"
                     }`}
                   >
-                    <img
-                      src={thumbUrl}
-                      alt={asset.title ?? asset.filename ?? "Image"}
-                      className="w-full h-full object-cover"
-                      onError={(e) => {
-                        // Fall back to the full serve URL if thumb is unavailable
-                        (e.currentTarget as HTMLImageElement).src = `/api/asset/serve/${asset._id}`;
-                      }}
-                    />
+                    {assetType === "image" ? (
+                      <img
+                        src={thumbUrl}
+                        alt={asset.title ?? asset.filename ?? "Image"}
+                        className="w-full h-full object-cover"
+                        onError={(e) => {
+                          // Fall back to the full serve URL if thumb is unavailable
+                          (e.currentTarget as HTMLImageElement).src = `/api/asset/serve/${asset._id}`;
+                        }}
+                      />
+                    ) : (
+                      <div className="flex h-full w-full flex-col items-center justify-center gap-1 px-2 text-[#6b7280]">
+                        <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                          {assetType === "audio" ? (
+                            <>
+                              <path d="M9 18V5l12-2v13" /><circle cx="6" cy="18" r="3" /><circle cx="18" cy="16" r="3" />
+                            </>
+                          ) : (
+                            <>
+                              <polygon points="23 7 16 12 23 17 23 7" /><rect x="1" y="5" width="15" height="14" rx="2" ry="2" />
+                            </>
+                          )}
+                        </svg>
+                        <span className="line-clamp-2 text-center text-[10px] leading-tight">{asset.title ?? asset.filename}</span>
+                      </div>
+                    )}
                     {isSelected && (
                       <div className="absolute inset-0 bg-[#2d6fa8]/20 flex items-center justify-center">
                         <div className="w-6 h-6 rounded-full bg-[#2d6fa8] flex items-center justify-center">
@@ -209,7 +235,7 @@ export default function AssetPickerModal({ onSelect, onClose }: AssetPickerModal
         {/* Footer */}
         <div className="flex items-center justify-between px-5 py-4 border-t border-[#e5e7eb] shrink-0">
           <p className="text-xs text-[#9ca3af]">
-            {selected ? "1 image selected" : `${assets.length} image${assets.length !== 1 ? "s" : ""}`}
+            {selected ? `1 ${t.noun} selected` : `${assets.length} ${t.noun}${assets.length !== 1 ? "s" : ""}`}
           </p>
           <div className="flex items-center gap-2.5">
             <button type="button" onClick={onClose} className="px-4 py-2 text-sm font-medium text-[#374151] bg-white border border-[#d1d5db] rounded-lg hover:bg-[#f9fafb] transition-colors">
@@ -221,7 +247,7 @@ export default function AssetPickerModal({ onSelect, onClose }: AssetPickerModal
               disabled={!selected}
               className="px-4 py-2 text-sm font-medium text-white bg-[#2d6fa8] hover:bg-[#245c8f] disabled:opacity-40 disabled:cursor-not-allowed rounded-lg transition-colors"
             >
-              Select Image
+              {t.confirm}
             </button>
           </div>
         </div>

--- a/new-ui-source/src/components/storyboard/AddContentMenu.tsx
+++ b/new-ui-source/src/components/storyboard/AddContentMenu.tsx
@@ -25,6 +25,7 @@ import {
   Target,
   Grid3x3,
   ListTodo,
+  Rows3,
   ChevronDown,
 } from 'lucide-react';
 import type { StoryboardInsertKind } from '@/types/storyboard';
@@ -71,6 +72,9 @@ const GROUPS: MenuGroup[] = [
   {
     label: 'Interactive',
     items: [
+      // Accordion has no distinct storyboard block yet — map it to Grouped
+      // Content (heading + body rows), per product decision.
+      { kind: 'groupedContent', label: 'Accordion', Icon: Rows3 },
       { kind: 'hotgraphic', label: 'Hot Graphic', Icon: Target },
       { kind: 'hotgrid', label: 'Hot Grid', Icon: Grid3x3 },
       { kind: 'actionplan', label: 'Laerdal Action Plan', Icon: ListTodo },
@@ -80,6 +84,9 @@ const GROUPS: MenuGroup[] = [
 
 const MENU_WIDTH = 260;
 
+// Add Content lists ONLY course-content components. AI and Comment are authoring
+// ACTIONS on a component card (see componentBlock/assessmentBlock headers), not
+// content components — they are intentionally NOT in this menu.
 export default function AddContentMenu({ onInsert }: { onInsert: (kind: StoryboardInsertKind) => void }) {
   const [open, setOpen] = useState(false);
   const [pos, setPos] = useState<{ left: number; top: number; maxHeight: number }>({ left: 0, top: 0, maxHeight: 360 });
@@ -104,14 +111,20 @@ export default function AddContentMenu({ onInsert }: { onInsert: (kind: Storyboa
       setOpen(false);
     };
     const close = () => setOpen(false);
+    // Close on scroll of an ANCESTOR (fixed menu would otherwise detach), but
+    // NOT when scrolling inside the menu's own scroll area — that capture-phase
+    // event was closing the menu on the first wheel tick ("scroll not working").
+    const onScroll = (e: Event) => {
+      if (menuRef.current?.contains(e.target as Node)) return;
+      setOpen(false);
+    };
     document.addEventListener('mousedown', onDown);
     window.addEventListener('resize', close);
-    // Close on scroll of any ancestor (fixed menu would otherwise detach).
-    window.addEventListener('scroll', close, true);
+    window.addEventListener('scroll', onScroll, true);
     return () => {
       document.removeEventListener('mousedown', onDown);
       window.removeEventListener('resize', close);
-      window.removeEventListener('scroll', close, true);
+      window.removeEventListener('scroll', onScroll, true);
     };
   }, [open]);
 
@@ -146,7 +159,7 @@ export default function AddContentMenu({ onInsert }: { onInsert: (kind: Storyboa
                 </div>
                 {group.items.map(({ kind, label, Icon }) => (
                   <button
-                    key={kind}
+                    key={label}
                     type="button"
                     onClick={() => choose(kind)}
                     className="flex w-full items-center gap-2.5 px-3 py-1.5 text-sm hover:bg-muted"

--- a/new-ui-source/src/components/storyboard/AddContentMenu.tsx
+++ b/new-ui-source/src/components/storyboard/AddContentMenu.tsx
@@ -1,0 +1,165 @@
+// "Add Content" dropdown (spec AC3/AC5/AC6). Categorised insert menu matching
+// the reference: Text & Visual / Media / Survey / Assessment / Interactive.
+//
+// Rendered in a portal with fixed positioning so it can never be clipped or
+// mis-stacked by the editor's scroll/overflow/backdrop-blur ancestors (that was
+// the "breaking" dropdown). Height is capped to the viewport and scrolls.
+
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  Plus,
+  Type,
+  Layers,
+  Image as ImageIcon,
+  Video,
+  AudioLines,
+  Puzzle,
+  ClipboardList,
+  ListChecks,
+  Images,
+  Shuffle,
+  ArrowDownUp,
+  TextCursorInput,
+  SlidersHorizontal,
+  Target,
+  Grid3x3,
+  ListTodo,
+  ChevronDown,
+} from 'lucide-react';
+import type { StoryboardInsertKind } from '@/types/storyboard';
+
+interface MenuItem {
+  kind: StoryboardInsertKind;
+  label: string;
+  Icon: typeof Type;
+}
+interface MenuGroup {
+  label: string;
+  items: MenuItem[];
+}
+
+const GROUPS: MenuGroup[] = [
+  {
+    label: 'Text & Visual',
+    items: [
+      { kind: 'text', label: 'Text', Icon: Type },
+      { kind: 'groupedContent', label: 'Grouped Content', Icon: Layers },
+      { kind: 'image', label: 'Image', Icon: ImageIcon },
+    ],
+  },
+  {
+    label: 'Media',
+    items: [
+      { kind: 'video', label: 'Video', Icon: Video },
+      { kind: 'audio', label: 'Audio', Icon: AudioLines },
+      { kind: 'h5p', label: 'H5P', Icon: Puzzle },
+    ],
+  },
+  { label: 'Survey', items: [{ kind: 'laerdalForm', label: 'Laerdal Form', Icon: ClipboardList }] },
+  {
+    label: 'Assessment',
+    items: [
+      { kind: 'mcq', label: 'MCQ', Icon: ListChecks },
+      { kind: 'gmcq', label: 'Graphic MCQ', Icon: Images },
+      { kind: 'matching', label: 'Matching', Icon: Shuffle },
+      { kind: 'reorder', label: 'Sentence Reordering', Icon: ArrowDownUp },
+      { kind: 'textInput', label: 'Text Input', Icon: TextCursorInput },
+      { kind: 'slider', label: 'Slider', Icon: SlidersHorizontal },
+    ],
+  },
+  {
+    label: 'Interactive',
+    items: [
+      { kind: 'hotgraphic', label: 'Hot Graphic', Icon: Target },
+      { kind: 'hotgrid', label: 'Hot Grid', Icon: Grid3x3 },
+      { kind: 'actionplan', label: 'Laerdal Action Plan', Icon: ListTodo },
+    ],
+  },
+];
+
+const MENU_WIDTH = 260;
+
+export default function AddContentMenu({ onInsert }: { onInsert: (kind: StoryboardInsertKind) => void }) {
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<{ left: number; top: number; maxHeight: number }>({ left: 0, top: 0, maxHeight: 360 });
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (!open || !btnRef.current) return;
+    const r = btnRef.current.getBoundingClientRect();
+    const margin = 8;
+    const left = Math.min(r.left, window.innerWidth - MENU_WIDTH - margin);
+    const top = r.bottom + 4;
+    const maxHeight = Math.max(160, window.innerHeight - top - margin);
+    setPos({ left: Math.max(margin, left), top, maxHeight });
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      const t = e.target as Node;
+      if (btnRef.current?.contains(t) || menuRef.current?.contains(t)) return;
+      setOpen(false);
+    };
+    const close = () => setOpen(false);
+    document.addEventListener('mousedown', onDown);
+    window.addEventListener('resize', close);
+    // Close on scroll of any ancestor (fixed menu would otherwise detach).
+    window.addEventListener('scroll', close, true);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      window.removeEventListener('resize', close);
+      window.removeEventListener('scroll', close, true);
+    };
+  }, [open]);
+
+  const choose = (kind: StoryboardInsertKind) => {
+    onInsert(kind);
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <button
+        ref={btnRef}
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-secondary"
+      >
+        <Plus className="h-3.5 w-3.5" /> Add Content
+        <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+      </button>
+
+      {open &&
+        createPortal(
+          <div
+            ref={menuRef}
+            style={{ position: 'fixed', left: pos.left, top: pos.top, width: MENU_WIDTH, maxHeight: pos.maxHeight }}
+            className="z-[1000] overflow-y-auto rounded-md border bg-background py-1 shadow-lg"
+          >
+            {GROUPS.map((group) => (
+              <div key={group.label}>
+                <div className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                  {group.label}
+                </div>
+                {group.items.map(({ kind, label, Icon }) => (
+                  <button
+                    key={kind}
+                    type="button"
+                    onClick={() => choose(kind)}
+                    className="flex w-full items-center gap-2.5 px-3 py-1.5 text-sm hover:bg-muted"
+                  >
+                    <Icon className="h-4 w-4 text-muted-foreground" />
+                    {label}
+                  </button>
+                ))}
+              </div>
+            ))}
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}

--- a/new-ui-source/src/components/storyboard/AiAssistPopover.tsx
+++ b/new-ui-source/src/components/storyboard/AiAssistPopover.tsx
@@ -1,0 +1,233 @@
+// "Samaritan Assistance" AI popover for the storyboard (ADAPT-3760).
+//
+// Functional parity with the legacy CKEditor "Samaritan Assistance" tool
+// (frontend/src/modules/scaffold/backboneFormsOverrides.js): four fixed actions
+// (Improve wording / Shorten / Prolong / Correct spelling) + a free-text prompt
+// ("Ask Samaritan to edit or generate from scratch…"), then Insert / Replace /
+// Try again / Dismiss. All AI runs through the server proxy (samaritanAssist →
+// POST /api/storyboard/ai); no key is ever in the browser.
+//
+// Insert  → creates a NEW storyboard Text component (persists on Save).
+// Replace → replaces the active block's content.
+
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { HeartHandshake, HelpCircle, X, RefreshCw, Send } from 'lucide-react';
+import { samaritanAssist, type SamaritanAction } from '@/api/ai';
+
+interface QuickAction {
+  label: string;
+  action: SamaritanAction;
+}
+const QUICK_ACTIONS: QuickAction[] = [
+  { label: 'Improve wording', action: 'improve' },
+  { label: 'Shorten', action: 'shorten' },
+  { label: 'Prolong', action: 'lengthen' },
+  { label: 'Correct spelling', action: 'spelling' },
+];
+
+export default function AiAssistPopover({
+  initialText = '',
+  courseContext,
+  onInsert,
+  onReplace,
+  onClose,
+}: {
+  initialText?: string;
+  courseContext?: string;
+  onInsert: (text: string) => void;
+  onReplace: (text: string) => void;
+  onClose: () => void;
+}) {
+  const [content, setContent] = useState(initialText);
+  const [prompt, setPrompt] = useState('');
+  const [result, setResult] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Remember the last run so "Try again" can re-issue it.
+  const lastRun = useRef<{ action: SamaritanAction; instruction?: string } | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const run = async (action: SamaritanAction, instruction?: string) => {
+    // Fixed actions operate on the content box; guide instead of 400ing when empty.
+    if (action !== 'custom' && !content.trim()) {
+      setError('Add or paste some content above first, or type an instruction below to generate from scratch.');
+      return;
+    }
+    lastRun.current = { action, instruction };
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const out = (
+        await samaritanAssist(action, content, { instruction, context: courseContext })
+      ).trim();
+      if (!out) {
+        setError('Samaritan returned no content. Try again or refine your prompt.');
+      } else {
+        setResult(out);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'AI request failed. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const submitPrompt = () => {
+    const instruction = prompt.trim();
+    if (!instruction && !content.trim()) {
+      setError('Enter a prompt or some content first.');
+      return;
+    }
+    void run('custom', instruction);
+  };
+
+  const tryAgain = () => {
+    if (lastRun.current) void run(lastRun.current.action, lastRun.current.instruction);
+  };
+
+  const canApply = !!result && !loading;
+
+  return createPortal(
+    <div className="fixed inset-0 z-[1100] flex items-start justify-center bg-black/20 pt-24" onMouseDown={onClose}>
+      <div
+        className="w-[min(92vw,520px)] rounded-xl border bg-background p-5 shadow-2xl"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="mb-4 flex items-center gap-2">
+          <HeartHandshake className="h-5 w-5" style={{ color: 'var(--samaritan)' }} />
+          <h3 className="text-base font-semibold">Samaritan Assistance</h3>
+          <div className="ml-auto flex items-center gap-1 text-muted-foreground">
+            <span title="Improve, shorten, prolong or spell-check the content, or type your own instruction.">
+              <HelpCircle className="h-4 w-4" />
+            </span>
+            <button type="button" onClick={onClose} title="Close" className="rounded p-1 hover:bg-muted">
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+
+        {/* Content / result */}
+        {result ? (
+          <div
+            className="mb-3 max-h-56 overflow-y-auto whitespace-pre-wrap rounded-lg border p-3 text-sm"
+            style={{ background: 'linear-gradient(90deg, #FBDBFB 0%, #E0E6FA 100%)' }}
+          >
+            {result}
+          </div>
+        ) : (
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder="Add your content here..."
+            rows={4}
+            disabled={loading}
+            className="mb-3 w-full resize-y rounded-lg bg-muted/60 p-3 text-sm outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+          />
+        )}
+
+        {loading && (
+          <div className="mb-3 text-sm text-muted-foreground">Loading response from Samaritan…</div>
+        )}
+        {error && <div className="mb-3 text-sm text-red-600">{error}</div>}
+
+        {/* Quick actions */}
+        {!result && (
+          <div className="mb-3 flex flex-wrap gap-2">
+            {QUICK_ACTIONS.map((a) => (
+              <button
+                key={a.action}
+                type="button"
+                disabled={loading}
+                onClick={() => void run(a.action)}
+                className="rounded-full border px-3 py-1.5 text-sm hover:bg-secondary disabled:opacity-50"
+              >
+                {a.label}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Free-text prompt */}
+        <div className="mb-4 flex items-center gap-2 rounded-full border px-3 py-1.5">
+          <input
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') submitPrompt();
+            }}
+            placeholder="Ask Samaritan to edit or generate from scratch..."
+            disabled={loading}
+            className="min-w-0 flex-1 bg-transparent text-sm outline-none disabled:opacity-60"
+          />
+          <button
+            type="button"
+            onClick={submitPrompt}
+            disabled={loading}
+            title="Send"
+            className="rounded-full p-1 text-muted-foreground hover:bg-muted disabled:opacity-50"
+          >
+            <Send className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Footer: Try again · Dismiss · Replace · Insert */}
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={tryAgain}
+            disabled={!lastRun.current || loading}
+            title="Try again"
+            className="rounded-md p-2 text-muted-foreground hover:bg-muted disabled:opacity-40"
+          >
+            <RefreshCw className="h-4 w-4" />
+          </button>
+          <div className="ml-auto flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border px-3 py-1.5 text-sm hover:bg-secondary"
+            >
+              Dismiss
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                if (result) onReplace(result);
+                onClose();
+              }}
+              disabled={!canApply}
+              title="Replace the current block's content"
+              className="rounded-md border px-3 py-1.5 text-sm hover:bg-secondary disabled:opacity-40"
+            >
+              Replace
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                if (result) onInsert(result);
+                onClose();
+              }}
+              disabled={!canApply}
+              title="Insert the generated content"
+              className="rounded-md px-4 py-1.5 text-sm font-semibold text-primary-foreground hover:opacity-90 disabled:opacity-40"
+              style={{ background: 'var(--primary)' }}
+            >
+              Insert
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/new-ui-source/src/components/storyboard/AiGuidance.tsx
+++ b/new-ui-source/src/components/storyboard/AiGuidance.tsx
@@ -1,0 +1,45 @@
+// "AI guidance" box in the Contents panel (spec AC7).
+//
+// Heuristic, client-side instructional-design hints derived from the document
+// summary — mirrors the reference design's suggestions. No LLM call yet; the
+// server-side AI proxy (Phase 6) will deepen these.
+
+import { Sparkles } from 'lucide-react';
+import type { StoryboardSummary } from '@/types/storyboard';
+
+function buildHints(summary: StoryboardSummary): string[] {
+  const hints: string[] = [];
+  const nonText = summary.contentItems - summary.textBlocks;
+  if (summary.contentItems > 0 && nonText === 0) {
+    hints.push('Mostly plain text. Suggested: Grouped Content or an Image.');
+  }
+  if (!summary.hasAssessment) {
+    hints.push('No knowledge check yet. Suggested: add an MCQ.');
+  }
+  if (!summary.hasVisual) {
+    hints.push('No visuals yet. Suggested: add an Image or Video.');
+  }
+  if (summary.topics === 0) {
+    hints.push('No topics yet. Add an H1 heading to start a topic.');
+  }
+  return hints;
+}
+
+export default function AiGuidance({ summary }: { summary: StoryboardSummary }) {
+  const hints = buildHints(summary);
+  if (hints.length === 0) return null;
+
+  return (
+    <div className="rounded-lg border border-samaritan/30 bg-samaritan/5 p-3">
+      <div className="mb-2 flex items-center gap-1.5 text-sm font-semibold" style={{ color: 'var(--samaritan)' }}>
+        <Sparkles className="h-4 w-4" />
+        AI guidance
+      </div>
+      <ul className="space-y-1.5 text-[13px] leading-snug text-muted-foreground">
+        {hints.map((h, i) => (
+          <li key={i}>• {h}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/new-ui-source/src/components/storyboard/BlockNoteStoryboardEditor.tsx
+++ b/new-ui-source/src/components/storyboard/BlockNoteStoryboardEditor.tsx
@@ -1,0 +1,316 @@
+// BlockNote implementation of the storyboard editor.
+//
+// The ONLY files that know about BlockNote are this one, schema.ts and
+// blocks/*. Everything else depends on the engine-agnostic
+// `StoryboardEditorHandle` from `@/types/storyboard`.
+
+import { forwardRef, useCallback, useEffect, useImperativeHandle } from 'react';
+import { filterSuggestionItems, type PartialBlock } from '@blocknote/core';
+import { BlockNoteView } from '@blocknote/mantine';
+import {
+  blockTypeSelectItems,
+  FormattingToolbar,
+  FormattingToolbarController,
+  getDefaultReactSlashMenuItems,
+  SuggestionMenuController,
+  useCreateBlockNote,
+  type DefaultReactSuggestionItem,
+} from '@blocknote/react';
+
+import '@blocknote/core/fonts/inter.css';
+import '@blocknote/mantine/style.css';
+
+import {
+  adaptTypeForLevel,
+  defaultAssessmentData,
+  INSERT_META,
+  isAssessmentKind,
+  type PlaceholderCategory,
+  type StoryboardDocument,
+  type StoryboardEditorHandle,
+  type StoryboardEditorProps,
+  type StoryboardHeading,
+  type StoryboardInsertKind,
+  type StoryboardSummary,
+} from '@/types/storyboard';
+import { storyboardSchema } from './schema';
+import { makeComponentBlock, type ComponentKind } from './blocks/componentBlock';
+
+// "Add Content" kinds that map to the rich component card (sbComponent).
+const COMPONENT_CARD_KINDS = new Set<StoryboardInsertKind>([
+  'text',
+  'groupedContent',
+  'image',
+  'video',
+  'audio',
+  'h5p',
+  'laerdalForm',
+]);
+
+const DEFAULT_CONTENT: PartialBlock[] = [
+  { type: 'heading', props: { level: 1 }, content: 'New Page Title' },
+  { type: 'heading', props: { level: 2 }, content: 'New Section Title' },
+  { type: 'paragraph', content: '' },
+];
+
+const ASSET_TYPES = new Set(['image', 'video', 'audio']);
+
+function inlineText(content: unknown): string {
+  if (!Array.isArray(content)) return '';
+  return content
+    .map((node) =>
+      node && typeof node === 'object' && typeof (node as { text?: unknown }).text === 'string'
+        ? (node as { text: string }).text
+        : ''
+    )
+    .join('');
+}
+
+// Neutral insert kind → a concrete BlockNote block. Returns a loose shape; the
+// call site casts to the editor's block type.
+//   heading                     → heading block
+//   text/grouped/image/…/form   → rich component card (sbComponent, AC3)
+//   mcq/gmcq/…                   → assessment card (sbAssessment, AC5)
+//   hotgraphic/…/instruction    → metadata placeholder (sbPlaceholder, AC6)
+function blockForKind(kind: StoryboardInsertKind, level = 1): Record<string, unknown> {
+  if (kind === 'heading') return { type: 'heading', props: { level }, content: 'New heading' };
+  if (COMPONENT_CARD_KINDS.has(kind)) return makeComponentBlock(kind as ComponentKind);
+
+  const meta = INSERT_META[kind as keyof typeof INSERT_META];
+  if (isAssessmentKind(kind)) {
+    return {
+      type: 'sbAssessment',
+      props: { kind, title: '', adaptComponent: meta.adaptComponent, data: JSON.stringify(defaultAssessmentData(kind)) },
+    };
+  }
+  return {
+    type: 'sbPlaceholder',
+    props: { label: meta.label, category: meta.category, adaptComponent: meta.adaptComponent },
+  };
+}
+
+function BlockNoteStoryboardEditorImpl(
+  { initialDocument, editable = true, onChange, onActiveBlock }: StoryboardEditorProps,
+  ref: React.Ref<StoryboardEditorHandle>
+) {
+  const editor = useCreateBlockNote({
+    schema: storyboardSchema,
+    initialContent:
+      Array.isArray(initialDocument) && initialDocument.length
+        ? (initialDocument as PartialBlock[])
+        : DEFAULT_CONTENT,
+  });
+
+  const getHeadings = useCallback((): StoryboardHeading[] => {
+    return editor.document
+      .filter((block) => block.type === 'heading')
+      .map((block) => {
+        const level = Number((block.props as { level?: number }).level ?? 1);
+        return {
+          id: block.id,
+          level,
+          text: inlineText(block.content),
+          adaptType: adaptTypeForLevel(level),
+        };
+      });
+  }, [editor]);
+
+  const getSummary = useCallback((): StoryboardSummary => {
+    let topics = 0;
+    let sections = 0;
+    let contentItems = 0;
+    let assets = 0;
+    let textBlocks = 0;
+    let hasVisual = false;
+    let hasAssessment = false;
+
+    for (const block of editor.document) {
+      if (block.type === 'heading') {
+        const level = Number((block.props as { level?: number }).level ?? 1);
+        if (level === 1) topics += 1;
+        else if (level === 2) sections += 1;
+        continue;
+      }
+      if (ASSET_TYPES.has(block.type)) {
+        assets += 1;
+        contentItems += 1;
+        if (block.type === 'image' || block.type === 'video') hasVisual = true;
+        continue;
+      }
+      if (block.type === 'sbAssessment') {
+        contentItems += 1;
+        hasAssessment = true;
+        continue;
+      }
+      if (block.type === 'sbComponent') {
+        contentItems += 1;
+        const k = (block.props as { kind?: string }).kind;
+        if (k === 'image' || k === 'video') hasVisual = true;
+        if (k === 'image' || k === 'video' || k === 'audio') assets += 1;
+        continue;
+      }
+      if (block.type === 'sbPlaceholder') {
+        contentItems += 1;
+        if ((block.props as { category?: PlaceholderCategory }).category === 'assessment') {
+          hasAssessment = true;
+        }
+        continue;
+      }
+      if (block.type === 'paragraph' && inlineText(block.content).trim()) {
+        textBlocks += 1;
+        contentItems += 1;
+      }
+    }
+
+    return { topics, sections, contentItems, assets, textBlocks, hasVisual, hasAssessment };
+  }, [editor]);
+
+  const insert = useCallback(
+    (kind: StoryboardInsertKind, opts?: { level?: number }) => {
+      const ref = editor.getTextCursorPosition().block;
+      const inserted = editor.insertBlocks(
+        [blockForKind(kind, opts?.level) as never],
+        ref,
+        'after'
+      );
+      const first = inserted[0];
+      if (first) editor.setTextCursorPosition(first, 'end');
+    },
+    [editor]
+  );
+
+  const focusBlock = useCallback(
+    (blockId: string) => {
+      try {
+        editor.setTextCursorPosition(blockId, 'start');
+      } catch {
+        /* block removed — ignore */
+      }
+      document.querySelector(`[data-id="${blockId}"]`)?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+      });
+    },
+    [editor]
+  );
+
+  useImperativeHandle(
+    ref,
+    (): StoryboardEditorHandle => ({
+      getDocument: () => editor.document as StoryboardDocument,
+      setDocument: (doc) => {
+        const blocks = (Array.isArray(doc) ? doc : []) as PartialBlock[];
+        if (blocks.length) editor.replaceBlocks(editor.document, blocks);
+      },
+      getHeadings,
+      getSummary,
+      insert,
+      getActiveText: () => {
+        try {
+          return inlineText(editor.getTextCursorPosition().block.content);
+        } catch {
+          return '';
+        }
+      },
+      replaceActive: (text: string) => {
+        try {
+          editor.updateBlock(editor.getTextCursorPosition().block, { content: text });
+        } catch {
+          /* no active block */
+        }
+      },
+      insertAfterActive: (text: string) => {
+        try {
+          editor.insertBlocks(
+            [{ type: 'paragraph', content: text } as never],
+            editor.getTextCursorPosition().block,
+            'after'
+          );
+        } catch {
+          /* no active block */
+        }
+      },
+      focusBlock,
+    }),
+    [editor, getHeadings, getSummary, insert, focusBlock]
+  );
+
+  useEffect(() => {
+    if (!onChange) return;
+    return editor.onChange(() => onChange(editor.document as StoryboardDocument, getHeadings()));
+  }, [editor, onChange, getHeadings]);
+
+  // Report the cursor's block so the Review panel can anchor comments (AC9).
+  useEffect(() => {
+    if (!onActiveBlock) return;
+    return editor.onSelectionChange(() => {
+      try {
+        const block = editor.getTextCursorPosition().block;
+        onActiveBlock({ id: block.id, text: inlineText(block.content), type: block.type });
+      } catch {
+        onActiveBlock(null);
+      }
+    });
+  }, [editor, onActiveBlock]);
+
+  // Formatting-tab restriction (spec AC4): the block-type dropdown offers only
+  // H4 among headings — H1–H3 (structure) come from the "Add Heading" control.
+  const isHeadingTitle = (title: string) => /^\s*(toggle\s+)?heading\b/i.test(title);
+
+  const getSlashItems = (query: string): DefaultReactSuggestionItem[] => {
+    const defaults = getDefaultReactSlashMenuItems(editor);
+    const headingIcon = defaults.find((i) => isHeadingTitle(i.title))?.icon;
+    // Keep every non-heading default, then add a single "Heading 4" item.
+    const nonHeadings = defaults.filter((i) => !isHeadingTitle(i.title));
+    const h4: DefaultReactSuggestionItem = {
+      title: 'Heading 4',
+      group: 'Headings',
+      icon: headingIcon,
+      subtext: 'Component-level heading',
+      onItemClick: () => {
+        const block = editor.getTextCursorPosition().block;
+        editor.updateBlock(block, { type: 'heading', props: { level: 4 } } as never);
+      },
+    };
+    const custom: DefaultReactSuggestionItem[] = (
+      Object.keys(INSERT_META) as (keyof typeof INSERT_META)[]
+    ).map((kind) => ({
+      title: INSERT_META[kind].label,
+      group: INSERT_META[kind].category,
+      onItemClick: () => insert(kind),
+    }));
+    return filterSuggestionItems([...nonHeadings, h4, ...custom], query);
+  };
+
+  // Block-type dropdown in the formatting toolbar: paragraph + lists + H4 only.
+  const formattingBlockTypes = () => {
+    const defaults = blockTypeSelectItems(editor.dictionary);
+    const headingIcon = defaults.find((i) => i.type === 'heading')?.icon;
+    const h4 = {
+      name: 'Heading 4',
+      type: 'heading',
+      props: { level: 4 },
+      icon: headingIcon ?? (() => null),
+      isSelected: (block: { type: string; props?: { level?: number } }) =>
+        block.type === 'heading' && block.props?.level === 4,
+    };
+    return [
+      ...defaults.filter((i) => i.type !== 'heading' && !/toggle\s+heading/i.test(i.name)),
+      h4,
+    ] as typeof defaults;
+  };
+
+  return (
+    <BlockNoteView editor={editor} editable={editable} theme="light" slashMenu={false} formattingToolbar={false}>
+      <FormattingToolbarController
+        formattingToolbar={() => <FormattingToolbar blockTypeSelectItems={formattingBlockTypes()} />}
+      />
+      <SuggestionMenuController
+        triggerCharacter="/"
+        getItems={async (query) => getSlashItems(query)}
+      />
+    </BlockNoteView>
+  );
+}
+
+export const BlockNoteStoryboardEditor = forwardRef(BlockNoteStoryboardEditorImpl);

--- a/new-ui-source/src/components/storyboard/BlockNoteStoryboardEditor.tsx
+++ b/new-ui-source/src/components/storyboard/BlockNoteStoryboardEditor.tsx
@@ -34,7 +34,7 @@ import {
   type StoryboardSummary,
 } from '@/types/storyboard';
 import { storyboardSchema } from './schema';
-import { makeComponentBlock, type ComponentKind } from './blocks/componentBlock';
+import { makeComponentBlock, isComponentKind, type ComponentKind } from './blocks/componentBlock';
 
 // "Add Content" kinds that map to the rich component card (sbComponent).
 const COMPONENT_CARD_KINDS = new Set<StoryboardInsertKind>([
@@ -179,6 +179,24 @@ function BlockNoteStoryboardEditorImpl(
     [editor]
   );
 
+  // Insert a pre-populated component card (AI Assistance → Insert). Only
+  // component-card kinds are supported; others no-op. Returns the new block id.
+  const insertComponent = useCallback(
+    (kind: StoryboardInsertKind, opts?: { title?: string; data?: Record<string, unknown> }): string | null => {
+      if (!isComponentKind(kind)) return null;
+      const ref = editor.getTextCursorPosition().block;
+      const inserted = editor.insertBlocks(
+        [makeComponentBlock(kind as ComponentKind, opts) as never],
+        ref,
+        'after'
+      );
+      const first = inserted[0];
+      if (first) editor.setTextCursorPosition(first, 'end');
+      return first?.id ?? null;
+    },
+    [editor]
+  );
+
   const focusBlock = useCallback(
     (blockId: string) => {
       try {
@@ -205,6 +223,7 @@ function BlockNoteStoryboardEditorImpl(
       getHeadings,
       getSummary,
       insert,
+      insertComponent,
       getActiveText: () => {
         try {
           return inlineText(editor.getTextCursorPosition().block.content);
@@ -232,7 +251,7 @@ function BlockNoteStoryboardEditorImpl(
       },
       focusBlock,
     }),
-    [editor, getHeadings, getSummary, insert, focusBlock]
+    [editor, getHeadings, getSummary, insert, insertComponent, focusBlock]
   );
 
   useEffect(() => {

--- a/new-ui-source/src/components/storyboard/CommentPopover.tsx
+++ b/new-ui-source/src/components/storyboard/CommentPopover.tsx
@@ -1,0 +1,218 @@
+// Block-anchored comment popover for the storyboard (ADAPT-3760).
+//
+// Opened from Add Content → Comment. Reuses the existing storyboardcomment
+// backend via useStoryboardReview (add / resolve / delete / reply) — comments
+// anchor to (_storyboardId, blockId) exactly like the Review Center. This is a
+// second entry point to the SAME data, not a new store. There is no @mention
+// backend, so "@ Mention" is a lightweight affordance that inserts "@".
+
+import { useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { X, Check, RotateCcw, Trash2, CornerDownRight, AtSign } from 'lucide-react';
+import type { StoryboardComment } from '@/api/adaptAuthoring';
+
+function timeAgo(iso?: string): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return isNaN(d.getTime()) ? '' : d.toLocaleString();
+}
+
+export default function CommentPopover({
+  blockId,
+  blockLabel,
+  courseId,
+  comments,
+  loading,
+  onAdd,
+  onResolve,
+  onDelete,
+  onClose,
+}: {
+  blockId: string | null;
+  blockLabel: string;
+  courseId?: string;
+  comments: StoryboardComment[];
+  loading?: boolean;
+  onAdd: (blockId: string, body: string, courseId?: string, parentId?: string) => Promise<void>;
+  onResolve: (commentId: string, resolved: boolean) => Promise<void>;
+  onDelete: (commentId: string) => Promise<void>;
+  onClose: () => void;
+}) {
+  const [body, setBody] = useState('');
+  const [reply, setReply] = useState<{ id: string; text: string } | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  // Only comments on the active block, threaded (top-level + replies).
+  const { tops, repliesOf } = useMemo(() => {
+    const forBlock = comments.filter((c) => c.blockId === blockId);
+    const t = forBlock.filter((c) => !c._parentCommentId);
+    const repliesOf = (id: string) =>
+      forBlock
+        .filter((c) => c._parentCommentId === id)
+        .sort((a, b) => (a.createdAt || '').localeCompare(b.createdAt || ''));
+    return { tops: t, repliesOf };
+  }, [comments, blockId]);
+
+  const post = async () => {
+    if (!blockId || !body.trim() || busy) return;
+    setBusy(true);
+    try {
+      await onAdd(blockId, body, courseId);
+      setBody('');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const sendReply = async (parentId: string) => {
+    if (!blockId || !reply?.text.trim() || busy) return;
+    setBusy(true);
+    try {
+      await onAdd(blockId, reply.text, courseId, parentId);
+      setReply(null);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return createPortal(
+    <div className="fixed inset-0 z-[1100] flex items-start justify-center bg-black/20 pt-24" onMouseDown={onClose}>
+      <div
+        className="w-[min(92vw,420px)] rounded-xl border bg-background p-4 shadow-2xl"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="mb-3 flex items-center gap-2">
+          <span className="truncate text-[11px] font-semibold uppercase tracking-wide text-muted-foreground" title={blockLabel}>
+            {blockLabel}
+          </span>
+          <button type="button" onClick={onClose} title="Close" className="ml-auto rounded p-1 hover:bg-muted">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {!blockId ? (
+          <p className="mb-3 text-sm text-muted-foreground">
+            Place the cursor in a block to comment on it.
+          </p>
+        ) : (
+          <div className="mb-3 max-h-64 space-y-2 overflow-y-auto">
+            {tops.length === 0 && !loading && (
+              <p className="text-sm text-muted-foreground">No comments yet.</p>
+            )}
+            {tops.map((top) => (
+              <div key={top._id} className="rounded-lg border p-2.5">
+                <div className="mb-1 flex items-center gap-1">
+                  <span className="text-[11px] text-muted-foreground">{timeAgo(top.createdAt)}</span>
+                  <div className="ml-auto flex items-center gap-1">
+                    <button
+                      type="button"
+                      title={top.resolved ? 'Reopen' : 'Resolve'}
+                      onClick={() => onResolve(top._id, !top.resolved)}
+                      className="grid h-6 w-6 place-items-center rounded text-muted-foreground hover:bg-muted"
+                    >
+                      {top.resolved ? <RotateCcw className="h-3.5 w-3.5" /> : <Check className="h-3.5 w-3.5" />}
+                    </button>
+                    <button
+                      type="button"
+                      title="Delete"
+                      onClick={() => onDelete(top._id)}
+                      className="grid h-6 w-6 place-items-center rounded text-muted-foreground hover:bg-muted"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </div>
+                <p className="whitespace-pre-wrap text-sm text-foreground">{top.body}</p>
+
+                {repliesOf(top._id).map((r) => (
+                  <div key={r._id} className="mt-2 flex gap-1.5 border-l-2 border-border pl-2">
+                    <CornerDownRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                    <div className="min-w-0">
+                      <p className="whitespace-pre-wrap text-sm text-foreground">{r.body}</p>
+                      <p className="mt-0.5 text-[11px] text-muted-foreground">{timeAgo(r.createdAt)}</p>
+                    </div>
+                  </div>
+                ))}
+
+                {!top.resolved &&
+                  (reply?.id === top._id ? (
+                    <form
+                      className="mt-2 flex gap-1.5"
+                      onSubmit={(e) => {
+                        e.preventDefault();
+                        void sendReply(top._id);
+                      }}
+                    >
+                      <input
+                        autoFocus
+                        value={reply.text}
+                        onChange={(e) => setReply({ id: top._id, text: e.target.value })}
+                        placeholder="Reply…"
+                        className="flex-1 rounded border border-border bg-background px-2 py-1 text-sm outline-none focus:border-primary"
+                      />
+                      <button type="submit" disabled={!reply.text.trim() || busy} className="text-xs font-medium text-primary disabled:opacity-40">
+                        Reply
+                      </button>
+                    </form>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setReply({ id: top._id, text: '' })}
+                      className="mt-1.5 text-xs font-medium text-primary"
+                    >
+                      Reply
+                    </button>
+                  ))}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Compose */}
+        {blockId && (
+          <>
+            <textarea
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) void post();
+              }}
+              placeholder="Comment... use @ to mention"
+              rows={2}
+              className="mb-2 w-full resize-y rounded-lg bg-muted/60 p-2.5 text-sm outline-none focus:ring-2 focus:ring-ring"
+            />
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setBody((b) => `${b}@`)}
+                title="Mention someone"
+                className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-sm hover:bg-secondary"
+              >
+                <AtSign className="h-3.5 w-3.5" /> Mention
+              </button>
+              <button
+                type="button"
+                onClick={() => void post()}
+                disabled={!body.trim() || busy}
+                className="ml-auto rounded-md px-4 py-1.5 text-sm font-semibold text-primary-foreground hover:opacity-90 disabled:opacity-40"
+                style={{ background: 'var(--primary)' }}
+              >
+                Post
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/new-ui-source/src/components/storyboard/ContentsPanel.tsx
+++ b/new-ui-source/src/components/storyboard/ContentsPanel.tsx
@@ -19,8 +19,8 @@ export default function ContentsPanel({
   onCollapse?: () => void;
 }) {
   return (
-    <div className="flex h-full flex-col">
-      <div className="flex items-center justify-between border-b px-3 py-2.5">
+    <div className="flex h-full flex-col bg-muted/20">
+      <div className="flex items-center justify-between border-b bg-muted/40 px-3 py-2.5 backdrop-blur">
         <div className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
           <ListTree className="h-4 w-4" />
           Contents

--- a/new-ui-source/src/components/storyboard/ContentsPanel.tsx
+++ b/new-ui-source/src/components/storyboard/ContentsPanel.tsx
@@ -1,0 +1,49 @@
+// Left panel — "CONTENTS": TOC tree (top) + AI guidance (bottom). Spec AC1/AC7.
+
+import { ListTree, ChevronDown } from 'lucide-react';
+import type { StoryboardHeading, StoryboardSummary } from '@/types/storyboard';
+import TableOfContents from './TableOfContents';
+import AiGuidance from './AiGuidance';
+
+export default function ContentsPanel({
+  headings,
+  summary,
+  activeId,
+  onNavigate,
+  onCollapse,
+}: {
+  headings: StoryboardHeading[];
+  summary: StoryboardSummary;
+  activeId?: string;
+  onNavigate: (id: string) => void;
+  onCollapse?: () => void;
+}) {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b px-3 py-2.5">
+        <div className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+          <ListTree className="h-4 w-4" />
+          Contents
+        </div>
+        {onCollapse && (
+          <button
+            type="button"
+            aria-label="Collapse contents"
+            onClick={onCollapse}
+            className="grid h-6 w-6 place-items-center rounded text-muted-foreground hover:bg-muted"
+          >
+            <ChevronDown className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      <nav className="flex-1 overflow-y-auto p-2">
+        <TableOfContents headings={headings} activeId={activeId} onNavigate={onNavigate} />
+      </nav>
+
+      <div className="border-t p-3">
+        <AiGuidance summary={summary} />
+      </div>
+    </div>
+  );
+}

--- a/new-ui-source/src/components/storyboard/DocumentToolbar.tsx
+++ b/new-ui-source/src/components/storyboard/DocumentToolbar.tsx
@@ -3,7 +3,7 @@
 //   Row 2: Enrich with AI
 // (References and JSON state are hidden for Phase 1.)
 
-import { FileText, Info, Sparkles } from 'lucide-react';
+import { FileText, Info, RefreshCw, Sparkles } from 'lucide-react';
 import type { StoryboardInsertKind } from '@/types/storyboard';
 import AddContentMenu from './AddContentMenu';
 import HeadingMenu from './HeadingMenu';
@@ -12,13 +12,15 @@ export default function DocumentToolbar({
   onInsert,
   onInsertHeading,
   onEnrichAI,
+  onRefresh,
 }: {
   onInsert: (kind: StoryboardInsertKind) => void;
   onInsertHeading: (level: number) => void;
   onEnrichAI: () => void;
+  onRefresh?: () => void;
 }) {
   return (
-    <div className="border-b bg-background/95 px-6 py-2 backdrop-blur">
+    <div className="border-b bg-background/95 px-8 py-2 backdrop-blur">
       <div className="flex flex-wrap items-center gap-2">
         <div className="mr-1 flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
           <FileText className="h-4 w-4" /> Storyboard Document
@@ -32,6 +34,16 @@ export default function DocumentToolbar({
         >
           <Info className="h-3.5 w-3.5" /> Add Instruction
         </button>
+        {onRefresh && (
+          <button
+            type="button"
+            onClick={onRefresh}
+            title="Reload the storyboard from the latest course content"
+            className="ml-auto inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-secondary"
+          >
+            <RefreshCw className="h-3.5 w-3.5" /> Refresh from course
+          </button>
+        )}
       </div>
 
       <div className="mt-1.5 flex flex-wrap items-center gap-2">

--- a/new-ui-source/src/components/storyboard/DocumentToolbar.tsx
+++ b/new-ui-source/src/components/storyboard/DocumentToolbar.tsx
@@ -1,0 +1,53 @@
+// Center toolbar above the canvas (spec AC2/AC3/AC7).
+//   Row 1: STORYBOARD DOCUMENT · Add Heading · Add Content · Add Instruction
+//   Row 2: Enrich with AI
+// (References and JSON state are hidden for Phase 1.)
+
+import { FileText, Info, Sparkles } from 'lucide-react';
+import type { StoryboardInsertKind } from '@/types/storyboard';
+import AddContentMenu from './AddContentMenu';
+import HeadingMenu from './HeadingMenu';
+
+export default function DocumentToolbar({
+  onInsert,
+  onInsertHeading,
+  onEnrichAI,
+}: {
+  onInsert: (kind: StoryboardInsertKind) => void;
+  onInsertHeading: (level: number) => void;
+  onEnrichAI: () => void;
+}) {
+  return (
+    <div className="border-b bg-background/95 px-6 py-2 backdrop-blur">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="mr-1 flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          <FileText className="h-4 w-4" /> Storyboard Document
+        </div>
+        <HeadingMenu onSelect={onInsertHeading} />
+        <AddContentMenu onInsert={onInsert} />
+        <button
+          type="button"
+          onClick={() => onInsert('instruction')}
+          className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-secondary"
+        >
+          <Info className="h-3.5 w-3.5" /> Add Instruction
+        </button>
+      </div>
+
+      <div className="mt-1.5 flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={onEnrichAI}
+          className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:opacity-90"
+          style={{
+            borderColor: 'color-mix(in oklab, var(--samaritan) 30%, transparent)',
+            background: 'color-mix(in oklab, var(--samaritan) 8%, transparent)',
+            color: 'var(--samaritan)',
+          }}
+        >
+          <Sparkles className="h-3.5 w-3.5" /> Enrich with AI
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/new-ui-source/src/components/storyboard/GenerateDialog.tsx
+++ b/new-ui-source/src/components/storyboard/GenerateDialog.tsx
@@ -1,0 +1,132 @@
+// Generate-course dialog (ADAPT-3760, Phase 4 / AC11).
+// Shows a pre-generation validation report + plan summary, then the result.
+
+import { Loader2, X, AlertTriangle, CheckCircle2, ArrowRight } from 'lucide-react';
+import type { GenerationPlan, GenerationResult } from '@/api/storyboardGeneration';
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border p-2 text-center">
+      <div className="text-lg font-semibold text-foreground">{value}</div>
+      <div className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</div>
+    </div>
+  );
+}
+
+export default function GenerateDialog({
+  plan,
+  running,
+  result,
+  onConfirm,
+  onClose,
+}: {
+  plan: GenerationPlan | null;
+  running: boolean;
+  result: GenerationResult | null;
+  onConfirm: () => void;
+  onClose: () => void;
+}) {
+  const blocked = !!plan && plan.issues.length > 0;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-6" onClick={running ? undefined : onClose}>
+      <div className="w-full max-w-lg rounded-lg border bg-background shadow-lg" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between border-b px-4 py-2.5">
+          <h3 className="text-sm font-semibold">Generate Course</h3>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            disabled={running}
+            className="grid h-7 w-7 place-items-center rounded text-muted-foreground hover:bg-muted disabled:opacity-40"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="p-4">
+          {result ? (
+            <div className="text-center">
+              <CheckCircle2 className="mx-auto mb-2 h-8 w-8 text-[#166534]" />
+              <p className="text-sm font-medium text-foreground">Course generated.</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {result.created} created · {result.updated} updated · {result.deleted} removed
+              </p>
+            </div>
+          ) : !plan ? (
+            <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" /> Analysing storyboard…
+            </div>
+          ) : (
+            <>
+              <p className="mb-3 text-sm text-muted-foreground">
+                This will map your storyboard headings onto the Adapt course structure.
+              </p>
+              <div className="mb-3 grid grid-cols-4 gap-2">
+                <Stat label="Topics" value={plan.topics} />
+                <Stat label="Sections" value={plan.sections} />
+                <Stat label="Groups" value={plan.groups} />
+                <Stat label="Components" value={plan.components} />
+              </div>
+
+              {plan.willDelete > 0 && (
+                <div className="mb-3 flex items-start gap-2 rounded-md border border-[#fcd34d] bg-[#fffbeb] p-2.5 text-sm text-[#92400e]">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <span>
+                    {plan.willDelete} existing course item(s) not present in the storyboard will be <b>removed</b>.
+                  </span>
+                </div>
+              )}
+
+              {plan.issues.map((msg, i) => (
+                <div key={`i${i}`} className="mb-1.5 flex items-start gap-2 rounded-md border border-[#fca5a5] bg-[#fef2f2] p-2 text-sm text-[#991b1b]">
+                  <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" /> {msg}
+                </div>
+              ))}
+              {plan.warnings.slice(0, 5).map((msg, i) => (
+                <div key={`w${i}`} className="mb-1.5 text-xs text-[#92400e]">
+                  ⚠ {msg}
+                </div>
+              ))}
+              {plan.warnings.length > 5 && (
+                <div className="text-xs text-muted-foreground">…and {plan.warnings.length - 5} more.</div>
+              )}
+            </>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 border-t px-4 py-2.5">
+          {result ? (
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md bg-[color:var(--primary)] px-4 py-1.5 text-sm font-semibold text-primary-foreground"
+            >
+              Done
+            </button>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={running}
+                className="rounded-md border px-3 py-1.5 text-sm hover:bg-secondary disabled:opacity-40"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={onConfirm}
+                disabled={!plan || blocked || running}
+                className="inline-flex items-center gap-1.5 rounded-md bg-[color:var(--primary)] px-4 py-1.5 text-sm font-semibold text-primary-foreground disabled:opacity-40"
+              >
+                {running ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <ArrowRight className="h-3.5 w-3.5" />}
+                {running ? 'Generating…' : 'Generate'}
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/new-ui-source/src/components/storyboard/HeadingMenu.tsx
+++ b/new-ui-source/src/components/storyboard/HeadingMenu.tsx
@@ -1,0 +1,102 @@
+// "Add Heading" dropdown (spec AC4). Matches the Lovable design: a HEADINGS
+// group offering H1 — Topic / H2 — Section / H3 — Content Group Heading.
+//
+// Rendered in a portal with fixed positioning so it can never be clipped or
+// mis-stacked by the editor's scroll/overflow/backdrop-blur ancestors — the
+// same treatment as AddContentMenu.
+
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Heading1, ChevronDown } from 'lucide-react';
+
+interface HeadingOption {
+  level: number;
+  label: string;
+}
+
+// H1–H3 only (H4/component is authored via Add Content cards).
+const HEADINGS: HeadingOption[] = [
+  { level: 1, label: 'H1 — Topic' },
+  { level: 2, label: 'H2 — Section' },
+  { level: 3, label: 'H3 — Content Group Heading' },
+];
+
+const MENU_WIDTH = 240;
+
+export default function HeadingMenu({ onSelect }: { onSelect: (level: number) => void }) {
+  const [open, setOpen] = useState(false);
+  const [pos, setPos] = useState<{ left: number; top: number; maxHeight: number }>({ left: 0, top: 0, maxHeight: 320 });
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (!open || !btnRef.current) return;
+    const r = btnRef.current.getBoundingClientRect();
+    const margin = 8;
+    const left = Math.min(r.left, window.innerWidth - MENU_WIDTH - margin);
+    const top = r.bottom + 4;
+    const maxHeight = Math.max(160, window.innerHeight - top - margin);
+    setPos({ left: Math.max(margin, left), top, maxHeight });
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      const t = e.target as Node;
+      if (btnRef.current?.contains(t) || menuRef.current?.contains(t)) return;
+      setOpen(false);
+    };
+    const close = () => setOpen(false);
+    document.addEventListener('mousedown', onDown);
+    window.addEventListener('resize', close);
+    window.addEventListener('scroll', close, true);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      window.removeEventListener('resize', close);
+      window.removeEventListener('scroll', close, true);
+    };
+  }, [open]);
+
+  const choose = (level: number) => {
+    onSelect(level);
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <button
+        ref={btnRef}
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-secondary"
+      >
+        <Heading1 className="h-3.5 w-3.5" /> Add Heading
+        <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+      </button>
+
+      {open &&
+        createPortal(
+          <div
+            ref={menuRef}
+            style={{ position: 'fixed', left: pos.left, top: pos.top, width: MENU_WIDTH, maxHeight: pos.maxHeight }}
+            className="z-[1000] overflow-y-auto rounded-md border bg-background py-1 shadow-lg"
+          >
+            <div className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Headings
+            </div>
+            {HEADINGS.map(({ level, label }) => (
+              <button
+                key={level}
+                type="button"
+                onClick={() => choose(level)}
+                className="flex w-full items-center px-3 py-1.5 text-sm hover:bg-muted"
+              >
+                {label}
+              </button>
+            ))}
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}

--- a/new-ui-source/src/components/storyboard/ReviewCenter.tsx
+++ b/new-ui-source/src/components/storyboard/ReviewCenter.tsx
@@ -150,8 +150,8 @@ export default function ReviewCenter({
   };
 
   return (
-    <aside className="flex h-full flex-col">
-      <div className="flex items-center justify-between border-b px-4 py-2.5">
+    <aside className="flex h-full flex-col bg-muted/20">
+      <div className="flex items-center justify-between border-b bg-muted/40 px-4 py-2.5 backdrop-blur">
         <h2 className="text-sm font-semibold text-foreground">Review Center</h2>
         {onCollapse && (
           <button

--- a/new-ui-source/src/components/storyboard/ReviewCenter.tsx
+++ b/new-ui-source/src/components/storyboard/ReviewCenter.tsx
@@ -1,0 +1,289 @@
+// Right panel — "Review Center" (spec AC8/AC9).
+//
+// Storyboard summary + block-anchored comment threads (add / reply / resolve)
+// + the audit/activity trail. Comments and audit come from the Phase 1 backend
+// via useStoryboardReview. Comments anchor to block ids; a comment whose block
+// no longer exists is shown as "(removed block)" rather than lost.
+
+import { useState } from 'react';
+import { PanelRightClose, MessageSquarePlus, Check, RotateCcw, Trash2, CornerDownRight } from 'lucide-react';
+import type { StoryboardSummary } from '@/types/storyboard';
+import type { StoryboardComment, StoryboardAuditEvent } from '@/api/adaptAuthoring';
+import type { UseStoryboardReviewResult } from '@/hooks/useStoryboardReview';
+
+type Tab = 'open' | 'resolved' | 'approvals' | 'activity';
+
+function SummaryRow({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex items-center justify-between py-1 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-medium text-foreground">{value}</span>
+    </div>
+  );
+}
+
+function timeAgo(iso?: string): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return '';
+  return d.toLocaleString();
+}
+
+interface CommentThreadProps {
+  top: StoryboardComment;
+  replies: StoryboardComment[];
+  label: string;
+  onReply: (parentId: string, blockId: string, body: string) => void;
+  onResolve: (id: string, resolved: boolean) => void;
+  onDelete: (id: string) => void;
+}
+
+function CommentThread({ top, replies, label, onReply, onResolve, onDelete }: CommentThreadProps) {
+  const [reply, setReply] = useState('');
+  return (
+    <div className="rounded-lg border p-2.5">
+      <div className="mb-1 flex items-center gap-2">
+        <span className="truncate text-[11px] font-semibold uppercase tracking-wide text-muted-foreground" title={label}>
+          {label}
+        </span>
+        <div className="ml-auto flex items-center gap-1">
+          <button
+            type="button"
+            title={top.resolved ? 'Reopen' : 'Resolve'}
+            onClick={() => onResolve(top._id, !top.resolved)}
+            className="grid h-6 w-6 place-items-center rounded text-muted-foreground hover:bg-muted"
+          >
+            {top.resolved ? <RotateCcw className="h-3.5 w-3.5" /> : <Check className="h-3.5 w-3.5" />}
+          </button>
+          <button
+            type="button"
+            title="Delete"
+            onClick={() => onDelete(top._id)}
+            className="grid h-6 w-6 place-items-center rounded text-muted-foreground hover:bg-muted"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </div>
+      <p className="whitespace-pre-wrap text-sm text-foreground">{top.body}</p>
+      <p className="mt-0.5 text-[11px] text-muted-foreground">{timeAgo(top.createdAt)}</p>
+
+      {replies.map((r) => (
+        <div key={r._id} className="mt-2 flex gap-1.5 border-l-2 border-border pl-2">
+          <CornerDownRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <div className="min-w-0">
+            <p className="whitespace-pre-wrap text-sm text-foreground">{r.body}</p>
+            <p className="mt-0.5 text-[11px] text-muted-foreground">{timeAgo(r.createdAt)}</p>
+          </div>
+        </div>
+      ))}
+
+      {!top.resolved && (
+        <form
+          className="mt-2 flex gap-1.5"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (reply.trim()) {
+              onReply(top._id, top.blockId, reply);
+              setReply('');
+            }
+          }}
+        >
+          <input
+            value={reply}
+            onChange={(e) => setReply(e.target.value)}
+            placeholder="Reply…"
+            className="flex-1 rounded border border-border bg-background px-2 py-1 text-sm outline-none focus:border-primary"
+          />
+          <button type="submit" disabled={!reply.trim()} className="text-xs font-medium text-primary disabled:opacity-40">
+            Reply
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}
+
+interface ReviewCenterProps {
+  summary: StoryboardSummary;
+  review: UseStoryboardReviewResult;
+  status: string;
+  /** The block a new comment will anchor to (cursor position). */
+  activeBlock?: { id: string; label: string };
+  courseId?: string;
+  /** Resolve a block id to a human label (heading text, etc.). */
+  labelFor: (blockId: string) => string;
+  onCollapse?: () => void;
+}
+
+export default function ReviewCenter({
+  summary,
+  review,
+  status,
+  activeBlock,
+  courseId,
+  labelFor,
+  onCollapse,
+}: ReviewCenterProps) {
+  const [tab, setTab] = useState<Tab>('open');
+  const [draft, setDraft] = useState('');
+
+  const tops = review.comments.filter((c) => !c._parentCommentId);
+  const repliesOf = (id: string) =>
+    review.comments
+      .filter((c) => c._parentCommentId === id)
+      .sort((a, b) => new Date(a.createdAt || 0).getTime() - new Date(b.createdAt || 0).getTime());
+  const openTops = tops.filter((c) => !c.resolved);
+  const resolvedTops = tops.filter((c) => c.resolved);
+
+  const tabs: { id: Tab; label: string }[] = [
+    { id: 'open', label: `Open (${review.openCount})` },
+    { id: 'resolved', label: `Resolved (${review.resolvedCount})` },
+    { id: 'approvals', label: 'Approvals' },
+    { id: 'activity', label: 'Activity' },
+  ];
+
+  const addTopLevel = () => {
+    if (!activeBlock || !draft.trim()) return;
+    review.addComment(activeBlock.id, draft, courseId);
+    setDraft('');
+  };
+
+  return (
+    <aside className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b px-4 py-2.5">
+        <h2 className="text-sm font-semibold text-foreground">Review Center</h2>
+        {onCollapse && (
+          <button
+            type="button"
+            aria-label="Collapse review center"
+            onClick={onCollapse}
+            className="grid h-6 w-6 place-items-center rounded text-muted-foreground hover:bg-muted"
+          >
+            <PanelRightClose className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      <div className="border-b px-4 py-3">
+        <div className="mb-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Storyboard Summary
+        </div>
+        <SummaryRow label="Topics" value={summary.topics} />
+        <SummaryRow label="Sections" value={summary.sections} />
+        <SummaryRow label="Content items" value={summary.contentItems} />
+        <SummaryRow label="Assets" value={summary.assets} />
+        <SummaryRow label="Open Comments" value={review.openCount} />
+        <SummaryRow label="Resolved" value={review.resolvedCount} />
+        <SummaryRow label="Status" value={status.replace('_', ' ')} />
+      </div>
+
+      <div className="flex items-center gap-4 border-b px-4">
+        {tabs.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            onClick={() => setTab(t.id)}
+            className={`-mb-px border-b-2 py-2 text-sm transition-colors ${
+              tab === t.id
+                ? 'border-primary font-medium text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="flex-1 space-y-2 overflow-y-auto p-4">
+        {tab === 'open' && (
+          <>
+            <div className="rounded-lg border p-2.5">
+              <div className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                <MessageSquarePlus className="h-3.5 w-3.5" />
+                {activeBlock ? `Comment on: ${activeBlock.label}` : 'Select a block to comment'}
+              </div>
+              <textarea
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                placeholder="Add a comment…"
+                rows={2}
+                disabled={!activeBlock}
+                className="w-full resize-y rounded border border-border bg-background px-2 py-1 text-sm outline-none focus:border-primary disabled:opacity-50"
+              />
+              <div className="mt-1 flex justify-end">
+                <button
+                  type="button"
+                  onClick={addTopLevel}
+                  disabled={!activeBlock || !draft.trim()}
+                  className="rounded-md bg-[color:var(--primary)] px-3 py-1 text-xs font-semibold text-primary-foreground disabled:opacity-40"
+                >
+                  Comment
+                </button>
+              </div>
+            </div>
+
+            {openTops.length === 0 ? (
+              <p className="pt-2 text-center text-sm text-muted-foreground">No open comments.</p>
+            ) : (
+              openTops.map((c) => (
+                <CommentThread
+                  key={c._id}
+                  top={c}
+                  replies={repliesOf(c._id)}
+                  label={labelFor(c.blockId)}
+                  onReply={(parentId, blockId, body) => review.addComment(blockId, body, courseId, parentId)}
+                  onResolve={review.setResolved}
+                  onDelete={review.removeComment}
+                />
+              ))
+            )}
+          </>
+        )}
+
+        {tab === 'resolved' &&
+          (resolvedTops.length === 0 ? (
+            <p className="text-center text-sm text-muted-foreground">No resolved comments yet.</p>
+          ) : (
+            resolvedTops.map((c) => (
+              <CommentThread
+                key={c._id}
+                top={c}
+                replies={repliesOf(c._id)}
+                label={labelFor(c.blockId)}
+                onReply={(parentId, blockId, body) => review.addComment(blockId, body, courseId, parentId)}
+                onResolve={review.setResolved}
+                onDelete={review.removeComment}
+              />
+            ))
+          ))}
+
+        {tab === 'approvals' && (
+          <div className="rounded-lg border border-dashed p-4 text-center text-sm text-muted-foreground">
+            Current status: <span className="font-medium text-foreground">{status.replace('_', ' ')}</span>.
+            <br />
+            Use the status pill in the top bar to move Draft → In Review → Approved.
+          </div>
+        )}
+
+        {tab === 'activity' &&
+          (review.audit.length === 0 ? (
+            <p className="text-center text-sm text-muted-foreground">No activity yet.</p>
+          ) : (
+            review.audit.map((a: StoryboardAuditEvent) => (
+              <div key={a._id} className="rounded-lg border p-2.5 text-sm">
+                <span className="font-medium text-foreground">{a.event.replace('_', ' ')}</span>
+                {a.fromStatus && a.toStatus && (
+                  <span className="text-muted-foreground">
+                    {' '}
+                    — {a.fromStatus.replace('_', ' ')} → {a.toStatus.replace('_', ' ')}
+                  </span>
+                )}
+                <p className="mt-0.5 text-[11px] text-muted-foreground">{timeAgo(a.createdAt)}</p>
+              </div>
+            ))
+          ))}
+      </div>
+    </aside>
+  );
+}

--- a/new-ui-source/src/components/storyboard/StoryboardTopBar.tsx
+++ b/new-ui-source/src/components/storyboard/StoryboardTopBar.tsx
@@ -8,7 +8,6 @@ import { useEffect, useRef, useState } from 'react';
 import {
   ArrowLeft,
   Upload,
-  Sparkles,
   Download,
   Users,
   ArrowRight,
@@ -16,14 +15,10 @@ import {
   Save,
 } from 'lucide-react';
 import type { ReviewStatus } from '@/types/storyboard';
-import type { StoryboardAiAction } from '@/api/ai';
 
-const AI_ACTION_LABELS: { label: string; action: StoryboardAiAction }[] = [
-  { label: 'Improve', action: 'improve' },
-  { label: 'Rewrite', action: 'rewrite' },
-  { label: 'Summarize', action: 'summarize' },
-  { label: 'Generate Suggestions', action: 'suggest' },
-];
+// AI is no longer a top-bar action — it lives under Add Content → AI Assistance
+// (Samaritan Assistance popover). The underlying /api/storyboard/ai proxy and
+// the card-level AI buttons are unchanged.
 
 const STATUS_META: Record<ReviewStatus, { label: string; className: string; next: ReviewStatus }> = {
   draft: { label: 'Draft', className: 'bg-muted text-foreground', next: 'in_review' },
@@ -88,7 +83,6 @@ export default function StoryboardTopBar({
   onCycleStatus,
   onBack,
   onStub,
-  onAiAction,
   onImport,
   onExport,
   onGenerate,
@@ -100,7 +94,6 @@ export default function StoryboardTopBar({
   onCycleStatus: () => void;
   onBack: () => void;
   onStub: (action: string, phase: string) => void;
-  onAiAction: (action: StoryboardAiAction) => void;
   onImport: () => void;
   onExport: (format: string) => void;
   onGenerate: () => void;
@@ -146,15 +139,6 @@ export default function StoryboardTopBar({
         >
           <Upload className="h-3.5 w-3.5" /> Import
         </button>
-        <Dropdown
-          label="AI Actions"
-          Icon={Sparkles}
-          items={AI_ACTION_LABELS.map((a) => a.label)}
-          onSelect={(label) => {
-            const match = AI_ACTION_LABELS.find((a) => a.label === label);
-            if (match) onAiAction(match.action);
-          }}
-        />
         <Dropdown label="Export" Icon={Download} items={['Word (.docx)', 'PDF (.pdf)']} onSelect={onExport} />
         <button
           type="button"

--- a/new-ui-source/src/components/storyboard/StoryboardTopBar.tsx
+++ b/new-ui-source/src/components/storyboard/StoryboardTopBar.tsx
@@ -1,0 +1,177 @@
+// Storyboard top bar (spec AC8/AC10/AC11).
+//   Back · Draft status · Import · AI Actions ▾ · Export ▾ · Share for Review ·
+//   Generate Course →
+// Backend-dependent actions (Import/AI/Export/Share/Generate) are stubbed with
+// a toast and a Phase note until their respective phases land.
+
+import { useEffect, useRef, useState } from 'react';
+import {
+  ArrowLeft,
+  Upload,
+  Sparkles,
+  Download,
+  Users,
+  ArrowRight,
+  ChevronDown,
+  Save,
+} from 'lucide-react';
+import type { ReviewStatus } from '@/types/storyboard';
+import type { StoryboardAiAction } from '@/api/ai';
+
+const AI_ACTION_LABELS: { label: string; action: StoryboardAiAction }[] = [
+  { label: 'Improve', action: 'improve' },
+  { label: 'Rewrite', action: 'rewrite' },
+  { label: 'Summarize', action: 'summarize' },
+  { label: 'Generate Suggestions', action: 'suggest' },
+];
+
+const STATUS_META: Record<ReviewStatus, { label: string; className: string; next: ReviewStatus }> = {
+  draft: { label: 'Draft', className: 'bg-muted text-foreground', next: 'in_review' },
+  in_review: { label: 'In Review', className: 'bg-[#FCE3CF] text-[#92400e]', next: 'approved' },
+  approved: { label: 'Approved', className: 'bg-[#CCEED2] text-[#166534]', next: 'draft' },
+};
+
+function Dropdown({
+  label,
+  Icon,
+  items,
+  onSelect,
+}: {
+  label: string;
+  Icon: typeof Upload;
+  items: string[];
+  onSelect: (item: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!open) return;
+    const h = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', h);
+    return () => document.removeEventListener('mousedown', h);
+  }, [open]);
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-secondary"
+      >
+        <Icon className="h-3.5 w-3.5" /> {label}
+        <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+      </button>
+      {open && (
+        <div className="absolute right-0 top-full z-30 mt-1 w-52 rounded-md border bg-background py-1 shadow-lg">
+          {items.map((item) => (
+            <button
+              key={item}
+              type="button"
+              onClick={() => {
+                onSelect(item);
+                setOpen(false);
+              }}
+              className="flex w-full items-center px-3 py-1.5 text-sm hover:bg-muted"
+            >
+              {item}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function StoryboardTopBar({
+  status,
+  onCycleStatus,
+  onBack,
+  onStub,
+  onAiAction,
+  onImport,
+  onExport,
+  onGenerate,
+  onSave,
+  dirty,
+  saving,
+}: {
+  status: ReviewStatus;
+  onCycleStatus: () => void;
+  onBack: () => void;
+  onStub: (action: string, phase: string) => void;
+  onAiAction: (action: StoryboardAiAction) => void;
+  onImport: () => void;
+  onExport: (format: string) => void;
+  onGenerate: () => void;
+  onSave: () => void;
+  dirty: boolean;
+  saving: boolean;
+}) {
+  const meta = STATUS_META[status];
+
+  return (
+    <header className="flex items-center gap-2 border-b bg-background px-4 py-2">
+      <button
+        type="button"
+        onClick={onBack}
+        className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-secondary"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" /> Back
+      </button>
+      <button
+        type="button"
+        onClick={onCycleStatus}
+        title="Click to change review status"
+        className={`rounded-full px-3 py-1 text-xs font-medium ${meta.className}`}
+      >
+        {meta.label}
+      </button>
+      {dirty && <span className="text-xs text-[#92400e]">Unsaved changes</span>}
+
+      <div className="ml-auto flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={!dirty || saving}
+          className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-secondary disabled:opacity-50"
+        >
+          <Save className="h-3.5 w-3.5" /> {saving ? 'Saving…' : 'Save'}
+        </button>
+        <button
+          type="button"
+          onClick={onImport}
+          title="Import Word, PDF or PowerPoint"
+          className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-secondary"
+        >
+          <Upload className="h-3.5 w-3.5" /> Import
+        </button>
+        <Dropdown
+          label="AI Actions"
+          Icon={Sparkles}
+          items={AI_ACTION_LABELS.map((a) => a.label)}
+          onSelect={(label) => {
+            const match = AI_ACTION_LABELS.find((a) => a.label === label);
+            if (match) onAiAction(match.action);
+          }}
+        />
+        <Dropdown label="Export" Icon={Download} items={['Word (.docx)', 'PDF (.pdf)']} onSelect={onExport} />
+        <button
+          type="button"
+          onClick={() => onStub('Share for Review', 'Phase 5')}
+          className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-secondary"
+        >
+          <Users className="h-3.5 w-3.5" /> Share for Review
+        </button>
+        <button
+          type="button"
+          onClick={onGenerate}
+          className="inline-flex items-center gap-1.5 rounded-md px-4 py-1.5 text-sm font-semibold text-primary-foreground hover:opacity-90"
+          style={{ background: 'var(--primary)' }}
+        >
+          Generate Course <ArrowRight className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/new-ui-source/src/components/storyboard/StoryboardWorkspace.tsx
+++ b/new-ui-source/src/components/storyboard/StoryboardWorkspace.tsx
@@ -1,0 +1,485 @@
+// Storyboard workspace — full 3-panel document experience (ADAPT-3760),
+// matching the Lovable reference. Chrome-free of any route concerns so it can
+// be a full-screen route (StoryboardPage) or embedded in Course Configuration.
+//
+//   Top bar   — StoryboardTopBar (save, status, import/ai/export/share/generate)
+//   Left       — ContentsPanel (TOC + AI guidance)
+//   Center     — DocumentToolbar + COURSE header + BlockNote canvas
+//
+// Persistence is backed by useStoryboard (ADAPT-3779): the document is loaded
+// once, edits are staged in the hook's draft, and Save PUTs it back. Because
+// BlockNote reads its initial content only once, the editor is mounted *after*
+// the storyboard has loaded (and starter content seeded), keyed on the id.
+
+import { useEffect, useRef, useState } from 'react';
+import { Loader2, PanelLeftOpen, PanelRightOpen } from 'lucide-react';
+import type {
+  ActiveBlockInfo,
+  StoryboardDocument,
+  StoryboardEditorHandle,
+  StoryboardHeading,
+  StoryboardInsertKind,
+  StoryboardSummary,
+} from '@/types/storyboard';
+import { useStoryboard } from '@/hooks/useStoryboard';
+import { useStoryboardReview } from '@/hooks/useStoryboardReview';
+import { storyboardAi, type StoryboardAiAction } from '@/api/ai';
+import {
+  getCourseStoryboardBlocks,
+  saveStoryboardToCourse,
+  exportStoryboardWord,
+  exportStoryboardPdf,
+  importStoryboardDocument,
+  updateStoryboard,
+  addStoryboardAudit,
+  type ImportFormat,
+  type StoryboardStatus,
+} from '@/api/adaptAuthoring';
+import {
+  planStoryboardGeneration,
+  generateStoryboardCourse,
+  type GenerationPlan,
+  type GenerationResult,
+} from '@/api/storyboardGeneration';
+import { BlockNoteStoryboardEditor } from './BlockNoteStoryboardEditor';
+import ContentsPanel from './ContentsPanel';
+import DocumentToolbar from './DocumentToolbar';
+import StoryboardTopBar from './StoryboardTopBar';
+import ReviewCenter from './ReviewCenter';
+import GenerateDialog from './GenerateDialog';
+
+const EMPTY_SUMMARY: StoryboardSummary = {
+  topics: 0,
+  sections: 0,
+  contentItems: 0,
+  assets: 0,
+  textBlocks: 0,
+  hasVisual: false,
+  hasAssessment: false,
+};
+
+const NEXT_STATUS: Record<StoryboardStatus, StoryboardStatus> = {
+  draft: 'in_review',
+  in_review: 'approved',
+  approved: 'draft',
+};
+
+function triggerDownload(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function base64ToBlob(b64: string, mime: string): Blob {
+  const bytes = atob(b64);
+  const arr = new Uint8Array(bytes.length);
+  for (let i = 0; i < bytes.length; i += 1) arr[i] = bytes.charCodeAt(i);
+  return new Blob([arr], { type: mime });
+}
+
+function readFileBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result).split(',')[1] ?? '');
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+// Starter content for a brand-new storyboard (mirrors the editor's own default).
+const STARTER_DOCUMENT: unknown[] = [
+  { type: 'heading', props: { level: 1 }, content: 'New Page Title' },
+  { type: 'heading', props: { level: 2 }, content: 'New Section Title' },
+  { type: 'paragraph', content: '' },
+];
+
+export default function StoryboardWorkspace({
+  courseId,
+  courseTitle = 'Untitled course',
+  initialDocument,
+  onBack,
+}: {
+  courseId?: string;
+  courseTitle?: string;
+  initialDocument?: StoryboardDocument;
+  onBack?: () => void;
+}) {
+  const sb = useStoryboard(courseId);
+  const review = useStoryboardReview(sb.storyboardId);
+  const editorRef = useRef<StoryboardEditorHandle>(null);
+
+  const [headings, setHeadings] = useState<StoryboardHeading[]>([]);
+  const [summary, setSummary] = useState<StoryboardSummary>(EMPTY_SUMMARY);
+  const [activeId, setActiveId] = useState<string>();
+  const [activeBlock, setActiveBlock] = useState<ActiveBlockInfo | null>(null);
+  const [showContents, setShowContents] = useState(true);
+  const [showReview, setShowReview] = useState(true);
+  const [toast, setToast] = useState<string>();
+
+  // Course generation (AC11) dialog state.
+  const [genOpen, setGenOpen] = useState(false);
+  const [genPlan, setGenPlan] = useState<GenerationPlan | null>(null);
+  const [genRunning, setGenRunning] = useState(false);
+  const [genResult, setGenResult] = useState<GenerationResult | null>(null);
+
+  // Resolve a block id to a human label for the Review panel (AC9).
+  const labelFor = (blockId: string): string => {
+    const h = headings.find((x) => x.id === blockId);
+    if (h) return `H${h.level} · ${h.text || 'Untitled'}`;
+    if (activeBlock && activeBlock.id === blockId && activeBlock.text) return activeBlock.text;
+    return '(content block)';
+  };
+
+  // The editor mounts once, after load, with this exact content — captured so
+  // the hook draft and the editor start perfectly in sync.
+  const [booted, setBooted] = useState(false);
+  const initialContent = useRef<unknown[]>(STARTER_DOCUMENT);
+  const bootstrapped = useRef(false);
+  // block id → generated content id, for idempotent regeneration (AC11).
+  const generatedMap = useRef<Record<string, string>>({});
+
+  const flash = (msg: string) => {
+    setToast(msg);
+    window.setTimeout(() => setToast(undefined), 2600);
+  };
+
+  // Once the storyboard has loaded, decide the editor's initial content.
+  // Priority: the last-saved storyboard document (so nothing the author did —
+  // including chosen media assets held in card data — is ever lost on reload),
+  // then a projection of the live course (first open of an existing course, so
+  // the storyboard mirrors it), then any passed-in doc, then starter content.
+  useEffect(() => {
+    if (sb.loading || bootstrapped.current) return;
+    bootstrapped.current = true;
+    (async () => {
+      let doc: unknown[] | null =
+        Array.isArray(sb.document) && sb.document.length ? (sb.document as unknown[]) : null;
+      const fromSaved = !!doc;
+      if (!doc && courseId) {
+        try {
+          const courseBlocks = await getCourseStoryboardBlocks(courseId);
+          if (courseBlocks.length) doc = courseBlocks;
+        } catch {
+          /* fall back to the passed-in doc / starter below */
+        }
+      }
+      if (!doc) {
+        doc =
+          Array.isArray(initialDocument) && (initialDocument as unknown[]).length
+            ? (initialDocument as unknown[])
+            : STARTER_DOCUMENT;
+      }
+      initialContent.current = doc;
+      sb.setDocument(doc);
+      // Only the already-saved document is clean; a fresh course projection is
+      // staged so the first Save writes it through.
+      if (fromSaved) sb.markSaved(doc);
+      setBooted(true);
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sb.loading]);
+
+  // Populate TOC + summary from the initial content (the editor doesn't emit
+  // onChange on mount).
+  useEffect(() => {
+    if (!booted) return;
+    setHeadings(editorRef.current?.getHeadings() ?? []);
+    setSummary(editorRef.current?.getSummary() ?? EMPTY_SUMMARY);
+  }, [booted]);
+
+  const handleChange = (doc: StoryboardDocument, nextHeadings: StoryboardHeading[]) => {
+    setHeadings(nextHeadings);
+    setSummary(editorRef.current?.getSummary() ?? EMPTY_SUMMARY);
+    sb.setDocument(doc as unknown[]); // stage into the hook draft (drives dirty/save)
+  };
+
+  const handleNavigate = (blockId: string) => {
+    setActiveId(blockId);
+    editorRef.current?.focusBlock(blockId);
+  };
+
+  const insert = (kind: StoryboardInsertKind) => editorRef.current?.insert(kind);
+  const insertHeading = (level: number) => editorRef.current?.insert('heading', { level });
+
+  const stub = (action: string, phase: string) => flash(`${action} — arrives in ${phase}.`);
+
+  // AI actions (AC7) operate on the cursor block's text via the server proxy.
+  // Improve/Rewrite replace the block; Summarize/Suggest append a paragraph.
+  const runAi = async (action: StoryboardAiAction) => {
+    const text = editorRef.current?.getActiveText() ?? '';
+    if (!text.trim()) {
+      flash('Place the cursor in a block with text first.');
+      return;
+    }
+    flash('Asking Samaritan…');
+    try {
+      const result = (await storyboardAi(action, text, courseTitle)).trim();
+      if (!result) {
+        flash('AI returned no content.');
+        return;
+      }
+      if (action === 'improve' || action === 'rewrite') editorRef.current?.replaceActive(result);
+      else editorRef.current?.insertAfterActive(result);
+      flash('AI suggestion applied.');
+    } catch (e) {
+      flash(`AI failed — ${e instanceof Error ? e.message : 'unknown error'}`);
+    }
+  };
+
+  const handleSave = async () => {
+    const doc = editorRef.current?.getDocument() as unknown[] | undefined;
+    try {
+      let msg = 'Storyboard saved.';
+      // Write content edits back to the live course (source of truth, AC11).
+      if (courseId && doc) {
+        const r = await saveStoryboardToCourse(courseId, doc);
+        msg =
+          `Saved to course — ${r.updatedTitles} title(s), ${r.updatedBodies} text edit(s).` +
+          (r.unmapped ? ` ${r.unmapped} new block(s) need course generation (Phase 4).` : '');
+      }
+      // Also persist the storyboard snapshot (documentJson) if we have a record.
+      if (sb.storyboardId) await sb.save();
+      flash(msg);
+    } catch (e) {
+      flash(`Save failed — ${e instanceof Error ? e.message : 'unknown error'}`);
+    }
+  };
+
+  const cycleStatus = async () => {
+    if (!sb.storyboardId) return;
+    const next = NEXT_STATUS[sb.status];
+    try {
+      // Snapshot-on-approval (AC8): persist the current document before approving.
+      if (next === 'approved') await sb.save();
+      await sb.changeStatus(next);
+      await review.refresh(); // reflect the new status_change audit event
+    } catch {
+      flash('Could not change status.');
+    }
+  };
+
+  // Import a Word/PDF/PPTX file → blocks, then load them into the editor (AC10).
+  const handleImport = () => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.docx,.pdf,.pptx';
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      const ext = (file.name.split('.').pop() || '').toLowerCase();
+      const format: ImportFormat = ext === 'pdf' ? 'pdf' : ext === 'pptx' ? 'pptx' : 'word';
+      flash('Importing…');
+      try {
+        const b64 = await readFileBase64(file);
+        const { blocks } = await importStoryboardDocument(format, b64);
+        if (Array.isArray(blocks) && blocks.length) {
+          editorRef.current?.setDocument(blocks);
+          sb.setDocument(blocks);
+          flash(`Imported ${blocks.length} block(s) — review, then Save.`);
+        } else {
+          flash('Nothing importable found in that file.');
+        }
+      } catch (e) {
+        flash(`Import failed — ${e instanceof Error ? e.message : 'unknown error'}`);
+      }
+    };
+    input.click();
+  };
+
+  // Export the storyboard to Word or PDF — both server-built (AC10).
+  const handleExport = async (label: string) => {
+    if (!sb.storyboardId) {
+      flash('Save the storyboard first to export.');
+      return;
+    }
+    const isPdf = label.toLowerCase().includes('pdf');
+    flash('Exporting…');
+    try {
+      if (sb.dirty) await sb.save(); // export reads the persisted document
+      const { filename, mime, dataBase64 } = isPdf
+        ? await exportStoryboardPdf(sb.storyboardId)
+        : await exportStoryboardWord(sb.storyboardId);
+      triggerDownload(base64ToBlob(dataBase64, mime), filename);
+    } catch (e) {
+      flash(`Export failed — ${e instanceof Error ? e.message : 'unknown error'}`);
+    }
+  };
+
+  // Open the Generate dialog and compute a validation plan (AC11).
+  const generate = async () => {
+    if (!courseId) {
+      flash('No course to generate into.');
+      return;
+    }
+    setGenOpen(true);
+    setGenResult(null);
+    setGenPlan(null);
+    try {
+      const doc = (editorRef.current?.getDocument() as unknown[]) ?? [];
+      setGenPlan(await planStoryboardGeneration(courseId, doc, generatedMap.current));
+    } catch (e) {
+      setGenPlan({
+        topics: 0,
+        sections: 0,
+        groups: 0,
+        components: 0,
+        willDelete: 0,
+        issues: [`Could not analyse: ${e instanceof Error ? e.message : 'unknown error'}`],
+        warnings: [],
+      });
+    }
+  };
+
+  // Apply generation, then re-seed the document from the course (idempotency)
+  // and record the audit event.
+  const confirmGenerate = async () => {
+    if (!courseId) return;
+    const doc = (editorRef.current?.getDocument() as unknown[]) ?? [];
+    setGenRunning(true);
+    try {
+      const result = await generateStoryboardCourse(courseId, doc, generatedMap.current);
+      generatedMap.current = result.blockToContent;
+      if (sb.storyboardId) {
+        await updateStoryboard(sb.storyboardId, { _generatedContentMap: result.blockToContent });
+        await addStoryboardAudit(sb.storyboardId, {
+          event: 'generated',
+          _courseId: courseId,
+          meta: { created: result.created, updated: result.updated, deleted: result.deleted },
+        });
+      }
+      // Re-seed from the freshly-generated course so every block carries a
+      // content id — the next generation is then a no-op.
+      const fresh = await getCourseStoryboardBlocks(courseId);
+      if (fresh.length) {
+        editorRef.current?.setDocument(fresh);
+        sb.setDocument(fresh);
+        sb.markSaved(fresh);
+      }
+      await review.refresh();
+      setGenResult(result);
+    } catch (e) {
+      setGenOpen(false);
+      flash(`Generation failed — ${e instanceof Error ? e.message : 'unknown error'}`);
+    } finally {
+      setGenRunning(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background text-foreground">
+      <StoryboardTopBar
+        status={sb.status}
+        onCycleStatus={cycleStatus}
+        onBack={() => onBack?.()}
+        onStub={stub}
+        onAiAction={runAi}
+        onImport={handleImport}
+        onExport={handleExport}
+        onGenerate={generate}
+        onSave={handleSave}
+        dirty={sb.dirty}
+        saving={sb.saving}
+      />
+
+      {sb.error && (
+        <div className="border-b border-[#fecaca] bg-[#fef2f2] px-4 py-2 text-sm text-[#991b1b]">
+          {sb.error}
+        </div>
+      )}
+
+      <div className="flex min-h-0 flex-1">
+        {/* Left — Contents */}
+        {showContents ? (
+          <div className="w-64 shrink-0 border-r">
+            <ContentsPanel
+              headings={headings}
+              summary={summary}
+              activeId={activeId}
+              onNavigate={handleNavigate}
+              onCollapse={() => setShowContents(false)}
+            />
+          </div>
+        ) : (
+          <button
+            type="button"
+            aria-label="Show contents"
+            onClick={() => setShowContents(true)}
+            className="grid w-9 shrink-0 place-items-start border-r pt-3 text-muted-foreground hover:bg-muted"
+          >
+            <PanelLeftOpen className="h-4 w-4" />
+          </button>
+        )}
+
+        {/* Center — document */}
+        <main className="flex min-w-0 flex-1 flex-col bg-background">
+          <DocumentToolbar onInsert={insert} onInsertHeading={insertHeading} onEnrichAI={() => runAi('improve')} />
+          <div className="flex-1 overflow-y-auto">
+            <article className="mx-auto max-w-3xl px-8 py-10">
+              <div className="text-xs font-semibold uppercase tracking-widest" style={{ color: 'var(--samaritan)' }}>
+                Course
+              </div>
+              <h1 className="mt-1 text-4xl font-bold tracking-tight text-foreground">{courseTitle}</h1>
+              <hr className="my-6 border-border" />
+              {booted ? (
+                <BlockNoteStoryboardEditor
+                  key={sb.storyboardId ?? 'sb'}
+                  ref={editorRef}
+                  initialDocument={initialContent.current}
+                  onChange={handleChange}
+                  onActiveBlock={setActiveBlock}
+                />
+              ) : (
+                <div className="flex items-center gap-2 py-16 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" /> Loading storyboard…
+                </div>
+              )}
+            </article>
+          </div>
+        </main>
+
+        {/* Right — Review Center (comments + audit, AC8/AC9) */}
+        {showReview ? (
+          <div className="w-80 shrink-0 border-l">
+            <ReviewCenter
+              summary={summary}
+              review={review}
+              status={sb.status}
+              activeBlock={activeBlock ? { id: activeBlock.id, label: labelFor(activeBlock.id) } : undefined}
+              courseId={courseId}
+              labelFor={labelFor}
+              onCollapse={() => setShowReview(false)}
+            />
+          </div>
+        ) : (
+          <button
+            type="button"
+            aria-label="Show review center"
+            onClick={() => setShowReview(true)}
+            className="grid w-9 shrink-0 place-items-start border-l pt-3 text-muted-foreground hover:bg-muted"
+          >
+            <PanelRightOpen className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+
+      {genOpen && (
+        <GenerateDialog
+          plan={genPlan}
+          running={genRunning}
+          result={genResult}
+          onConfirm={confirmGenerate}
+          onClose={() => setGenOpen(false)}
+        />
+      )}
+
+      {toast && (
+        <div className="fixed bottom-6 left-1/2 z-50 -translate-x-1/2 rounded-lg bg-foreground px-4 py-2 text-sm text-background shadow-lg">
+          {toast}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/new-ui-source/src/components/storyboard/StoryboardWorkspace.tsx
+++ b/new-ui-source/src/components/storyboard/StoryboardWorkspace.tsx
@@ -23,7 +23,6 @@ import type {
 } from '@/types/storyboard';
 import { useStoryboard } from '@/hooks/useStoryboard';
 import { useStoryboardReview } from '@/hooks/useStoryboardReview';
-import { storyboardAi, type StoryboardAiAction } from '@/api/ai';
 import {
   getCourseStoryboardBlocks,
   saveStoryboardToCourse,
@@ -47,6 +46,9 @@ import DocumentToolbar from './DocumentToolbar';
 import StoryboardTopBar from './StoryboardTopBar';
 import ReviewCenter from './ReviewCenter';
 import GenerateDialog from './GenerateDialog';
+import AiAssistPopover from './AiAssistPopover';
+import CommentPopover from './CommentPopover';
+import { storyboardActions, type AiAssistRequest, type CommentRequest } from './storyboardActions';
 
 const EMPTY_SUMMARY: StoryboardSummary = {
   topics: 0,
@@ -118,6 +120,20 @@ export default function StoryboardWorkspace({
   const [showContents, setShowContents] = useState(true);
   const [showReview, setShowReview] = useState(true);
   const [toast, setToast] = useState<string>();
+  // Component-action popovers (AI Assistance / Comment). Opened by the card
+  // header actions via the storyboardActions channel — NOT from Add Content.
+  const [aiConfig, setAiConfig] = useState<AiAssistRequest | null>(null);
+  const [commentConfig, setCommentConfig] = useState<CommentRequest | null>(null);
+
+  // Register the card→workspace action channel (cards render inside BlockNote).
+  useEffect(
+    () =>
+      storyboardActions.register({
+        openAi: (req) => setAiConfig(req),
+        openComment: (req) => setCommentConfig(req),
+      }),
+    []
+  );
 
   // Course generation (AC11) dialog state.
   const [genOpen, setGenOpen] = useState(false);
@@ -146,37 +162,35 @@ export default function StoryboardWorkspace({
     window.setTimeout(() => setToast(undefined), 2600);
   };
 
-  // Once the storyboard has loaded, decide the editor's initial content.
-  // Priority: the last-saved storyboard document (so nothing the author did —
-  // including chosen media assets held in card data — is ever lost on reload),
-  // then a projection of the live course (first open of an existing course, so
-  // the storyboard mirrors it), then any passed-in doc, then starter content.
+  // Once the storyboard has loaded, decide the editor's initial content. The
+  // live course is the source of truth (spec: the storyboard is always generated
+  // from the latest backend course structure), so we project it first — this
+  // reflects edits made anywhere in the AT. Fallbacks: the last-saved storyboard
+  // snapshot, any passed-in doc, then starter content. Save keeps them in sync.
   useEffect(() => {
     if (sb.loading || bootstrapped.current) return;
     bootstrapped.current = true;
     (async () => {
-      let doc: unknown[] | null =
-        Array.isArray(sb.document) && sb.document.length ? (sb.document as unknown[]) : null;
-      const fromSaved = !!doc;
-      if (!doc && courseId) {
+      let doc: unknown[] | null = null;
+      if (courseId) {
         try {
           const courseBlocks = await getCourseStoryboardBlocks(courseId);
           if (courseBlocks.length) doc = courseBlocks;
         } catch {
-          /* fall back to the passed-in doc / starter below */
+          /* fall back to the saved snapshot / starter below */
         }
       }
       if (!doc) {
         doc =
-          Array.isArray(initialDocument) && (initialDocument as unknown[]).length
-            ? (initialDocument as unknown[])
-            : STARTER_DOCUMENT;
+          Array.isArray(sb.document) && sb.document.length
+            ? (sb.document as unknown[])
+            : Array.isArray(initialDocument) && (initialDocument as unknown[]).length
+              ? (initialDocument as unknown[])
+              : STARTER_DOCUMENT;
       }
       initialContent.current = doc;
       sb.setDocument(doc);
-      // Only the already-saved document is clean; a fresh course projection is
-      // staged so the first Save writes it through.
-      if (fromSaved) sb.markSaved(doc);
+      sb.markSaved(doc); // seeding from the backend is not an unsaved edit
       setBooted(true);
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -204,43 +218,84 @@ export default function StoryboardWorkspace({
   const insert = (kind: StoryboardInsertKind) => editorRef.current?.insert(kind);
   const insertHeading = (level: number) => editorRef.current?.insert('heading', { level });
 
-  const stub = (action: string, phase: string) => flash(`${action} — arrives in ${phase}.`);
-
-  // AI actions (AC7) operate on the cursor block's text via the server proxy.
-  // Improve/Rewrite replace the block; Summarize/Suggest append a paragraph.
-  const runAi = async (action: StoryboardAiAction) => {
-    const text = editorRef.current?.getActiveText() ?? '';
-    if (!text.trim()) {
-      flash('Place the cursor in a block with text first.');
+  // Pull the latest backend course structure into the storyboard on demand
+  // (spec §1 — keep the storyboard synchronized with the AT). Guarded so it
+  // never discards unsaved edits.
+  const refreshFromCourse = async () => {
+    if (!courseId) return;
+    if (sb.dirty) {
+      flash('Save your changes first — then refresh from the course.');
       return;
     }
-    flash('Asking Samaritan…');
+    flash('Refreshing from course…');
     try {
-      const result = (await storyboardAi(action, text, courseTitle)).trim();
-      if (!result) {
-        flash('AI returned no content.');
-        return;
+      const fresh = await getCourseStoryboardBlocks(courseId);
+      if (fresh.length) {
+        editorRef.current?.setDocument(fresh);
+        sb.setDocument(fresh);
+        sb.markSaved(fresh);
+        setHeadings(editorRef.current?.getHeadings() ?? []);
+        setSummary(editorRef.current?.getSummary() ?? EMPTY_SUMMARY);
+        flash('Storyboard updated from the latest course content.');
+      } else {
+        flash('No course content to load yet.');
       }
-      if (action === 'improve' || action === 'rewrite') editorRef.current?.replaceActive(result);
-      else editorRef.current?.insertAfterActive(result);
-      flash('AI suggestion applied.');
     } catch (e) {
-      flash(`AI failed — ${e instanceof Error ? e.message : 'unknown error'}`);
+      flash(`Refresh failed — ${e instanceof Error ? e.message : 'unknown error'}`);
     }
+  };
+
+  const stub = (action: string, phase: string) => flash(`${action} — arrives in ${phase}.`);
+
+  // Document-level "Enrich with AI" (toolbar): open the SAME Samaritan popup,
+  // seeded from the cursor block. Insert → new Text component at the cursor;
+  // Replace → rewrite the cursor block. (Card-level AI supplies its own
+  // handlers via the storyboardActions channel.)
+  const openEnrichAi = () => {
+    setAiConfig({
+      initialText: activeBlock?.text || editorRef.current?.getActiveText() || '',
+      onInsert: (text) => {
+        editorRef.current?.insertComponent('text', { data: { description: text, showTitle: false } });
+        setHeadings(editorRef.current?.getHeadings() ?? []);
+        setSummary(editorRef.current?.getSummary() ?? EMPTY_SUMMARY);
+      },
+      onReplace: (text) => editorRef.current?.replaceActive(text),
+    });
   };
 
   const handleSave = async () => {
     const doc = editorRef.current?.getDocument() as unknown[] | undefined;
     try {
       let msg = 'Storyboard saved.';
-      // Write content edits back to the live course (source of truth, AC11).
       if (courseId && doc) {
+        // 1. Write edits to EXISTING course content (titles, text, media/_media).
         const r = await saveStoryboardToCourse(courseId, doc);
-        msg =
-          `Saved to course — ${r.updatedTitles} title(s), ${r.updatedBodies} text edit(s).` +
-          (r.unmapped ? ` ${r.unmapped} new block(s) need course generation (Phase 4).` : '');
+        msg = `Saved to course — ${r.updatedTitles} title(s), ${r.updatedBodies} content edit(s).`;
+        // 2. New blocks/components (incl. new media) → additively create them in
+        //    the backend so nothing is left only in the draft. Never deletes.
+        if (r.unmapped > 0) {
+          const result = await generateStoryboardCourse(courseId, doc, generatedMap.current, { skipDeletes: true });
+          generatedMap.current = { ...generatedMap.current, ...result.blockToContent };
+          if (sb.storyboardId) await updateStoryboard(sb.storyboardId, { _generatedContentMap: generatedMap.current });
+          if (result.created) msg += ` ${result.created} new item(s) added to the course.`;
+          // Media/assessment can't persist if their component type isn't
+          // installed — surface it instead of silently degrading to text.
+          if (result.missingTypes.length) {
+            msg += ` ⚠ Not generated (no installed plugin): ${result.missingTypes.join(', ')} — install the component plugin, then Save again. Your storyboard content is kept.`;
+          }
+          // 3. Re-seed from the backend so the storyboard mirrors the saved
+          //    course (new content ids + canonical media) — no manual refresh.
+          const fresh = await getCourseStoryboardBlocks(courseId);
+          if (fresh.length) {
+            editorRef.current?.setDocument(fresh);
+            sb.setDocument(fresh);
+            sb.markSaved(fresh);
+            setHeadings(editorRef.current?.getHeadings() ?? []);
+            setSummary(editorRef.current?.getSummary() ?? EMPTY_SUMMARY);
+          }
+        }
       }
-      // Also persist the storyboard snapshot (documentJson) if we have a record.
+      // 4. Persist the storyboard snapshot (documentJson).
       if (sb.storyboardId) await sb.save();
       flash(msg);
     } catch (e) {
@@ -300,9 +355,13 @@ export default function StoryboardWorkspace({
     try {
       if (sb.dirty) await sb.save(); // export reads the persisted document
       const { filename, mime, dataBase64 } = isPdf
-        ? await exportStoryboardPdf(sb.storyboardId)
-        : await exportStoryboardWord(sb.storyboardId);
-      triggerDownload(base64ToBlob(dataBase64, mime), filename);
+        ? await exportStoryboardPdf(sb.storyboardId, courseTitle)
+        : await exportStoryboardWord(sb.storyboardId, courseTitle);
+      // Name the download after the course title (fall back to the server name).
+      const ext = isPdf ? 'pdf' : 'docx';
+      const safeCourse = courseTitle.trim().replace(/[\\/:*?"<>|]+/g, '_');
+      const downloadName = safeCourse ? `${safeCourse}.${ext}` : filename;
+      triggerDownload(base64ToBlob(dataBase64, mime), downloadName);
     } catch (e) {
       flash(`Export failed — ${e instanceof Error ? e.message : 'unknown error'}`);
     }
@@ -375,7 +434,6 @@ export default function StoryboardWorkspace({
         onCycleStatus={cycleStatus}
         onBack={() => onBack?.()}
         onStub={stub}
-        onAiAction={runAi}
         onImport={handleImport}
         onExport={handleExport}
         onGenerate={generate}
@@ -415,14 +473,24 @@ export default function StoryboardWorkspace({
 
         {/* Center — document */}
         <main className="flex min-w-0 flex-1 flex-col bg-background">
-          <DocumentToolbar onInsert={insert} onInsertHeading={insertHeading} onEnrichAI={() => runAi('improve')} />
+          <DocumentToolbar
+            onInsert={insert}
+            onInsertHeading={insertHeading}
+            onEnrichAI={openEnrichAi}
+            onRefresh={courseId ? refreshFromCourse : undefined}
+          />
           <div className="flex-1 overflow-y-auto">
-            <article className="mx-auto max-w-3xl px-8 py-10">
-              <div className="text-xs font-semibold uppercase tracking-widest" style={{ color: 'var(--samaritan)' }}>
-                Course
+            {/* Authoring canvas ~60% of the viewport (Lovable proportions),
+                capped to the center column when the side panels squeeze it. */}
+            <article className="mx-auto w-[60vw] max-w-full px-8 py-10">
+              <div className="mb-8 border-b pb-5">
+                <div className="text-[10px] font-semibold uppercase tracking-[0.2em]" style={{ color: 'var(--samaritan)' }}>
+                  Course
+                </div>
+                <h1 className="mt-1 text-[2.6rem] font-bold leading-tight tracking-tight text-foreground">
+                  {courseTitle}
+                </h1>
               </div>
-              <h1 className="mt-1 text-4xl font-bold tracking-tight text-foreground">{courseTitle}</h1>
-              <hr className="my-6 border-border" />
               {booted ? (
                 <BlockNoteStoryboardEditor
                   key={sb.storyboardId ?? 'sb'}
@@ -472,6 +540,36 @@ export default function StoryboardWorkspace({
           result={genResult}
           onConfirm={confirmGenerate}
           onClose={() => setGenOpen(false)}
+        />
+      )}
+
+      {aiConfig && (
+        <AiAssistPopover
+          initialText={aiConfig.initialText || ''}
+          courseContext={courseTitle}
+          onInsert={(t) => {
+            aiConfig.onInsert(t);
+            flash('AI content inserted as a component. Save to persist it.');
+          }}
+          onReplace={(t) => {
+            aiConfig.onReplace(t);
+            flash('AI content applied.');
+          }}
+          onClose={() => setAiConfig(null)}
+        />
+      )}
+
+      {commentConfig && (
+        <CommentPopover
+          blockId={commentConfig.blockId}
+          blockLabel={commentConfig.label}
+          courseId={courseId}
+          comments={review.comments}
+          loading={review.loading}
+          onAdd={review.addComment}
+          onResolve={review.setResolved}
+          onDelete={review.removeComment}
+          onClose={() => setCommentConfig(null)}
         />
       )}
 

--- a/new-ui-source/src/components/storyboard/TableOfContents.tsx
+++ b/new-ui-source/src/components/storyboard/TableOfContents.tsx
@@ -1,0 +1,102 @@
+// TOC tree (spec AC1). Pure projection of document headings, with H1–H4
+// badges, expand/collapse, and click-to-navigate.
+
+import { useMemo, useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { cn } from '@/utils';
+import type { StoryboardHeading } from '@/types/storyboard';
+
+interface TocNode extends StoryboardHeading {
+  children: TocNode[];
+}
+
+function buildToc(headings: StoryboardHeading[]): TocNode[] {
+  const root: TocNode[] = [];
+  const stack: TocNode[] = [];
+  for (const h of headings) {
+    const node: TocNode = { ...h, children: [] };
+    while (stack.length && stack[stack.length - 1].level >= h.level) stack.pop();
+    (stack.length ? stack[stack.length - 1].children : root).push(node);
+    stack.push(node);
+  }
+  return root;
+}
+
+function TocItem({
+  node,
+  activeId,
+  onNavigate,
+}: {
+  node: TocNode;
+  activeId?: string;
+  onNavigate: (id: string) => void;
+}) {
+  const [collapsed, setCollapsed] = useState(false);
+  const hasChildren = node.children.length > 0;
+
+  return (
+    <li>
+      <div
+        className={cn(
+          'group flex items-center gap-1.5 rounded px-1.5 py-1 text-sm cursor-pointer hover:bg-muted',
+          node.id === activeId && 'bg-primary/10 text-primary'
+        )}
+        style={{ paddingLeft: `${(node.level - 1) * 14 + 4}px` }}
+      >
+        <button
+          type="button"
+          aria-label={collapsed ? 'Expand' : 'Collapse'}
+          onClick={() => setCollapsed((c) => !c)}
+          className={cn('grid h-4 w-4 shrink-0 place-items-center text-muted-foreground', !hasChildren && 'invisible')}
+        >
+          {collapsed ? <ChevronRight className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+        </button>
+        <span className="shrink-0 text-[10px] font-bold uppercase text-muted-foreground">
+          H{node.level}
+        </span>
+        <span
+          className="min-w-0 flex-1 truncate"
+          title={node.text || 'Untitled'}
+          onClick={() => onNavigate(node.id)}
+        >
+          {node.text || <em className="text-muted-foreground">Untitled</em>}
+        </span>
+      </div>
+      {hasChildren && !collapsed && (
+        <ul>
+          {node.children.map((child) => (
+            <TocItem key={child.id} node={child} activeId={activeId} onNavigate={onNavigate} />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+export default function TableOfContents({
+  headings,
+  activeId,
+  onNavigate,
+}: {
+  headings: StoryboardHeading[];
+  activeId?: string;
+  onNavigate: (id: string) => void;
+}) {
+  const tree = useMemo(() => buildToc(headings), [headings]);
+
+  if (tree.length === 0) {
+    return (
+      <p className="px-1.5 py-2 text-sm text-muted-foreground">
+        Add a heading to build your table of contents.
+      </p>
+    );
+  }
+
+  return (
+    <ul>
+      {tree.map((node) => (
+        <TocItem key={node.id} node={node} activeId={activeId} onNavigate={onNavigate} />
+      ))}
+    </ul>
+  );
+}

--- a/new-ui-source/src/components/storyboard/blocks/assessmentBlock.tsx
+++ b/new-ui-source/src/components/storyboard/blocks/assessmentBlock.tsx
@@ -1,0 +1,287 @@
+// Custom BlockNote block: simplified assessment authoring (spec AC5).
+//
+// One block covers MCQ / Graphic MCQ / Matching / Sentence Reordering / Text
+// Input / Slider. It shows only the essential authoring fields — advanced
+// settings (feedback, scoring, attempts) are deferred to the Page Editor. The
+// structured model is stored as JSON in the `data` prop (BlockNote props are
+// primitives only) and validated inline so it's generation-ready for Phase 4.
+
+import { useState } from 'react';
+import { Plus, X, CheckCircle2, AlertTriangle } from 'lucide-react';
+import { createReactBlockSpec } from '@blocknote/react';
+import {
+  defaultAssessmentData,
+  isAssessmentKind,
+  validateAssessment,
+  type AssessmentData,
+  type AssessmentKind,
+  type McqOption,
+} from '@/types/storyboard';
+
+const LABELS: Record<AssessmentKind, string> = {
+  mcq: 'MCQ',
+  gmcq: 'Graphic MCQ',
+  matching: 'Matching',
+  reorder: 'Sentence Reordering',
+  textInput: 'Text Input',
+  slider: 'Slider',
+};
+
+function parseData(kind: AssessmentKind, raw: string): AssessmentData {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') return parsed as AssessmentData;
+  } catch {
+    /* fall through to default */
+  }
+  return defaultAssessmentData(kind);
+}
+
+// Small presentational helpers ------------------------------------------------
+
+const inputCls =
+  'w-full rounded border border-border bg-background px-2 py-1 text-sm text-foreground outline-none focus:border-primary';
+const stop = (e: React.KeyboardEvent) => e.stopPropagation(); // keep keys out of BlockNote
+
+function RowButton({ onClick, label }: { onClick: () => void; label: string }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+    >
+      <Plus className="h-3 w-3" /> {label}
+    </button>
+  );
+}
+
+function RemoveButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="Remove"
+      className="grid h-6 w-6 shrink-0 place-items-center rounded text-muted-foreground hover:bg-muted"
+    >
+      <X className="h-3.5 w-3.5" />
+    </button>
+  );
+}
+
+// Per-kind forms --------------------------------------------------------------
+
+function OptionsForm({
+  data,
+  graphic,
+  update,
+}: {
+  data: AssessmentData;
+  graphic: boolean;
+  update: (next: AssessmentData) => void;
+}) {
+  const options = data.options ?? [];
+  const setOptions = (next: McqOption[]) => update({ ...data, options: next });
+  return (
+    <div className="space-y-1.5">
+      {options.map((opt, i) => (
+        <div key={i} className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            checked={opt.correct}
+            onChange={(e) => setOptions(options.map((o, j) => (j === i ? { ...o, correct: e.target.checked } : o)))}
+            title="Correct answer"
+            className="h-4 w-4 shrink-0 accent-[color:var(--primary)]"
+          />
+          <input
+            value={opt.text}
+            placeholder={`Option ${i + 1}`}
+            onKeyDown={stop}
+            onChange={(e) => setOptions(options.map((o, j) => (j === i ? { ...o, text: e.target.value } : o)))}
+            className={inputCls}
+          />
+          {graphic && (
+            <input
+              value={opt.image ?? ''}
+              placeholder="Image URL"
+              onKeyDown={stop}
+              onChange={(e) => setOptions(options.map((o, j) => (j === i ? { ...o, image: e.target.value } : o)))}
+              className={`${inputCls} max-w-[9rem]`}
+            />
+          )}
+          <RemoveButton onClick={() => setOptions(options.filter((_, j) => j !== i))} />
+        </div>
+      ))}
+      <RowButton onClick={() => setOptions([...options, { text: '', correct: false }])} label="Add option" />
+    </div>
+  );
+}
+
+function MatchingForm({ data, update }: { data: AssessmentData; update: (n: AssessmentData) => void }) {
+  const pairs = data.pairs ?? [];
+  const setPairs = (next: typeof pairs) => update({ ...data, pairs: next });
+  return (
+    <div className="space-y-1.5">
+      {pairs.map((p, i) => (
+        <div key={i} className="flex items-center gap-2">
+          <input
+            value={p.prompt}
+            placeholder="Prompt"
+            onKeyDown={stop}
+            onChange={(e) => setPairs(pairs.map((x, j) => (j === i ? { ...x, prompt: e.target.value } : x)))}
+            className={inputCls}
+          />
+          <span className="text-muted-foreground">↔</span>
+          <input
+            value={p.answer}
+            placeholder="Correct match"
+            onKeyDown={stop}
+            onChange={(e) => setPairs(pairs.map((x, j) => (j === i ? { ...x, answer: e.target.value } : x)))}
+            className={inputCls}
+          />
+          <RemoveButton onClick={() => setPairs(pairs.filter((_, j) => j !== i))} />
+        </div>
+      ))}
+      <RowButton onClick={() => setPairs([...pairs, { prompt: '', answer: '' }])} label="Add pair" />
+    </div>
+  );
+}
+
+function ListForm({
+  values,
+  placeholder,
+  addLabel,
+  hint,
+  onChange,
+}: {
+  values: string[];
+  placeholder: (i: number) => string;
+  addLabel: string;
+  hint?: string;
+  onChange: (next: string[]) => void;
+}) {
+  return (
+    <div className="space-y-1.5">
+      {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+      {values.map((v, i) => (
+        <div key={i} className="flex items-center gap-2">
+          {placeholder(i).startsWith('#') && (
+            <span className="w-5 shrink-0 text-xs text-muted-foreground">{i + 1}.</span>
+          )}
+          <input
+            value={v}
+            placeholder={placeholder(i).replace(/^#/, '')}
+            onKeyDown={stop}
+            onChange={(e) => onChange(values.map((x, j) => (j === i ? e.target.value : x)))}
+            className={inputCls}
+          />
+          <RemoveButton onClick={() => onChange(values.filter((_, j) => j !== i))} />
+        </div>
+      ))}
+      <RowButton onClick={() => onChange([...values, ''])} label={addLabel} />
+    </div>
+  );
+}
+
+function SliderForm({ data, update }: { data: AssessmentData; update: (n: AssessmentData) => void }) {
+  const s = data.slider ?? { min: 0, max: 10, step: 1, correct: 5 };
+  const set = (patch: Partial<typeof s>) => update({ ...data, slider: { ...s, ...patch } });
+  const num = (v: string) => (v === '' ? 0 : Number(v));
+  return (
+    <div className="grid grid-cols-4 gap-2">
+      {(['min', 'max', 'step', 'correct'] as const).map((k) => (
+        <label key={k} className="text-xs text-muted-foreground">
+          <span className="mb-0.5 block capitalize">{k}</span>
+          <input
+            type="number"
+            value={s[k]}
+            onKeyDown={stop}
+            onChange={(e) => set({ [k]: num(e.target.value) })}
+            className={inputCls}
+          />
+        </label>
+      ))}
+    </div>
+  );
+}
+
+// The block ------------------------------------------------------------------
+
+export const assessmentBlock = createReactBlockSpec(
+  {
+    type: 'sbAssessment',
+    propSchema: {
+      kind: { default: 'mcq', values: ['mcq', 'gmcq', 'matching', 'reorder', 'textInput', 'slider'] },
+      title: { default: '' },
+      adaptComponent: { default: 'adapt-contrib-mcq' },
+      data: { default: '{}' },
+    },
+    content: 'none',
+  },
+  {
+    render: ({ block, editor }) => {
+      const kind = (isAssessmentKind(block.props.kind as string) ? block.props.kind : 'mcq') as AssessmentKind;
+      const [model, setModel] = useState<AssessmentData>(() => parseData(kind, block.props.data as string));
+
+      const update = (next: AssessmentData) => {
+        setModel(next);
+        editor.updateBlock(block, { props: { data: JSON.stringify(next), title: next.question || '' } });
+      };
+
+      const issues = validateAssessment(kind, model);
+      const ready = issues.length === 0;
+
+      return (
+        <div className="my-2 rounded-md border border-dashed border-primary/50 bg-primary/5 p-3" contentEditable={false}>
+          <div className="mb-2 flex items-center gap-2">
+            <span className="rounded bg-foreground/80 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-background">
+              Assessment
+            </span>
+            <span className="text-sm font-medium text-foreground">{LABELS[kind]}</span>
+            <span
+              className={`ml-auto inline-flex items-center gap-1 text-xs ${ready ? 'text-[#166534]' : 'text-[#92400e]'}`}
+              title={ready ? 'Generation-ready' : issues.join('\n')}
+            >
+              {ready ? <CheckCircle2 className="h-3.5 w-3.5" /> : <AlertTriangle className="h-3.5 w-3.5" />}
+              {ready ? 'Ready' : `${issues.length} to fix`}
+            </span>
+          </div>
+
+          <input
+            value={model.question}
+            placeholder="Question / instruction…"
+            onKeyDown={stop}
+            onChange={(e) => update({ ...model, question: e.target.value })}
+            className={`${inputCls} mb-2 font-medium`}
+          />
+
+          {(kind === 'mcq' || kind === 'gmcq') && (
+            <OptionsForm data={model} graphic={kind === 'gmcq'} update={update} />
+          )}
+          {kind === 'matching' && <MatchingForm data={model} update={update} />}
+          {kind === 'reorder' && (
+            <ListForm
+              values={model.items ?? []}
+              placeholder={() => '#Item'}
+              addLabel="Add item"
+              hint="List items in their correct order."
+              onChange={(next) => update({ ...model, items: next })}
+            />
+          )}
+          {kind === 'textInput' && (
+            <ListForm
+              values={model.answers ?? []}
+              placeholder={() => 'Acceptable answer'}
+              addLabel="Add acceptable answer"
+              onChange={(next) => update({ ...model, answers: next })}
+            />
+          )}
+          {kind === 'slider' && <SliderForm data={model} update={update} />}
+
+          <p className="mt-2 text-xs text-muted-foreground">
+            Advanced settings (feedback, scoring, attempts) are configured in the Page Editor.
+          </p>
+        </div>
+      );
+    },
+  }
+);

--- a/new-ui-source/src/components/storyboard/blocks/assessmentBlock.tsx
+++ b/new-ui-source/src/components/storyboard/blocks/assessmentBlock.tsx
@@ -1,20 +1,24 @@
-// Custom BlockNote block: simplified assessment authoring (spec AC5).
-//
-// One block covers MCQ / Graphic MCQ / Matching / Sentence Reordering / Text
-// Input / Slider. It shows only the essential authoring fields — advanced
-// settings (feedback, scoring, attempts) are deferred to the Page Editor. The
-// structured model is stored as JSON in the `data` prop (BlockNote props are
-// primitives only) and validated inline so it's generation-ready for Phase 4.
+// Assessment authoring card (spec AC5) — matches the Lovable question block:
+// a common header (badge, title, Show title, Replace, AI, Source, Delete, Done),
+// a "Regenerate with AI" bar, a Body field, per-kind options (with per-option
+// answer-specific feedback), a whole-question Feedback group, and a footer hint.
+// The structured model is stored as JSON in the `data` prop and is generation-
+// ready — options + feedback are written into the Adapt component on Save.
 
 import { useState } from 'react';
-import { Plus, X, CheckCircle2, AlertTriangle } from 'lucide-react';
+import { RefreshCw, Sparkles, Code, Trash2, Check, Plus, AlertTriangle, MessageSquare } from 'lucide-react';
+import { storyboardActions } from '../storyboardActions';
 import { createReactBlockSpec } from '@blocknote/react';
+import { storyboardAi } from '@/api/ai';
 import {
   defaultAssessmentData,
+  emptyFeedback,
   isAssessmentKind,
   validateAssessment,
   type AssessmentData,
+  type AssessmentFeedback,
   type AssessmentKind,
+  type MatchPair,
   type McqOption,
 } from '@/types/storyboard';
 
@@ -27,157 +31,159 @@ const LABELS: Record<AssessmentKind, string> = {
   slider: 'Slider',
 };
 
+const FOOTER: Record<AssessmentKind, string> = {
+  mcq: 'Select one option and then select Submit.',
+  gmcq: 'Select one option and then select Submit.',
+  matching: 'Match each item to its correct pair and then select Submit.',
+  reorder: 'Place the items in the correct order and then select Submit.',
+  textInput: 'Type your answer and then select Submit.',
+  slider: 'Move the slider to your answer and then select Submit.',
+};
+
+const inputCls =
+  'w-full rounded border border-border bg-background px-2 py-1 text-sm text-foreground outline-none focus:border-primary';
+const labelCls = 'mb-0.5 block text-[11px] font-semibold uppercase tracking-wide text-muted-foreground';
+const stop = (e: React.KeyboardEvent) => e.stopPropagation();
+
 function parseData(kind: AssessmentKind, raw: string): AssessmentData {
   try {
-    const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === 'object') return parsed as AssessmentData;
+    const p = JSON.parse(raw);
+    if (p && typeof p === 'object') return { ...defaultAssessmentData(kind), ...p };
   } catch {
-    /* fall through to default */
+    /* fall through */
   }
   return defaultAssessmentData(kind);
 }
 
-// Small presentational helpers ------------------------------------------------
-
-const inputCls =
-  'w-full rounded border border-border bg-background px-2 py-1 text-sm text-foreground outline-none focus:border-primary';
-const stop = (e: React.KeyboardEvent) => e.stopPropagation(); // keep keys out of BlockNote
-
-function RowButton({ onClick, label }: { onClick: () => void; label: string }) {
+function HeaderBtn({ onClick, active, children, title }: { onClick: () => void; active?: boolean; children: React.ReactNode; title?: string }) {
   return (
     <button
       type="button"
       onClick={onClick}
-      className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+      title={title}
+      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs hover:bg-muted ${active ? 'border-primary text-primary' : 'text-muted-foreground'}`}
     >
-      <Plus className="h-3 w-3" /> {label}
+      {children}
     </button>
   );
 }
 
-function RemoveButton({ onClick }: { onClick: () => void }) {
+// ── Feedback group (whole-question) ──────────────────────────────────────────
+
+function FeedbackGroup({ fb, set }: { fb: AssessmentFeedback; set: (f: AssessmentFeedback) => void }) {
+  const field = (key: keyof AssessmentFeedback, label: string) => (
+    <label className="mt-1 block">
+      <span className={labelCls}>{label}</span>
+      <input value={fb[key]} onKeyDown={stop} onChange={(e) => set({ ...fb, [key]: e.target.value })} className={inputCls} />
+    </label>
+  );
+  const empty = !Object.values(fb).some((v) => v.trim());
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-label="Remove"
-      className="grid h-6 w-6 shrink-0 place-items-center rounded text-muted-foreground hover:bg-muted"
-    >
-      <X className="h-3.5 w-3.5" />
-    </button>
+    <div className="mt-2 rounded border border-border p-2">
+      <div className={labelCls}>Feedback</div>
+      {field('correct', 'Correct')}
+      {field('incorrect', 'Incorrect')}
+      {field('incorrectNotFinal', 'Incorrect — not final')}
+      {field('partlyCorrectFinal', 'Partly correct — final')}
+      {field('partlyCorrectNotFinal', 'Partly correct — not final')}
+      {empty && (
+        <div className="mt-1.5 inline-flex items-center gap-1 text-xs text-[#92400e]">
+          <AlertTriangle className="h-3.5 w-3.5" /> Feedback not configured
+        </div>
+      )}
+    </div>
   );
 }
 
-// Per-kind forms --------------------------------------------------------------
+// ── Per-kind bodies ──────────────────────────────────────────────────────────
 
-function OptionsForm({
-  data,
-  graphic,
-  update,
-}: {
-  data: AssessmentData;
-  graphic: boolean;
-  update: (next: AssessmentData) => void;
-}) {
+function OptionsForm({ data, graphic, update }: { data: AssessmentData; graphic: boolean; update: (n: AssessmentData) => void }) {
   const options = data.options ?? [];
   const setOptions = (next: McqOption[]) => update({ ...data, options: next });
+  const patch = (i: number, p: Partial<McqOption>) => setOptions(options.map((o, j) => (j === i ? { ...o, ...p } : o)));
   return (
-    <div className="space-y-1.5">
+    <div className="mt-2 rounded border border-border p-2">
+      <div className={labelCls}>Options</div>
       {options.map((opt, i) => (
-        <div key={i} className="flex items-center gap-2">
-          <input
-            type="checkbox"
-            checked={opt.correct}
-            onChange={(e) => setOptions(options.map((o, j) => (j === i ? { ...o, correct: e.target.checked } : o)))}
-            title="Correct answer"
-            className="h-4 w-4 shrink-0 accent-[color:var(--primary)]"
-          />
-          <input
-            value={opt.text}
-            placeholder={`Option ${i + 1}`}
-            onKeyDown={stop}
-            onChange={(e) => setOptions(options.map((o, j) => (j === i ? { ...o, text: e.target.value } : o)))}
-            className={inputCls}
-          />
+        <div key={i} className="mb-2 rounded border border-border p-2">
+          <div className="mb-1 flex items-center justify-between gap-2">
+            <label className="flex items-center gap-1.5 text-xs font-medium text-foreground">
+              <input type="checkbox" checked={opt.correct} onChange={(e) => patch(i, { correct: e.target.checked })} className="h-4 w-4 accent-[color:var(--primary)]" />
+              Correct
+              <span className="ml-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                Option {i + 1}/{options.length}
+              </span>
+            </label>
+            <button type="button" aria-label="Remove option" onClick={() => setOptions(options.filter((_, j) => j !== i))} className="text-muted-foreground hover:text-foreground">
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </div>
           {graphic && (
-            <input
-              value={opt.image ?? ''}
-              placeholder="Image URL"
-              onKeyDown={stop}
-              onChange={(e) => setOptions(options.map((o, j) => (j === i ? { ...o, image: e.target.value } : o)))}
-              className={`${inputCls} max-w-[9rem]`}
-            />
+            <input value={opt.image ?? ''} placeholder="Image source URL" onKeyDown={stop} onChange={(e) => patch(i, { image: e.target.value })} className={`${inputCls} mb-1`} />
           )}
-          <RemoveButton onClick={() => setOptions(options.filter((_, j) => j !== i))} />
+          <label className="block">
+            <span className={labelCls}>Option text</span>
+            <input value={opt.text} onKeyDown={stop} onChange={(e) => patch(i, { text: e.target.value })} className={inputCls} />
+          </label>
+          <label className="mt-1 block">
+            <span className={labelCls}>Answer-specific feedback</span>
+            <input value={opt.feedback ?? ''} placeholder="Shown when this option is selected" onKeyDown={stop} onChange={(e) => patch(i, { feedback: e.target.value })} className={inputCls} />
+          </label>
         </div>
       ))}
-      <RowButton onClick={() => setOptions([...options, { text: '', correct: false }])} label="Add option" />
+      <button type="button" onClick={() => setOptions([...options, { text: '', correct: false, feedback: '' }])} className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline">
+        <Plus className="h-3 w-3" /> Add option
+      </button>
     </div>
   );
 }
 
 function MatchingForm({ data, update }: { data: AssessmentData; update: (n: AssessmentData) => void }) {
   const pairs = data.pairs ?? [];
-  const setPairs = (next: typeof pairs) => update({ ...data, pairs: next });
+  const setPairs = (next: MatchPair[]) => update({ ...data, pairs: next });
   return (
-    <div className="space-y-1.5">
+    <div className="mt-2 rounded border border-border p-2">
+      <div className={labelCls}>Options &amp; matching options</div>
       {pairs.map((p, i) => (
-        <div key={i} className="flex items-center gap-2">
-          <input
-            value={p.prompt}
-            placeholder="Prompt"
-            onKeyDown={stop}
-            onChange={(e) => setPairs(pairs.map((x, j) => (j === i ? { ...x, prompt: e.target.value } : x)))}
-            className={inputCls}
-          />
-          <span className="text-muted-foreground">↔</span>
-          <input
-            value={p.answer}
-            placeholder="Correct match"
-            onKeyDown={stop}
-            onChange={(e) => setPairs(pairs.map((x, j) => (j === i ? { ...x, answer: e.target.value } : x)))}
-            className={inputCls}
-          />
-          <RemoveButton onClick={() => setPairs(pairs.filter((_, j) => j !== i))} />
+        <div key={i} className="mb-2 rounded border border-border p-2">
+          <div className="mb-1 flex items-center justify-between">
+            <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Option {i + 1}/{pairs.length}</span>
+            <button type="button" aria-label="Remove pair" onClick={() => setPairs(pairs.filter((_, j) => j !== i))} className="text-muted-foreground hover:text-foreground">
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </div>
+          <label className="block">
+            <span className={labelCls}>Text</span>
+            <input value={p.prompt} onKeyDown={stop} onChange={(e) => setPairs(pairs.map((x, j) => (j === i ? { ...x, prompt: e.target.value } : x)))} className={inputCls} />
+          </label>
+          <label className="mt-1 block">
+            <span className={labelCls}>Matching option</span>
+            <input value={p.answer} placeholder="Correct match for this option" onKeyDown={stop} onChange={(e) => setPairs(pairs.map((x, j) => (j === i ? { ...x, answer: e.target.value } : x)))} className={inputCls} />
+          </label>
         </div>
       ))}
-      <RowButton onClick={() => setPairs([...pairs, { prompt: '', answer: '' }])} label="Add pair" />
+      <button type="button" onClick={() => setPairs([...pairs, { prompt: '', answer: '' }])} className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline">
+        <Plus className="h-3 w-3" /> Add option
+      </button>
     </div>
   );
 }
 
-function ListForm({
-  values,
-  placeholder,
-  addLabel,
-  hint,
-  onChange,
-}: {
-  values: string[];
-  placeholder: (i: number) => string;
-  addLabel: string;
-  hint?: string;
-  onChange: (next: string[]) => void;
-}) {
+function ListForm({ values, itemLabel, addLabel, onChange }: { values: string[]; itemLabel: string; addLabel: string; onChange: (n: string[]) => void }) {
   return (
-    <div className="space-y-1.5">
-      {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+    <div className="mt-2 rounded border border-border p-2">
       {values.map((v, i) => (
-        <div key={i} className="flex items-center gap-2">
-          {placeholder(i).startsWith('#') && (
-            <span className="w-5 shrink-0 text-xs text-muted-foreground">{i + 1}.</span>
-          )}
-          <input
-            value={v}
-            placeholder={placeholder(i).replace(/^#/, '')}
-            onKeyDown={stop}
-            onChange={(e) => onChange(values.map((x, j) => (j === i ? e.target.value : x)))}
-            className={inputCls}
-          />
-          <RemoveButton onClick={() => onChange(values.filter((_, j) => j !== i))} />
+        <div key={i} className="mb-1 flex items-center gap-2">
+          <span className="w-16 shrink-0 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">{itemLabel} {i + 1}</span>
+          <input value={v} onKeyDown={stop} onChange={(e) => onChange(values.map((x, j) => (j === i ? e.target.value : x)))} className={inputCls} />
+          <button type="button" aria-label="Remove" onClick={() => onChange(values.filter((_, j) => j !== i))} className="text-muted-foreground hover:text-foreground">
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
         </div>
       ))}
-      <RowButton onClick={() => onChange([...values, ''])} label={addLabel} />
+      <button type="button" onClick={() => onChange([...values, ''])} className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline">
+        <Plus className="h-3 w-3" /> {addLabel}
+      </button>
     </div>
   );
 }
@@ -187,24 +193,36 @@ function SliderForm({ data, update }: { data: AssessmentData; update: (n: Assess
   const set = (patch: Partial<typeof s>) => update({ ...data, slider: { ...s, ...patch } });
   const num = (v: string) => (v === '' ? 0 : Number(v));
   return (
-    <div className="grid grid-cols-4 gap-2">
+    <div className="mt-2 grid grid-cols-4 gap-2 rounded border border-border p-2">
       {(['min', 'max', 'step', 'correct'] as const).map((k) => (
-        <label key={k} className="text-xs text-muted-foreground">
-          <span className="mb-0.5 block capitalize">{k}</span>
-          <input
-            type="number"
-            value={s[k]}
-            onKeyDown={stop}
-            onChange={(e) => set({ [k]: num(e.target.value) })}
-            className={inputCls}
-          />
+        <label key={k} className="block">
+          <span className={labelCls}>{k}</span>
+          <input type="number" value={s[k]} onKeyDown={stop} onChange={(e) => set({ [k]: num(e.target.value) })} className={inputCls} />
         </label>
       ))}
     </div>
   );
 }
 
-// The block ------------------------------------------------------------------
+function Body({ kind, data, update }: { kind: AssessmentKind; data: AssessmentData; update: (n: AssessmentData) => void }) {
+  switch (kind) {
+    case 'mcq':
+    case 'gmcq':
+      return <OptionsForm data={data} graphic={kind === 'gmcq'} update={update} />;
+    case 'matching':
+      return <MatchingForm data={data} update={update} />;
+    case 'reorder':
+      return <ListForm values={data.items ?? []} itemLabel="Position" addLabel="Add item" onChange={(n) => update({ ...data, items: n })} />;
+    case 'textInput':
+      return <ListForm values={data.answers ?? []} itemLabel="Answer" addLabel="Add acceptable answer" onChange={(n) => update({ ...data, answers: n })} />;
+    case 'slider':
+      return <SliderForm data={data} update={update} />;
+    default:
+      return null;
+  }
+}
+
+// ── The block ────────────────────────────────────────────────────────────────
 
 export const assessmentBlock = createReactBlockSpec(
   {
@@ -212,7 +230,7 @@ export const assessmentBlock = createReactBlockSpec(
     propSchema: {
       kind: { default: 'mcq', values: ['mcq', 'gmcq', 'matching', 'reorder', 'textInput', 'slider'] },
       title: { default: '' },
-      adaptComponent: { default: 'adapt-contrib-mcq' },
+      adaptComponent: { default: 'mcq' },
       data: { default: '{}' },
     },
     content: 'none',
@@ -221,65 +239,122 @@ export const assessmentBlock = createReactBlockSpec(
     render: ({ block, editor }) => {
       const kind = (isAssessmentKind(block.props.kind as string) ? block.props.kind : 'mcq') as AssessmentKind;
       const [model, setModel] = useState<AssessmentData>(() => parseData(kind, block.props.data as string));
+      const [collapsed, setCollapsed] = useState(false);
+      const [source, setSource] = useState(false);
+      const title = block.props.title as string;
+      const fb = model.feedback ?? emptyFeedback();
 
       const update = (next: AssessmentData) => {
         setModel(next);
-        editor.updateBlock(block, { props: { data: JSON.stringify(next), title: next.question || '' } });
+        editor.updateBlock(block, { props: { data: JSON.stringify(next) } });
+      };
+      const setTitle = (t: string) => editor.updateBlock(block, { props: { title: t } });
+
+      const regenerate = async () => {
+        try {
+          const seed = model.question || title || LABELS[kind];
+          const r = (await storyboardAi('suggest', seed)).trim();
+          if (r) update({ ...model, question: r });
+        } catch {
+          /* surfaced elsewhere */
+        }
       };
 
       const issues = validateAssessment(kind, model);
-      const ready = issues.length === 0;
+
+      if (collapsed) {
+        return (
+          <div className="group relative my-2 rounded-lg border bg-muted/20 p-3" contentEditable={false}>
+            <div className="mb-1 flex items-center gap-2">
+              <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{LABELS[kind]}</span>
+              <span className="truncate text-sm font-medium text-foreground">{title || model.question || 'Untitled question'}</span>
+            </div>
+            {model.question && <p className="text-sm text-foreground">{model.question}</p>}
+            <ul className="mt-1 space-y-0.5">
+              {(model.options ?? []).filter((o) => o.text.trim()).map((o, i) => (
+                <li key={i} className={`text-sm ${o.correct ? 'font-medium text-[#166534]' : 'text-muted-foreground'}`}>
+                  {o.correct ? '✓ ' : '• '}{o.text}
+                </li>
+              ))}
+            </ul>
+            <button type="button" onClick={() => setCollapsed(false)} className="absolute right-2 top-2 inline-flex items-center gap-1 rounded-full border bg-background px-2 py-0.5 text-xs text-muted-foreground opacity-0 transition-opacity hover:bg-muted group-hover:opacity-100">
+              <RefreshCw className="h-3 w-3" /> Edit
+            </button>
+          </div>
+        );
+      }
 
       return (
-        <div className="my-2 rounded-md border border-dashed border-primary/50 bg-primary/5 p-3" contentEditable={false}>
-          <div className="mb-2 flex items-center gap-2">
-            <span className="rounded bg-foreground/80 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-background">
-              Assessment
+        <div className="my-2 rounded-lg border p-3" contentEditable={false}>
+          {/* Header */}
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            <span className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+              {LABELS[kind]}
             </span>
-            <span className="text-sm font-medium text-foreground">{LABELS[kind]}</span>
-            <span
-              className={`ml-auto inline-flex items-center gap-1 text-xs ${ready ? 'text-[#166534]' : 'text-[#92400e]'}`}
-              title={ready ? 'Generation-ready' : issues.join('\n')}
+            <input value={title} placeholder={`${LABELS[kind]} title`} onKeyDown={stop} onChange={(e) => setTitle(e.target.value)} className="min-w-0 flex-1 border-0 bg-transparent text-sm font-medium text-foreground outline-none placeholder:text-muted-foreground" />
+            <HeaderBtn onClick={() => update({ ...model, showTitle: !model.showTitle })} active={model.showTitle} title="Show the title to learners">
+              <Check className="h-3 w-3" /> Show title
+            </HeaderBtn>
+            <HeaderBtn onClick={() => {}} title="Change type in the Page Editor">
+              <RefreshCw className="h-3 w-3" /> Replace
+            </HeaderBtn>
+            <HeaderBtn onClick={regenerate} title="Draft with AI">
+              <Sparkles className="h-3 w-3" /> AI
+            </HeaderBtn>
+            <HeaderBtn onClick={() => setSource((s) => !s)} active={source} title="Toggle source view">
+              <Code className="h-3 w-3" /> Source
+            </HeaderBtn>
+            <HeaderBtn
+              onClick={() => storyboardActions.openComment({ blockId: block.id, label: `ASSESSMENT · ${LABELS[kind].toUpperCase()}` })}
+              title="Comment on this question"
             >
-              {ready ? <CheckCircle2 className="h-3.5 w-3.5" /> : <AlertTriangle className="h-3.5 w-3.5" />}
-              {ready ? 'Ready' : `${issues.length} to fix`}
-            </span>
+              <MessageSquare className="h-3 w-3" /> Comment
+            </HeaderBtn>
+            <HeaderBtn onClick={() => editor.removeBlocks([block])} title="Delete question">
+              <Trash2 className="h-3 w-3" /> Delete
+            </HeaderBtn>
+            <HeaderBtn onClick={() => setCollapsed(true)} title="Collapse">
+              <Check className="h-3 w-3" /> Done
+            </HeaderBtn>
           </div>
 
-          <input
-            value={model.question}
-            placeholder="Question / instruction…"
-            onKeyDown={stop}
-            onChange={(e) => update({ ...model, question: e.target.value })}
-            className={`${inputCls} mb-2 font-medium`}
-          />
+          {/* Regenerate with AI bar */}
+          <button
+            type="button"
+            onClick={regenerate}
+            className="mb-2 flex w-full items-center gap-2 rounded-md border border-dashed px-2 py-1.5 text-left text-xs hover:opacity-90"
+            style={{ borderColor: 'color-mix(in oklab, var(--samaritan) 40%, transparent)', background: 'color-mix(in oklab, var(--samaritan) 6%, transparent)' }}
+          >
+            <span className="inline-flex items-center gap-1 font-medium" style={{ color: 'var(--samaritan)' }}>
+              <Sparkles className="h-3.5 w-3.5" /> Regenerate with AI
+            </span>
+            <span className="text-muted-foreground">Drafts the question, items and feedback from the course content and learning objectives.</span>
+          </button>
 
-          {(kind === 'mcq' || kind === 'gmcq') && (
-            <OptionsForm data={model} graphic={kind === 'gmcq'} update={update} />
-          )}
-          {kind === 'matching' && <MatchingForm data={model} update={update} />}
-          {kind === 'reorder' && (
-            <ListForm
-              values={model.items ?? []}
-              placeholder={() => '#Item'}
-              addLabel="Add item"
-              hint="List items in their correct order."
-              onChange={(next) => update({ ...model, items: next })}
-            />
-          )}
-          {kind === 'textInput' && (
-            <ListForm
-              values={model.answers ?? []}
-              placeholder={() => 'Acceptable answer'}
-              addLabel="Add acceptable answer"
-              onChange={(next) => update({ ...model, answers: next })}
-            />
-          )}
-          {kind === 'slider' && <SliderForm data={model} update={update} />}
+          {source ? (
+            <textarea value={JSON.stringify(model, null, 2)} readOnly rows={8} className={`${inputCls} font-mono text-xs`} />
+          ) : (
+            <>
+              {/* Body */}
+              <label className="block">
+                <span className={labelCls}>Body</span>
+                <textarea value={model.question} placeholder="Type the question here" onKeyDown={stop} rows={2} onChange={(e) => update({ ...model, question: e.target.value })} className={`${inputCls} resize-y`} />
+              </label>
 
-          <p className="mt-2 text-xs text-muted-foreground">
-            Advanced settings (feedback, scoring, attempts) are configured in the Page Editor.
-          </p>
+              <Body kind={kind} data={model} update={update} />
+              <FeedbackGroup fb={fb} set={(f) => update({ ...model, feedback: f })} />
+            </>
+          )}
+
+          {/* Footer + readiness */}
+          <div className="mt-2 flex items-center justify-between">
+            <p className="text-sm italic text-muted-foreground">{FOOTER[kind]}</p>
+            {issues.length > 0 && (
+              <span className="inline-flex items-center gap-1 text-xs text-[#92400e]" title={issues.join('\n')}>
+                <AlertTriangle className="h-3.5 w-3.5" /> {issues.length} to fix
+              </span>
+            )}
+          </div>
         </div>
       );
     },

--- a/new-ui-source/src/components/storyboard/blocks/componentBlock.tsx
+++ b/new-ui-source/src/components/storyboard/blocks/componentBlock.tsx
@@ -1,0 +1,679 @@
+// Rich component authoring card (spec AC3). One BlockNote block renders the
+// full inline editor for every non-assessment content type, matching the
+// Lovable design: a common header (type badge, title, Show title, Replace, AI,
+// Source, Delete, Done) + a per-type body + a "Suggested components" footer.
+//
+// Media (image/video/audio) use the real DAM picker (AssetPickerModal) via
+// AssetField — "Select an Asset" browses/uploads course assets, "Select an
+// External Asset" accepts a URL. The chosen asset's course-relative link is
+// persisted into the Adapt graphic/media component fields (see mediaMapping.ts).
+// Data is stored as JSON in the `data` prop (BlockNote props are primitives only).
+
+import { useState } from 'react';
+import {
+  Type,
+  Layers,
+  Image as ImageIcon,
+  Video,
+  AudioLines,
+  Puzzle,
+  ClipboardList,
+  RefreshCw,
+  Sparkles,
+  Code,
+  Trash2,
+  Check,
+  Plus,
+  X,
+  FolderOpen,
+  Link2,
+} from 'lucide-react';
+import { createReactBlockSpec } from '@blocknote/react';
+import { storyboardAi } from '@/api/ai';
+import type { AssetKind } from '@/api/adaptAuthoring';
+import AssetPickerModal from '@/components/common/AssetPickerModal';
+import { emptyMediaData, type AssetRef, type ImageData, type MediaData } from '../mediaMapping';
+
+// ── Kinds + metadata ─────────────────────────────────────────────────────────
+
+export type ComponentKind =
+  | 'text'
+  | 'groupedContent'
+  | 'image'
+  | 'video'
+  | 'audio'
+  | 'h5p'
+  | 'laerdalForm';
+
+export const COMPONENT_KINDS: ComponentKind[] = [
+  'text',
+  'groupedContent',
+  'image',
+  'video',
+  'audio',
+  'h5p',
+  'laerdalForm',
+];
+
+const META: Record<ComponentKind, { badge: string; Icon: typeof Type; comp: string; suggest: ComponentKind[] }> = {
+  text: { badge: 'Text', Icon: Type, comp: 'text', suggest: ['groupedContent', 'image'] },
+  groupedContent: { badge: 'Grouped Content', Icon: Layers, comp: 'text', suggest: ['image', 'text'] },
+  image: { badge: 'Image', Icon: ImageIcon, comp: 'graphic', suggest: ['groupedContent', 'video'] },
+  video: { badge: 'Video', Icon: Video, comp: 'media', suggest: ['audio', 'image'] },
+  audio: { badge: 'Audio', Icon: AudioLines, comp: 'media', suggest: ['video', 'text'] },
+  h5p: { badge: 'H5P', Icon: Puzzle, comp: 'h5p', suggest: ['video', 'groupedContent'] },
+  laerdalForm: { badge: 'Laerdal Form', Icon: ClipboardList, comp: 'text', suggest: ['text'] },
+};
+
+const LABEL_TO_KIND: Record<string, ComponentKind> = Object.fromEntries(
+  COMPONENT_KINDS.map((k) => [META[k].badge, k])
+) as Record<string, ComponentKind>;
+
+// ── Data model ───────────────────────────────────────────────────────────────
+
+interface GroupedItem {
+  title: string;
+  body: string;
+  image: string; // preview URL (grouped content persists as a text component)
+}
+interface FormField {
+  control: string;
+  label: string;
+  placeholder: string;
+  mandatory: boolean;
+}
+interface ComponentData {
+  showTitle: boolean;
+  description: string;
+  instruction: string;
+  items?: GroupedItem[];
+  image?: ImageData; // image card (→ _graphic)
+  media?: MediaData; // video/audio card (→ _media)
+  fields?: FormField[];
+}
+
+const FORM_CONTROLS = ['Single-Line Text', 'Multi-Line Text', 'Number', 'Checkbox', 'Dropdown'];
+
+export function defaultComponentData(kind: ComponentKind): ComponentData {
+  const base: ComponentData = { showTitle: true, description: '', instruction: '' };
+  switch (kind) {
+    case 'groupedContent':
+      return { ...base, items: [{ title: '', body: '', image: '' }, { title: '', body: '', image: '' }] };
+    case 'image':
+      return { ...base, image: { link: '', url: '', alt: '' } };
+    case 'video':
+    case 'audio':
+    case 'h5p':
+      return { ...base, media: emptyMediaData() };
+    case 'laerdalForm':
+      return { ...base, fields: [{ control: 'Single-Line Text', label: 'Your answer', placeholder: 'Type here', mandatory: false }] };
+    default:
+      return base;
+  }
+}
+
+export function makeComponentBlock(kind: ComponentKind) {
+  return {
+    type: 'sbComponent',
+    props: { kind, title: '', adaptComponent: META[kind].comp, data: JSON.stringify(defaultComponentData(kind)) },
+  };
+}
+
+function parseData(kind: ComponentKind, raw: string): ComponentData {
+  try {
+    const p = JSON.parse(raw);
+    if (p && typeof p === 'object') return { ...defaultComponentData(kind), ...p };
+  } catch {
+    /* fall through */
+  }
+  return defaultComponentData(kind);
+}
+
+// ── Presentational helpers ───────────────────────────────────────────────────
+
+const inputCls =
+  'w-full rounded border border-border bg-background px-2 py-1 text-sm text-foreground outline-none focus:border-primary';
+const labelCls = 'mb-0.5 block text-[11px] font-semibold uppercase tracking-wide text-muted-foreground';
+const stop = (e: React.KeyboardEvent) => e.stopPropagation();
+
+function HeaderBtn({ onClick, active, children, title }: { onClick: () => void; active?: boolean; children: React.ReactNode; title?: string }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs hover:bg-muted ${active ? 'border-primary text-primary' : 'text-muted-foreground'}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+// Preview a chosen asset by kind. Prefers the resolvable preview `url`, falling
+// back to the persisted `link` (e.g. an external URL).
+function AssetPreview({ assetType, value }: { assetType: AssetKind; value: AssetRef }) {
+  const src = value.url || value.link || '';
+  if (!src) return null;
+  if (assetType === 'image') return <img src={src} alt="" className="max-h-48 w-full rounded object-contain" />;
+  if (assetType === 'audio') return <audio src={src} controls className="w-full" />;
+  return <video src={src} controls className="max-h-64 w-full rounded" />;
+}
+
+// The Lovable asset field: "Select an Asset" (DAM picker) / "Select an External
+// Asset" (URL) when empty; asset preview + path + Change/Remove when set.
+function AssetField({
+  assetType,
+  value,
+  onChange,
+}: {
+  assetType: AssetKind;
+  value?: AssetRef;
+  onChange: (next: AssetRef | undefined) => void;
+}) {
+  const [picking, setPicking] = useState(false);
+  const [external, setExternal] = useState(false);
+  const [url, setUrl] = useState('');
+  const has = !!(value && (value.link || value.url));
+
+  const applyExternal = () => {
+    const trimmed = url.trim();
+    if (!trimmed) return;
+    onChange({ link: trimmed, url: trimmed, external: true });
+    setExternal(false);
+    setUrl('');
+  };
+
+  return (
+    <div className="rounded-md border border-border p-3">
+      {has ? (
+        <div>
+          <AssetPreview assetType={assetType} value={value as AssetRef} />
+          <div className="mt-2 flex items-center gap-2">
+            <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground" title={value?.link}>
+              {value?.link}
+            </span>
+            <button type="button" onClick={() => setPicking(true)} className="rounded border border-primary px-2 py-0.5 text-xs text-primary hover:bg-primary/5">
+              Change
+            </button>
+            <button type="button" onClick={() => onChange(undefined)} className="rounded border border-red-500 px-2 py-0.5 text-xs text-red-600 hover:bg-red-50">
+              Remove
+            </button>
+          </div>
+        </div>
+      ) : external ? (
+        <div className="flex items-center gap-2">
+          <input
+            autoFocus
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            onKeyDown={(e) => {
+              e.stopPropagation();
+              if (e.key === 'Enter') applyExternal();
+            }}
+            placeholder="https://… (or YouTube / Vimeo link)"
+            className={inputCls}
+          />
+          <button type="button" onClick={applyExternal} className="rounded bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground">
+            Add
+          </button>
+          <button type="button" onClick={() => setExternal(false)} className="text-xs text-muted-foreground hover:text-foreground">
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => setPicking(true)}
+            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90"
+          >
+            <FolderOpen className="h-3.5 w-3.5" /> Select an Asset
+          </button>
+          <button
+            type="button"
+            onClick={() => setExternal(true)}
+            className="inline-flex items-center gap-1.5 rounded-md border border-primary px-3 py-1.5 text-sm font-medium text-primary hover:bg-primary/5"
+          >
+            <Link2 className="h-3.5 w-3.5" /> Select an External Asset
+          </button>
+        </div>
+      )}
+
+      {picking && (
+        <AssetPickerModal
+          assetType={assetType}
+          onClose={() => setPicking(false)}
+          onSelect={(asset) => {
+            onChange({ assetId: asset.id, link: asset.assetLink, url: asset.url, external: false });
+            setPicking(false);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Per-kind bodies ──────────────────────────────────────────────────────────
+
+function TranscriptFields({ kind, media, set }: { kind: 'video' | 'audio'; media: MediaData; set: (m: MediaData) => void }) {
+  const field = (key: keyof MediaData, label: string, ph: string) => (
+    <label className="block">
+      <span className={labelCls}>{label}</span>
+      <input value={(media[key] as string) || ''} placeholder={ph} onKeyDown={stop} onChange={(e) => set({ ...media, [key]: e.target.value })} className={inputCls} />
+    </label>
+  );
+  return (
+    <div className="space-y-2">
+      <div>
+        <span className={labelCls}>{kind === 'audio' ? 'Audio' : 'Video'} source</span>
+        <AssetField assetType={kind} value={media.asset} onChange={(a) => set({ ...media, asset: a })} />
+      </div>
+      {kind === 'video' && (
+        <div>
+          <span className={labelCls}>Poster image</span>
+          <AssetField assetType="image" value={media.poster} onChange={(a) => set({ ...media, poster: a })} />
+        </div>
+      )}
+      <div className="rounded border border-border p-2">
+        <div className={labelCls}>Transcript, captions &amp; chapters</div>
+        {field('transcriptSource', 'Transcript source', 'https://… .vtt / .txt')}
+        <label className="mt-1 block">
+          <span className={labelCls}>Transcript text (in the storyboard)</span>
+          <textarea value={media.transcriptText} onKeyDown={stop} onChange={(e) => set({ ...media, transcriptText: e.target.value })} rows={2} placeholder="Paste or write the transcript here" className={`${inputCls} resize-y`} />
+        </label>
+        {field('captionsSource', 'Captions source', 'https://… .vtt')}
+        {field('descriptionsSource', 'Descriptions source', 'https://… .vtt')}
+        {field('chaptersSource', 'Chapters source', 'https://… .vtt')}
+      </div>
+    </div>
+  );
+}
+
+function ComponentBody({ kind, data, set }: { kind: ComponentKind; data: ComponentData; set: (d: ComponentData) => void }) {
+  if (kind === 'text') {
+    return (
+      <div>
+        <span className={labelCls}>Description</span>
+        <textarea value={data.description} onKeyDown={stop} onChange={(e) => set({ ...data, description: e.target.value })} rows={2} placeholder="New component content…" className={`${inputCls} resize-y`} />
+      </div>
+    );
+  }
+
+  if (kind === 'groupedContent') {
+    const items = data.items ?? [];
+    const setItems = (n: GroupedItem[]) => set({ ...data, items: n });
+    return (
+      <div className="space-y-2">
+        <p className="text-sm italic text-muted-foreground">Select each heading to find out more.</p>
+        {items.map((it, i) => (
+          <div key={i} className="rounded border border-border p-2">
+            <div className="mb-1 flex items-center justify-between">
+              <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Item {i + 1} of {items.length}</span>
+              <button type="button" aria-label="Remove item" onClick={() => setItems(items.filter((_, j) => j !== i))} className="text-muted-foreground hover:text-foreground">
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            </div>
+            <input value={it.title} placeholder="Item title" onKeyDown={stop} onChange={(e) => setItems(items.map((x, j) => (j === i ? { ...x, title: e.target.value } : x)))} className={`${inputCls} mb-1`} />
+            <textarea value={it.body} placeholder="Item body — what should the learner read here?" onKeyDown={stop} rows={2} onChange={(e) => setItems(items.map((x, j) => (j === i ? { ...x, body: e.target.value } : x)))} className={`${inputCls} mb-1 resize-y`} />
+            <AssetField
+              assetType="image"
+              value={it.image ? { link: it.image, url: it.image } : undefined}
+              onChange={(a) => setItems(items.map((x, j) => (j === i ? { ...x, image: a?.url || a?.link || '' } : x)))}
+            />
+          </div>
+        ))}
+        <button type="button" onClick={() => setItems([...items, { title: '', body: '', image: '' }])} className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline">
+          <Plus className="h-3 w-3" /> Add item
+        </button>
+      </div>
+    );
+  }
+
+  if (kind === 'image') {
+    const image = data.image ?? { link: '', url: '', alt: '' };
+    return (
+      <div className="space-y-2">
+        <AssetField
+          assetType="image"
+          value={image.link || image.url ? image : undefined}
+          onChange={(a) => set({ ...data, image: { ...(a ?? { link: '', url: '' }), alt: image.alt } })}
+        />
+        <label className="block">
+          <span className={labelCls}>Alternative text</span>
+          <input value={image.alt} placeholder="Describe the image for screen readers" onKeyDown={stop} onChange={(e) => set({ ...data, image: { ...image, alt: e.target.value } })} className={inputCls} />
+        </label>
+      </div>
+    );
+  }
+
+  if (kind === 'video' || kind === 'audio') {
+    const media = data.media ?? emptyMediaData();
+    return <TranscriptFields kind={kind} media={media} set={(m) => set({ ...data, media: m })} />;
+  }
+
+  if (kind === 'h5p') {
+    return (
+      <div>
+        <span className={labelCls}>H5P source</span>
+        <AssetField assetType="video" value={data.media?.asset} onChange={(a) => set({ ...data, media: { ...(data.media ?? emptyMediaData()), asset: a } })} />
+      </div>
+    );
+  }
+
+  if (kind === 'laerdalForm') {
+    const fields = data.fields ?? [];
+    const setFields = (n: FormField[]) => set({ ...data, fields: n });
+    return (
+      <div className="space-y-2">
+        {fields.map((f, i) => (
+          <div key={i} className="rounded border border-border p-2">
+            <div className="mb-1 flex items-center justify-between">
+              <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Field {i + 1}/{fields.length}</span>
+              <button type="button" aria-label="Remove field" onClick={() => setFields(fields.filter((_, j) => j !== i))} className="text-muted-foreground hover:text-foreground">
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            </div>
+            <label className="block">
+              <span className={labelCls}>Form control</span>
+              <select value={f.control} onChange={(e) => setFields(fields.map((x, j) => (j === i ? { ...x, control: e.target.value } : x)))} className={inputCls}>
+                {FORM_CONTROLS.map((c) => (
+                  <option key={c}>{c}</option>
+                ))}
+              </select>
+            </label>
+            <label className="mt-1 block">
+              <span className={labelCls}>Label</span>
+              <input value={f.label} onKeyDown={stop} onChange={(e) => setFields(fields.map((x, j) => (j === i ? { ...x, label: e.target.value } : x)))} className={inputCls} />
+            </label>
+            <label className="mt-1 block">
+              <span className={labelCls}>Placeholder</span>
+              <input value={f.placeholder} onKeyDown={stop} onChange={(e) => setFields(fields.map((x, j) => (j === i ? { ...x, placeholder: e.target.value } : x)))} className={inputCls} />
+            </label>
+            <label className="mt-1 flex items-center gap-1.5 text-sm text-foreground">
+              <input type="checkbox" checked={f.mandatory} onChange={(e) => setFields(fields.map((x, j) => (j === i ? { ...x, mandatory: e.target.checked } : x)))} className="h-4 w-4 accent-[color:var(--primary)]" />
+              Is mandatory
+            </label>
+          </div>
+        ))}
+        <button type="button" onClick={() => setFields([...fields, { control: 'Single-Line Text', label: '', placeholder: '', mandatory: false }])} className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline">
+          <Plus className="h-3 w-3" /> Add form control
+        </button>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+// ── Read-only preview (the "Done"/collapsed state) ───────────────────────────
+// Matches the Lovable design: the finished card renders as it would read in the
+// course (image full-width, grouped content as heading + body + thumbnail rows,
+// media as a player, form as its controls) rather than a bare summary strip.
+
+function PreviewImage({ src, alt, className }: { src: string; alt: string; className?: string }) {
+  if (!src) {
+    return (
+      <div className={`flex items-center justify-center rounded-lg border border-dashed border-border bg-muted/40 text-xs text-muted-foreground ${className ?? 'h-40'}`}>
+        <ImageIcon className="mr-1.5 h-4 w-4" /> No image source
+      </div>
+    );
+  }
+  return <img src={src} alt={alt} className={`rounded-lg object-cover ${className ?? 'w-full'}`} />;
+}
+
+function MediaPlaceholder({ Icon, label }: { Icon: typeof Type; label: string }) {
+  return (
+    <div className="flex h-40 items-center justify-center rounded-lg border border-dashed border-border bg-muted/40 text-xs text-muted-foreground">
+      <Icon className="mr-1.5 h-4 w-4" /> {label}
+    </div>
+  );
+}
+
+function ComponentPreview({ kind, title, data }: { kind: ComponentKind; title: string; data: ComponentData }) {
+  const heading = data.showTitle && title ? <h4 className="mb-2 text-base font-semibold text-foreground">{title}</h4> : null;
+  const instruction = data.instruction ? <p className="mt-2 text-sm italic text-muted-foreground">{data.instruction}</p> : null;
+
+  if (kind === 'text') {
+    return (
+      <div>
+        {heading}
+        {data.description ? (
+          <p className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">{data.description}</p>
+        ) : (
+          <p className="text-sm italic text-muted-foreground">No content yet — click Edit to add some.</p>
+        )}
+        {instruction}
+      </div>
+    );
+  }
+
+  if (kind === 'groupedContent') {
+    const items = data.items ?? [];
+    return (
+      <div>
+        {heading}
+        <p className="mb-4 text-sm italic text-muted-foreground">Select each heading to find out more.</p>
+        <div className="space-y-5">
+          {items.map((it, i) => (
+            <div key={i} className="flex items-start justify-between gap-4">
+              <div className="min-w-0 flex-1">
+                <div className="font-semibold text-foreground">{it.title || `Item ${i + 1}`}</div>
+                {it.body && <div className="mt-0.5 whitespace-pre-wrap text-sm text-foreground">{it.body}</div>}
+              </div>
+              {it.image && <img src={it.image} alt="" className="h-20 w-32 shrink-0 rounded-md object-cover" />}
+            </div>
+          ))}
+        </div>
+        {instruction}
+      </div>
+    );
+  }
+
+  if (kind === 'image') {
+    const img = data.image;
+    const src = img?.url || img?.link || '';
+    return (
+      <div className="space-y-3">
+        {heading}
+        <PreviewImage src={src} alt={img?.alt || ''} />
+        {instruction}
+      </div>
+    );
+  }
+
+  if (kind === 'video') {
+    const src = data.media?.asset?.url || data.media?.asset?.link || '';
+    const poster = data.media?.poster?.url || data.media?.poster?.link || undefined;
+    return (
+      <div>
+        {heading}
+        {src ? (
+          <video src={src} poster={poster} controls className="w-full rounded-lg" />
+        ) : (
+          <MediaPlaceholder Icon={Video} label="No video source" />
+        )}
+        {instruction}
+      </div>
+    );
+  }
+
+  if (kind === 'audio') {
+    const src = data.media?.asset?.url || data.media?.asset?.link || '';
+    return (
+      <div>
+        {heading}
+        {src ? <audio src={src} controls className="w-full" /> : <MediaPlaceholder Icon={AudioLines} label="No audio source" />}
+        {instruction}
+      </div>
+    );
+  }
+
+  if (kind === 'h5p') {
+    return (
+      <div>
+        {heading}
+        <MediaPlaceholder Icon={Puzzle} label="H5P interactive content" />
+        {instruction}
+      </div>
+    );
+  }
+
+  if (kind === 'laerdalForm') {
+    const fields = data.fields ?? [];
+    return (
+      <div>
+        {heading}
+        <div className="space-y-3">
+          {fields.map((f, i) => (
+            <label key={i} className="block">
+              <span className="mb-0.5 block text-sm font-medium text-foreground">
+                {f.label || `Field ${i + 1}`}
+                {f.mandatory && <span className="ml-0.5 text-red-600">*</span>}
+              </span>
+              {f.control === 'Multi-Line Text' ? (
+                <textarea disabled placeholder={f.placeholder} rows={2} className={`${inputCls} resize-none bg-muted/40`} />
+              ) : f.control === 'Dropdown' ? (
+                <select disabled className={`${inputCls} bg-muted/40`}>
+                  <option>{f.placeholder || 'Select…'}</option>
+                </select>
+              ) : f.control === 'Checkbox' ? (
+                <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                  <input type="checkbox" disabled className="h-4 w-4" /> {f.placeholder}
+                </span>
+              ) : (
+                <input disabled type={f.control === 'Number' ? 'number' : 'text'} placeholder={f.placeholder} className={`${inputCls} bg-muted/40`} />
+              )}
+            </label>
+          ))}
+        </div>
+        {instruction}
+      </div>
+    );
+  }
+
+  return null;
+}
+
+// ── The block ────────────────────────────────────────────────────────────────
+
+export const componentBlock = createReactBlockSpec(
+  {
+    type: 'sbComponent',
+    propSchema: {
+      kind: { default: 'text', values: COMPONENT_KINDS },
+      title: { default: '' },
+      adaptComponent: { default: 'text' },
+      data: { default: '{}' },
+    },
+    content: 'none',
+  },
+  {
+    render: ({ block, editor }) => {
+      const kind = (COMPONENT_KINDS.includes(block.props.kind as ComponentKind) ? block.props.kind : 'text') as ComponentKind;
+      const meta = META[kind];
+      const [model, setModel] = useState<ComponentData>(() => parseData(kind, block.props.data as string));
+      const [collapsed, setCollapsed] = useState(false);
+      const [source, setSource] = useState(false);
+      const [dismissed, setDismissed] = useState(false);
+      const title = block.props.title as string;
+
+      const setData = (next: ComponentData) => {
+        setModel(next);
+        editor.updateBlock(block, { props: { data: JSON.stringify(next) } });
+      };
+      const setTitle = (t: string) => editor.updateBlock(block, { props: { title: t } });
+
+      const aiImprove = async () => {
+        const text = model.description || (model.items || []).map((i) => i.body).join('\n');
+        if (!text.trim()) return;
+        try {
+          const result = (await storyboardAi('improve', text)).trim();
+          if (result) setData({ ...model, description: result });
+        } catch {
+          /* surfaced elsewhere */
+        }
+      };
+
+      const insertSuggestion = (k: ComponentKind) => {
+        editor.insertBlocks([makeComponentBlock(k) as never], block, 'after');
+      };
+
+      if (collapsed) {
+        return (
+          <div className="group relative my-2 rounded-lg px-1 py-2 hover:bg-muted/20" contentEditable={false}>
+            <ComponentPreview kind={kind} title={title} data={model} />
+            <button
+              type="button"
+              onClick={() => setCollapsed(false)}
+              className="absolute right-1 top-1 inline-flex items-center gap-1 rounded-full border bg-background px-2 py-0.5 text-xs text-muted-foreground opacity-0 shadow-sm transition-opacity hover:bg-muted group-hover:opacity-100"
+            >
+              <RefreshCw className="h-3 w-3" /> Edit
+            </button>
+          </div>
+        );
+      }
+
+      return (
+        <div className="my-2 rounded-lg border p-3" contentEditable={false}>
+          {/* Header */}
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            <span className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+              <meta.Icon className="h-3 w-3" /> {meta.badge}
+            </span>
+            <input value={title} placeholder={`${meta.badge} title`} onKeyDown={stop} onChange={(e) => setTitle(e.target.value)} className="min-w-0 flex-1 border-0 bg-transparent text-sm font-medium text-foreground outline-none placeholder:text-muted-foreground" />
+            <HeaderBtn onClick={() => setData({ ...model, showTitle: !model.showTitle })} active={model.showTitle} title="Show the title to learners">
+              <Check className="h-3 w-3" /> Show title
+            </HeaderBtn>
+            <HeaderBtn onClick={() => {}} title="Change type in the Page Editor">
+              <RefreshCw className="h-3 w-3" /> Replace
+            </HeaderBtn>
+            <HeaderBtn onClick={aiImprove} title="Improve with AI">
+              <Sparkles className="h-3 w-3" /> AI
+            </HeaderBtn>
+            <HeaderBtn onClick={() => setSource((s) => !s)} active={source} title="Toggle source view">
+              <Code className="h-3 w-3" /> Source
+            </HeaderBtn>
+            <HeaderBtn onClick={() => editor.removeBlocks([block])} title="Delete component">
+              <Trash2 className="h-3 w-3" /> Delete
+            </HeaderBtn>
+            <HeaderBtn onClick={() => setCollapsed(true)} title="Collapse">
+              <Check className="h-3 w-3" /> Done
+            </HeaderBtn>
+          </div>
+
+          {/* Body */}
+          {source ? (
+            <textarea value={JSON.stringify(model, null, 2)} readOnly rows={6} className={`${inputCls} font-mono text-xs`} />
+          ) : (
+            <ComponentBody kind={kind} data={model} set={setData} />
+          )}
+
+          {/* Instruction */}
+          <label className="mt-2 block">
+            <span className={labelCls}>Instruction text (optional)</span>
+            <input value={model.instruction} placeholder="e.g. Watch the video before continuing." onKeyDown={stop} onChange={(e) => setData({ ...model, instruction: e.target.value })} className={inputCls} />
+          </label>
+
+          {/* Suggested components */}
+          {!dismissed && (
+            <div className="mt-2 flex items-center gap-2 rounded-md border border-dashed border-samaritan/30 bg-samaritan/5 px-2 py-1.5 text-xs">
+              <span className="inline-flex items-center gap-1 font-medium" style={{ color: 'var(--samaritan)' }}>
+                <Sparkles className="h-3 w-3" /> Suggested
+              </span>
+              {meta.suggest.map((k) => (
+                <button key={k} type="button" onClick={() => insertSuggestion(k)} className="rounded-full border px-2 py-0.5 hover:bg-muted">
+                  {META[k].badge}
+                </button>
+              ))}
+              <button type="button" onClick={() => setDismissed(true)} className="ml-auto text-muted-foreground hover:text-foreground">
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          )}
+        </div>
+      );
+    },
+  }
+);
+
+export { LABEL_TO_KIND };

--- a/new-ui-source/src/components/storyboard/blocks/componentBlock.tsx
+++ b/new-ui-source/src/components/storyboard/blocks/componentBlock.tsx
@@ -27,12 +27,32 @@ import {
   X,
   FolderOpen,
   Link2,
+  MessageSquare,
 } from 'lucide-react';
 import { createReactBlockSpec } from '@blocknote/react';
-import { storyboardAi } from '@/api/ai';
+import { storyboardActions } from '../storyboardActions';
 import type { AssetKind } from '@/api/adaptAuthoring';
 import AssetPickerModal from '@/components/common/AssetPickerModal';
-import { emptyMediaData, type AssetRef, type ImageData, type MediaData } from '../mediaMapping';
+import { emptyMediaData, toEmbedUrl, type AssetRef, type ImageData, type MediaData } from '../mediaMapping';
+
+// YouTube/Vimeo → iframe embed; direct file URLs → <video>. Matches Lovable.
+function VideoView({ src, poster, className }: { src: string; poster?: string; className?: string }) {
+  const embed = toEmbedUrl(src);
+  if (embed) {
+    return (
+      <div className={`aspect-video w-full overflow-hidden rounded ${className ?? ''}`}>
+        <iframe
+          src={embed}
+          title="Video"
+          className="h-full w-full"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"
+          allowFullScreen
+        />
+      </div>
+    );
+  }
+  return <video src={src} poster={poster || undefined} controls className={className ?? 'w-full rounded'} />;
+}
 
 // ── Kinds + metadata ─────────────────────────────────────────────────────────
 
@@ -74,7 +94,9 @@ const LABEL_TO_KIND: Record<string, ComponentKind> = Object.fromEntries(
 interface GroupedItem {
   title: string;
   body: string;
-  image: string; // preview URL (grouped content persists as a text component)
+  image: string; // PERSISTED value → `_graphic.src` (course/assets/<file> or external URL)
+  imageUrl?: string; // servable preview URL (/api/asset/serve/<id>); not persisted verbatim
+  imageAssetId?: string; // DAM asset id, for the courseasset publish link
 }
 interface FormField {
   control: string;
@@ -112,12 +134,18 @@ export function defaultComponentData(kind: ComponentKind): ComponentData {
   }
 }
 
-export function makeComponentBlock(kind: ComponentKind) {
+export function makeComponentBlock(
+  kind: ComponentKind,
+  opts?: { title?: string; data?: Partial<ComponentData> }
+) {
+  const data = { ...defaultComponentData(kind), ...(opts?.data as Partial<ComponentData>) };
   return {
     type: 'sbComponent',
-    props: { kind, title: '', adaptComponent: META[kind].comp, data: JSON.stringify(defaultComponentData(kind)) },
+    props: { kind, title: opts?.title ?? '', adaptComponent: META[kind].comp, data: JSON.stringify(data) },
   };
 }
+
+export const isComponentKind = (k: string): k is ComponentKind => (COMPONENT_KINDS as string[]).includes(k);
 
 function parseData(kind: ComponentKind, raw: string): ComponentData {
   try {
@@ -156,7 +184,7 @@ function AssetPreview({ assetType, value }: { assetType: AssetKind; value: Asset
   if (!src) return null;
   if (assetType === 'image') return <img src={src} alt="" className="max-h-48 w-full rounded object-contain" />;
   if (assetType === 'audio') return <audio src={src} controls className="w-full" />;
-  return <video src={src} controls className="max-h-64 w-full rounded" />;
+  return <VideoView src={src} className="max-h-64 w-full rounded" />;
 }
 
 // The Lovable asset field: "Select an Asset" (DAM picker) / "Select an External
@@ -317,8 +345,20 @@ function ComponentBody({ kind, data, set }: { kind: ComponentKind; data: Compone
             <textarea value={it.body} placeholder="Item body — what should the learner read here?" onKeyDown={stop} rows={2} onChange={(e) => setItems(items.map((x, j) => (j === i ? { ...x, body: e.target.value } : x)))} className={`${inputCls} mb-1 resize-y`} />
             <AssetField
               assetType="image"
-              value={it.image ? { link: it.image, url: it.image } : undefined}
-              onChange={(a) => setItems(items.map((x, j) => (j === i ? { ...x, image: a?.url || a?.link || '' } : x)))}
+              value={
+                it.image || it.imageUrl
+                  ? { link: it.image, url: it.imageUrl || it.image, assetId: it.imageAssetId }
+                  : undefined
+              }
+              onChange={(a) =>
+                setItems(
+                  items.map((x, j) =>
+                    j === i
+                      ? { ...x, image: a?.link || '', imageUrl: a?.url || '', imageAssetId: a?.assetId }
+                      : x
+                  )
+                )
+              }
             />
           </div>
         ))}
@@ -460,7 +500,7 @@ function ComponentPreview({ kind, title, data }: { kind: ComponentKind; title: s
                 <div className="font-semibold text-foreground">{it.title || `Item ${i + 1}`}</div>
                 {it.body && <div className="mt-0.5 whitespace-pre-wrap text-sm text-foreground">{it.body}</div>}
               </div>
-              {it.image && <img src={it.image} alt="" className="h-20 w-32 shrink-0 rounded-md object-cover" />}
+              {(it.imageUrl || it.image) && <img src={it.imageUrl || it.image} alt="" className="h-20 w-32 shrink-0 rounded-md object-cover" />}
             </div>
           ))}
         </div>
@@ -488,7 +528,7 @@ function ComponentPreview({ kind, title, data }: { kind: ComponentKind; title: s
       <div>
         {heading}
         {src ? (
-          <video src={src} poster={poster} controls className="w-full rounded-lg" />
+          <VideoView src={src} poster={poster} className="w-full rounded-lg" />
         ) : (
           <MediaPlaceholder Icon={Video} label="No video source" />
         )}
@@ -583,15 +623,22 @@ export const componentBlock = createReactBlockSpec(
       };
       const setTitle = (t: string) => editor.updateBlock(block, { props: { title: t } });
 
-      const aiImprove = async () => {
-        const text = model.description || (model.items || []).map((i) => i.body).join('\n');
-        if (!text.trim()) return;
-        try {
-          const result = (await storyboardAi('improve', text)).trim();
-          if (result) setData({ ...model, description: result });
-        } catch {
-          /* surfaced elsewhere */
-        }
+      // AI is an ACTION: open the Samaritan popup seeded with this card's text.
+      // Both Apply modes stay INSIDE this component (no new component is
+      // created): Replace overwrites the content, Insert appends to it.
+      const openAi = () => {
+        storyboardActions.openAi({
+          initialText: model.description || (model.items || []).map((i) => i.body).join('\n'),
+          onReplace: (text) => setData({ ...model, description: text }),
+          onInsert: (text) =>
+            setData({ ...model, description: model.description ? `${model.description}\n\n${text}` : text }),
+        });
+      };
+
+      // Comment is an ACTION attached to this component's block id (uses the
+      // storyboardcomment backend; does NOT touch the course structure).
+      const openComment = () => {
+        storyboardActions.openComment({ blockId: block.id, label: `CONTENT · ${meta.badge.toUpperCase()}` });
       };
 
       const insertSuggestion = (k: ComponentKind) => {
@@ -627,11 +674,14 @@ export const componentBlock = createReactBlockSpec(
             <HeaderBtn onClick={() => {}} title="Change type in the Page Editor">
               <RefreshCw className="h-3 w-3" /> Replace
             </HeaderBtn>
-            <HeaderBtn onClick={aiImprove} title="Improve with AI">
+            <HeaderBtn onClick={openAi} title="AI Assistance">
               <Sparkles className="h-3 w-3" /> AI
             </HeaderBtn>
             <HeaderBtn onClick={() => setSource((s) => !s)} active={source} title="Toggle source view">
               <Code className="h-3 w-3" /> Source
+            </HeaderBtn>
+            <HeaderBtn onClick={openComment} title="Comment on this component">
+              <MessageSquare className="h-3 w-3" /> Comment
             </HeaderBtn>
             <HeaderBtn onClick={() => editor.removeBlocks([block])} title="Delete component">
               <Trash2 className="h-3 w-3" /> Delete

--- a/new-ui-source/src/components/storyboard/blocks/placeholderBlock.tsx
+++ b/new-ui-source/src/components/storyboard/blocks/placeholderBlock.tsx
@@ -1,0 +1,66 @@
+// Custom BlockNote block: storyboard content placeholder (spec AC5/AC6).
+//
+// One block type covers every non-native content kind — grouped content,
+// media (H5P), survey (Laerdal Form), assessment (MCQ/GMCQ/…), interactive
+// placeholders (Hot Graphic/Grid/Action Plan) and instructions. It captures
+// only the metadata the course generator needs (label + category +
+// `adaptComponent`); detailed configuration is deferred to the Page Editor.
+
+import { createReactBlockSpec } from '@blocknote/react';
+import type { PlaceholderCategory } from '@/types/storyboard';
+
+const CATEGORY_STYLE: Record<PlaceholderCategory, { tag: string; className: string }> = {
+  group: { tag: 'Group', className: 'border-[color:var(--muted-foreground)]/40 bg-muted/40' },
+  media: { tag: 'Media', className: 'border-primary/40 bg-primary/5' },
+  survey: { tag: 'Survey', className: 'border-samaritan/40 bg-samaritan/5' },
+  assessment: { tag: 'Assessment', className: 'border-primary/50 bg-primary/5' },
+  interactive: { tag: 'Interactive', className: 'border-primary/50 bg-primary/5' },
+  instruction: { tag: 'Instruction', className: 'border-samaritan/40 bg-samaritan/5' },
+};
+
+export const placeholderBlock = createReactBlockSpec(
+  {
+    type: 'sbPlaceholder',
+    propSchema: {
+      label: { default: 'Content' },
+      category: {
+        default: 'group',
+        values: ['group', 'media', 'survey', 'assessment', 'interactive', 'instruction'],
+      },
+      title: { default: '' },
+      // Adapt component this generates into (AC11) — kept on the block so the
+      // generator never has to map kind → component itself.
+      adaptComponent: { default: 'block' },
+    },
+    content: 'none',
+  },
+  {
+    render: ({ block, editor }) => {
+      const category = block.props.category as PlaceholderCategory;
+      const style = CATEGORY_STYLE[category] ?? CATEGORY_STYLE.group;
+      const label = block.props.label as string;
+
+      const setTitle = (title: string) => editor.updateBlock(block, { props: { title } });
+
+      return (
+        <div className={`my-2 rounded-md border border-dashed p-3 ${style.className}`} contentEditable={false}>
+          <div className="flex items-center gap-2">
+            <span className="rounded bg-foreground/80 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-background">
+              {style.tag}
+            </span>
+            <span className="text-sm font-medium text-foreground">{label}</span>
+          </div>
+          <input
+            value={block.props.title as string}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder={`${label} title…`}
+            className="mt-2 w-full border-0 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+          />
+          <p className="mt-1 text-xs text-muted-foreground">
+            Placeholder → <code>{block.props.adaptComponent as string}</code>. Configure in the Page Editor.
+          </p>
+        </div>
+      );
+    },
+  }
+);

--- a/new-ui-source/src/components/storyboard/index.ts
+++ b/new-ui-source/src/components/storyboard/index.ts
@@ -1,0 +1,4 @@
+// Barrel export for the storyboard feature (ADAPT-3760).
+
+export { BlockNoteStoryboardEditor } from './BlockNoteStoryboardEditor';
+export { default as StoryboardWorkspace } from './StoryboardWorkspace';

--- a/new-ui-source/src/components/storyboard/mediaMapping.ts
+++ b/new-ui-source/src/components/storyboard/mediaMapping.ts
@@ -75,10 +75,54 @@ export function detectMediaType(link?: string): string {
   return "";
 }
 
+// A YouTube/Vimeo watch/link URL → an embeddable iframe URL (a <video> tag
+// cannot play watch-page URLs). Returns null for direct file URLs. Mirrors the
+// Lovable VideoPlayer behaviour.
+export function toEmbedUrl(raw?: string): string | null {
+  const url = (raw || "").trim();
+  if (!url) return null;
+  const yt = url.match(
+    /(?:youtube\.com\/(?:watch\?(?:.*&)?v=|embed\/|shorts\/|live\/)|youtu\.be\/)([\w-]{6,})/i
+  );
+  if (yt) return `https://www.youtube.com/embed/${yt[1]}`;
+  const vm = url.match(/vimeo\.com\/(?:video\/)?(\d+)/i);
+  if (vm) return `https://player.vimeo.com/video/${vm[1]}`;
+  return null;
+}
+
+// ── properties nesting ───────────────────────────────────────────────────────
+// Plugin-specific component attributes (`_graphic`, `_media`, `_items`,
+// `_feedback`, …) are NOT top-level fields on an Adapt authoring `component`
+// document — they live under a single `properties` object (see
+// plugins/content/component/model.schema). Writing them at the top level makes
+// the content model silently drop them. This helper merges a raw field patch
+// (e.g. `{_graphic: {...}}`) into `target.properties`, preserving any fields
+// already staged there (so title/_layout stay top-level and multiple plugin
+// fields accumulate under properties).
+export function mergeProperties(target: Record<string, unknown>, fields: Record<string, unknown>): void {
+  if (!fields || !Object.keys(fields).length) return;
+  const existing = (target.properties as Record<string, unknown> | undefined) || {};
+  target.properties = { ...existing, ...fields };
+}
+
 // ── Card data → Adapt component fields ───────────────────────────────────────
 
-// Image card → `_graphic` patch. Adapt's graphic component holds a single image
-// in `large` (desktop) + `small` (mobile); we set both to the same source.
+// The Laerdal Media Component (`laerdal-media`) backs BOTH image and video/audio
+// (spec: no generic components). Its `_media` object is the single asset store.
+export const LAERDAL_MEDIA_COMPONENT = "laerdal-media";
+
+function emptyMediaObject(): Record<string, unknown> {
+  return { mp4: "", ogv: "", webm: "", mp3: "", source: "", type: "", poster: "" };
+}
+
+// Image card → `laerdal-media` `_media` patch: the image is the poster (the only
+// image asset field on the media component).
+export function buildImageAsMedia(image?: ImageData): { _media: Record<string, unknown>; title?: string } {
+  const link = image?.link || "";
+  return { _media: { ...emptyMediaObject(), poster: link } };
+}
+
+// Image card → `_graphic` patch (legacy adapt-contrib-graphic fallback).
 export function buildGraphicField(image?: ImageData): { _graphic: Record<string, unknown> } {
   const link = image?.link || "";
   return { _graphic: { large: link, small: link, alt: image?.alt || "" } };
@@ -135,6 +179,29 @@ export function imageFromGraphic(graphic: GraphicShape | undefined, idByFilename
     link,
     url: resolveAssetUrl(link, idByFilename),
     alt: (graphic && graphic.alt) || "",
+    external: !!link && !isCourseAssetLink(link),
+  };
+}
+
+// A laerdal-media component with only a poster (no video/audio/source) is an
+// image; anything with a playable source is video/audio.
+export function classifyLaerdalMedia(media: MediaShape | undefined): "image" | "video" | "audio" {
+  const m = media || {};
+  const hasVideo = !!(m.mp4 || m.webm || m.ogv);
+  const hasAudio = !!m.mp3;
+  const hasSource = !!m.source;
+  if (!hasVideo && !hasAudio && !hasSource && m.poster) return "image";
+  if (hasAudio && !hasVideo && !hasSource) return "audio";
+  return "video";
+}
+
+// laerdal-media poster → image card data.
+export function imageFromMediaPoster(media: MediaShape | undefined, idByFilename: Record<string, string>): ImageData {
+  const link = (media && media.poster) || "";
+  return {
+    link,
+    url: resolveAssetUrl(link, idByFilename),
+    alt: "",
     external: !!link && !isCourseAssetLink(link),
   };
 }

--- a/new-ui-source/src/components/storyboard/mediaMapping.ts
+++ b/new-ui-source/src/components/storyboard/mediaMapping.ts
@@ -1,0 +1,160 @@
+// Shared media/asset mapping for storyboard component cards (ADAPT-3760).
+//
+// This module has NO React/BlockNote dependency so it can be imported by both
+// the editor card (componentBlock.tsx) and the persistence layer
+// (api/adaptAuthoring.ts, api/storyboardGeneration.ts). It is the single source
+// of truth for how a card's chosen asset maps to Adapt's `_graphic` / `_media`
+// component fields and back.
+
+// A selected asset. `link` is what persists into course data
+// (`course/assets/<filename>` for DAM assets, or an external URL). `url` is a
+// directly-loadable preview URL (`/api/asset/serve/<id>` or the external URL).
+export interface AssetRef {
+  assetId?: string; // DAM asset _id ("" / undefined for external)
+  link?: string; // persisted value (course/assets/<filename> OR external URL)
+  url?: string; // preview URL
+  external?: boolean;
+}
+
+export interface ImageData extends AssetRef {
+  alt: string;
+}
+
+export interface MediaData {
+  asset?: AssetRef; // main video/audio source
+  poster?: AssetRef; // video poster image
+  transcriptSource: string;
+  transcriptText: string;
+  captionsSource: string;
+  descriptionsSource: string;
+  chaptersSource: string;
+}
+
+export function emptyMediaData(): MediaData {
+  return {
+    asset: undefined,
+    poster: undefined,
+    transcriptSource: "",
+    transcriptText: "",
+    captionsSource: "",
+    descriptionsSource: "",
+    chaptersSource: "",
+  };
+}
+
+// ── Asset-link helpers ───────────────────────────────────────────────────────
+
+const COURSE_ASSETS_PREFIX = "course/assets/";
+
+export function isCourseAssetLink(link?: string): boolean {
+  return !!link && link.startsWith(COURSE_ASSETS_PREFIX);
+}
+
+// The DAM filename (hash.ext) from a `course/assets/<filename>` link — this is
+// the `_fieldName` used by the courseasset join collection.
+export function filenameFromLink(link?: string): string {
+  if (!link) return "";
+  return isCourseAssetLink(link) ? link.slice(COURSE_ASSETS_PREFIX.length) : "";
+}
+
+// Turn a stored link into a loadable preview URL. Course assets are resolved to
+// `/api/asset/serve/<id>` via the filename→assetId map; external URLs pass
+// through unchanged.
+export function resolveAssetUrl(link: string | undefined, idByFilename: Record<string, string>): string {
+  if (!link) return "";
+  if (!isCourseAssetLink(link)) return link; // external URL
+  const id = idByFilename[filenameFromLink(link)];
+  return id ? `/api/asset/serve/${id}` : link;
+}
+
+// Detect an external streaming provider for `_media.type`.
+export function detectMediaType(link?: string): string {
+  const l = (link || "").toLowerCase();
+  if (l.includes("youtube.com") || l.includes("youtu.be")) return "video/youtube";
+  if (l.includes("vimeo.com")) return "video/vimeo";
+  return "";
+}
+
+// ── Card data → Adapt component fields ───────────────────────────────────────
+
+// Image card → `_graphic` patch. Adapt's graphic component holds a single image
+// in `large` (desktop) + `small` (mobile); we set both to the same source.
+export function buildGraphicField(image?: ImageData): { _graphic: Record<string, unknown> } {
+  const link = image?.link || "";
+  return { _graphic: { large: link, small: link, alt: image?.alt || "" } };
+}
+
+// Video/audio card → `_media` patch. A DAM file goes into mp4 (video) / mp3
+// (audio); an external URL goes into `source` (+ `type` for YouTube/Vimeo).
+export function buildMediaField(kind: "video" | "audio", media?: MediaData): { _media: Record<string, unknown> } {
+  const asset = media?.asset;
+  const link = asset?.link || "";
+  const external = !!asset?.external || (!!link && !isCourseAssetLink(link));
+  const _media: Record<string, unknown> = {
+    mp4: "",
+    ogv: "",
+    webm: "",
+    mp3: "",
+    source: "",
+    type: "",
+    poster: media?.poster?.link || "",
+  };
+  if (link) {
+    if (external) {
+      _media.source = link;
+      _media.type = detectMediaType(link);
+    } else if (kind === "audio") {
+      _media.mp3 = link;
+    } else {
+      _media.mp4 = link;
+    }
+  }
+  return { _media };
+}
+
+// ── Adapt component fields → card data (read-back) ───────────────────────────
+
+interface GraphicShape {
+  large?: string;
+  small?: string;
+  alt?: string;
+}
+interface MediaShape {
+  mp4?: string;
+  ogv?: string;
+  webm?: string;
+  mp3?: string;
+  source?: string;
+  type?: string;
+  poster?: string;
+}
+
+export function imageFromGraphic(graphic: GraphicShape | undefined, idByFilename: Record<string, string>): ImageData {
+  const link = (graphic && (graphic.large || graphic.small)) || "";
+  return {
+    link,
+    url: resolveAssetUrl(link, idByFilename),
+    alt: (graphic && graphic.alt) || "",
+    external: !!link && !isCourseAssetLink(link),
+  };
+}
+
+// Returns the card kind ('video' | 'audio') implied by which fields are set,
+// plus the reconstructed MediaData.
+export function mediaFromComponent(
+  media: MediaShape | undefined,
+  idByFilename: Record<string, string>
+): { kind: "video" | "audio"; data: MediaData } {
+  const m = media || {};
+  const isAudio = !!m.mp3 && !m.mp4 && !m.webm && !m.ogv;
+  const link = m.mp4 || m.webm || m.ogv || m.mp3 || m.source || "";
+  const external = !!m.source && !m.mp4 && !m.mp3;
+  const data = emptyMediaData();
+  if (link) {
+    data.asset = { link, url: resolveAssetUrl(link, idByFilename), external };
+  }
+  if (m.poster) {
+    data.poster = { link: m.poster, url: resolveAssetUrl(m.poster, idByFilename) };
+  }
+  return { kind: isAudio ? "audio" : "video", data };
+}

--- a/new-ui-source/src/components/storyboard/schema.ts
+++ b/new-ui-source/src/components/storyboard/schema.ts
@@ -1,0 +1,28 @@
+// BlockNote schema for the storyboard editor.
+//
+// Default block set + headings limited to H1–H4 (spec AC4) + one generic
+// placeholder block covering all non-native content kinds (spec AC5/AC6).
+
+import {
+  BlockNoteSchema,
+  createHeadingBlockSpec,
+  defaultBlockSpecs,
+} from '@blocknote/core';
+import { STORYBOARD_HEADING_LEVELS } from '@/types/storyboard';
+import { placeholderBlock } from './blocks/placeholderBlock';
+import { assessmentBlock } from './blocks/assessmentBlock';
+import { componentBlock } from './blocks/componentBlock';
+
+export const storyboardSchema = BlockNoteSchema.create({
+  blockSpecs: {
+    ...defaultBlockSpecs,
+    // H1–H4 only (spec AC4). Default BlockNote exposes H1–H3.
+    heading: createHeadingBlockSpec({ levels: STORYBOARD_HEADING_LEVELS }),
+    // createReactBlockSpec returns a spec *factory* in v0.52 — call it here.
+    sbComponent: componentBlock(), // rich content cards: Text/Grouped/Image/Video/Audio/H5P/Form (AC3)
+    sbPlaceholder: placeholderBlock(), // interactive placeholders (AC6)
+    sbAssessment: assessmentBlock(), // simplified assessment authoring (AC5)
+  },
+});
+
+export type StoryboardSchema = typeof storyboardSchema;

--- a/new-ui-source/src/components/storyboard/storyboardActions.ts
+++ b/new-ui-source/src/components/storyboard/storyboardActions.ts
@@ -1,0 +1,46 @@
+// Action channel for storyboard component cards (ADAPT-3760).
+//
+// AI and Comment are authoring ACTIONS attached to a component card, not course
+// components. The cards are rendered inside BlockNote's block layer, so instead
+// of threading props through that layer we use a tiny module singleton: the
+// workspace registers handlers on mount and the card invokes open*() on click.
+// This opens the workspace-level AI Assistance / Comment popovers.
+
+export interface AiAssistRequest {
+  /** Seed text for the popover (the card's current content). */
+  initialText?: string;
+  /** Apply the AI result as a NEW Text component. */
+  onInsert: (text: string) => void;
+  /** Apply the AI result in place (replace the card's content). */
+  onReplace: (text: string) => void;
+}
+
+export interface CommentRequest {
+  /** BlockNote block id the comment anchors to (never changes course structure). */
+  blockId: string;
+  /** Header label, e.g. "CONTENT · TEXT". */
+  label: string;
+}
+
+interface Handlers {
+  openAi?: (req: AiAssistRequest) => void;
+  openComment?: (req: CommentRequest) => void;
+}
+
+let handlers: Handlers = {};
+
+export const storyboardActions = {
+  /** Called by the workspace on mount; returns an unregister fn. */
+  register(h: Handlers): () => void {
+    handlers = h;
+    return () => {
+      handlers = {};
+    };
+  },
+  openAi(req: AiAssistRequest): void {
+    handlers.openAi?.(req);
+  },
+  openComment(req: CommentRequest): void {
+    handlers.openComment?.(req);
+  },
+};

--- a/new-ui-source/src/hooks/useStoryboard.ts
+++ b/new-ui-source/src/hooks/useStoryboard.ts
@@ -1,0 +1,134 @@
+// Storyboard editing model (ADAPT-3779). Mirrors useCourseStructure: edits are
+// staged in a local DRAFT (the BlockNote document) and only written to the
+// backend when the caller invokes save(); discard() reverts to the last-saved
+// state; `dirty` is a JSON diff against the last save. On first load it fetches
+// the course's storyboard, lazily creating one if none exists.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  getStoryboardByCourse,
+  createStoryboard,
+  updateStoryboard,
+  setStoryboardStatus,
+  type StoryboardRecord,
+  type StoryboardStatus,
+} from "../api/adaptAuthoring";
+
+export interface UseStoryboardResult {
+  storyboardId?: string;
+  document: unknown[];
+  status: StoryboardStatus;
+  version: number;
+  loading: boolean;
+  saving: boolean;
+  dirty: boolean;
+  error?: string;
+  /** Stage a new document in the draft (does not persist). */
+  setDocument: (doc: unknown[]) => void;
+  /** Reset the dirty baseline to `doc` (or the current draft) without saving. */
+  markSaved: (doc?: unknown[]) => void;
+  /** Persist the draft document to the backend. */
+  save: () => Promise<void>;
+  /** Revert the draft to the last-saved document. */
+  discard: () => void;
+  /** Change review status (persists + records an audit event server-side). */
+  changeStatus: (next: StoryboardStatus) => Promise<void>;
+}
+
+export function useStoryboard(courseId?: string): UseStoryboardResult {
+  const [record, setRecord] = useState<StoryboardRecord | null>(null); // last-saved
+  const [draftDoc, setDraftDoc] = useState<unknown[]>([]);
+  const [status, setStatus] = useState<StoryboardStatus>("draft");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string>();
+
+  // JSON of the last-saved document, for the dirty diff (mirrors useCourseStructure).
+  const savedJson = useRef<string>("[]");
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!courseId) {
+      setLoading(false);
+      return;
+    }
+    (async () => {
+      setLoading(true);
+      setError(undefined);
+      try {
+        let rec = await getStoryboardByCourse(courseId);
+        if (!rec) rec = await createStoryboard({ _courseId: courseId });
+        if (cancelled) return;
+        const doc = rec.documentJson ?? [];
+        setRecord(rec);
+        setDraftDoc(doc);
+        setStatus(rec.status);
+        savedJson.current = JSON.stringify(doc);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load storyboard");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId]);
+
+  const dirty = useMemo(() => JSON.stringify(draftDoc) !== savedJson.current, [draftDoc]);
+
+  const setDocument = useCallback((doc: unknown[]) => setDraftDoc(doc), []);
+
+  const markSaved = useCallback(
+    (doc?: unknown[]) => {
+      savedJson.current = JSON.stringify(doc ?? draftDoc);
+    },
+    [draftDoc]
+  );
+
+  const save = useCallback(async () => {
+    if (!record) return;
+    setSaving(true);
+    setError(undefined);
+    try {
+      const updated = await updateStoryboard(record._id, { documentJson: draftDoc });
+      setRecord(updated);
+      savedJson.current = JSON.stringify(updated.documentJson ?? draftDoc);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save storyboard");
+      throw e;
+    } finally {
+      setSaving(false);
+    }
+  }, [record, draftDoc]);
+
+  const discard = useCallback(() => {
+    setDraftDoc(record?.documentJson ?? []);
+  }, [record]);
+
+  const changeStatus = useCallback(
+    async (next: StoryboardStatus) => {
+      if (!record) return;
+      const updated = await setStoryboardStatus(record._id, next);
+      setRecord(updated);
+      setStatus(updated.status);
+    },
+    [record]
+  );
+
+  return {
+    storyboardId: record?._id,
+    document: draftDoc,
+    status,
+    version: record?.version ?? 1,
+    loading,
+    saving,
+    dirty,
+    error,
+    setDocument,
+    markSaved,
+    save,
+    discard,
+    changeStatus,
+  };
+}

--- a/new-ui-source/src/hooks/useStoryboardReview.ts
+++ b/new-ui-source/src/hooks/useStoryboardReview.ts
@@ -1,0 +1,97 @@
+// Review/comments data for a storyboard (ADAPT-3760, Phase 5 / AC8 / AC9).
+// Loads comment threads + the audit trail from the Phase 1 backend and exposes
+// add / reply / resolve / delete operations that refresh on success.
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  listStoryboardComments,
+  addStoryboardComment,
+  updateStoryboardComment,
+  deleteStoryboardComment,
+  listStoryboardAudit,
+  type StoryboardComment,
+  type StoryboardAuditEvent,
+} from "../api/adaptAuthoring";
+
+export interface UseStoryboardReviewResult {
+  comments: StoryboardComment[];
+  audit: StoryboardAuditEvent[];
+  openCount: number;
+  resolvedCount: number;
+  loading: boolean;
+  refresh: () => Promise<void>;
+  addComment: (blockId: string, body: string, courseId?: string, parentCommentId?: string) => Promise<void>;
+  setResolved: (commentId: string, resolved: boolean) => Promise<void>;
+  removeComment: (commentId: string) => Promise<void>;
+}
+
+export function useStoryboardReview(storyboardId?: string): UseStoryboardReviewResult {
+  const [comments, setComments] = useState<StoryboardComment[]>([]);
+  const [audit, setAudit] = useState<StoryboardAuditEvent[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!storyboardId) {
+      setComments([]);
+      setAudit([]);
+      return;
+    }
+    setLoading(true);
+    try {
+      const [c, a] = await Promise.all([
+        listStoryboardComments(storyboardId),
+        listStoryboardAudit(storyboardId),
+      ]);
+      setComments(Array.isArray(c) ? c : []);
+      setAudit(Array.isArray(a) ? a : []);
+    } catch {
+      /* leave previous state; the panel shows empty states */
+    } finally {
+      setLoading(false);
+    }
+  }, [storyboardId]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const addComment = useCallback(
+    async (blockId: string, body: string, courseId?: string, parentCommentId?: string) => {
+      if (!storyboardId || !body.trim()) return;
+      await addStoryboardComment(storyboardId, {
+        blockId,
+        body: body.trim(),
+        _courseId: courseId,
+        _parentCommentId: parentCommentId,
+      });
+      await refresh();
+    },
+    [storyboardId, refresh]
+  );
+
+  const setResolved = useCallback(
+    async (commentId: string, resolved: boolean) => {
+      await updateStoryboardComment(commentId, { resolved });
+      await refresh();
+    },
+    [refresh]
+  );
+
+  const removeComment = useCallback(
+    async (commentId: string) => {
+      await deleteStoryboardComment(commentId);
+      await refresh();
+    },
+    [refresh]
+  );
+
+  const { openCount, resolvedCount } = useMemo(() => {
+    const tops = comments.filter((c) => !c._parentCommentId);
+    return {
+      openCount: tops.filter((c) => !c.resolved).length,
+      resolvedCount: tops.filter((c) => c.resolved).length,
+    };
+  }, [comments]);
+
+  return { comments, audit, openCount, resolvedCount, loading, refresh, addComment, setResolved, removeComment };
+}

--- a/new-ui-source/src/index.css
+++ b/new-ui-source/src/index.css
@@ -109,11 +109,28 @@
   --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.07), 0 2px 4px -2px rgb(0 0 0 / 0.05);
   --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.08), 0 4px 6px -4px rgb(0 0 0 / 0.05);
+
+  /* ── Storyboard (ADAPT-3760) semantic tokens ────────────────────────
+     shadcn-style aliases used by the storyboard UI, mapped to LIFE palette
+     so the Lovable design ports over cleanly. `--samaritan` is the AI accent. */
+  --muted:            var(--life-neutral-050);
+  --muted-foreground: var(--life-neutral-500);
+  --secondary:        var(--life-neutral-050);
+  --primary:          var(--life-primary-500);
+  --primary-foreground: var(--life-base-white);
+  --samaritan:        var(--life-accent2-500);
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-border: var(--border);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-secondary: var(--secondary);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-samaritan: var(--samaritan);
   --font-sans: "Lato", var(--font-geist-sans), "Noto Sans", sans-serif;
   --font-mono: var(--font-geist-mono);
 }

--- a/new-ui-source/src/pages/SetupPage.tsx
+++ b/new-ui-source/src/pages/SetupPage.tsx
@@ -6,6 +6,7 @@ import AiAssistant from "../components/common/AiAssistant";
 import CourseStructureMapView from "../components/course/CourseStructureMapView";
 import CourseStructureTree from "../components/course/CourseStructureTree";
 import AddComponentDrawer from "../components/course/AddComponentDrawer";
+import { StoryboardWorkspace } from "../components/storyboard";
 import { getCourseBootstrapData } from "../api/adaptAuthoring";
 import { useCourseStructure } from "../hooks/useCourseStructure";
 import { STRUCTURE_LABELS } from "../types/structure";
@@ -4545,7 +4546,15 @@ function CourseCreationCenterContent() {
     if (activeNav === "learner-experience") return <LearnerExperiencePanel />;
     if (activeNav === "technical-settings") return <TechnicalSettingPage courseId={courseId} onNavigationRequest={setActiveNav} pendingNavigation={pendingNavigation} onPendingNavigationHandled={() => setPendingNavigation(null)} />;
     if (activeNav === "publish") return <PublishPanel />;
-    return <ComingSoonPanel label={activeItem?.label ?? (activeNav === "storyboarding" ? "Storyboarding" : "")} />;
+    if (activeNav === "storyboarding")
+      return (
+        <StoryboardWorkspace
+          courseId={courseId}
+          courseTitle={title}
+          onBack={() => setActiveNav("overview")}
+        />
+      );
+    return <ComingSoonPanel label={activeItem?.label ?? ""} />;
   }
 
   function openExportDialog() {
@@ -4791,7 +4800,7 @@ function CourseCreationCenterContent() {
         </aside>
 
         {/* -- Right content panel -- */}
-        <main className={`flex-1 overflow-hidden bg-[#f8fafc] ${activeNav === "menu" || activeNav === "navigation" ? "" : "overflow-y-auto px-8 py-8 min-h-0"}`}>
+        <main className={`flex-1 overflow-hidden bg-[#f8fafc] ${activeNav === "menu" || activeNav === "navigation" || activeNav === "storyboarding" ? "" : "overflow-y-auto px-8 py-8 min-h-0"}`}>
           {renderPanel()}
         </main>
       </div>

--- a/new-ui-source/src/pages/StoryboardPage.tsx
+++ b/new-ui-source/src/pages/StoryboardPage.tsx
@@ -1,0 +1,23 @@
+// Storyboard Authoring page — full-screen route wrapper (ADAPT-3760).
+// Thin route wrapper around the reusable <StoryboardWorkspace/>, which is also
+// embedded in the Course Configuration "Storyboard" panel.
+
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { StoryboardWorkspace } from '@/components/storyboard';
+
+export default function StoryboardPage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const courseTitle = (location.state as { title?: string } | null)?.title;
+
+  return (
+    <div className="h-screen">
+      <StoryboardWorkspace
+        courseId={id}
+        courseTitle={courseTitle}
+        onBack={() => navigate(`/course/${id ?? ''}`)}
+      />
+    </div>
+  );
+}

--- a/new-ui-source/src/routes.tsx
+++ b/new-ui-source/src/routes.tsx
@@ -5,6 +5,7 @@ import HomePage from './pages/HomePage'
 import NewCoursePage from './pages/NewCoursePage'
 import SetupPage from './pages/SetupPage'
 import PageEditorPage from './pages/editor/pageEditorPage'
+import StoryboardPage from './pages/StoryboardPage'
 import CourseStructureDemoPage from './pages/CourseStructureDemoPage'
 import UserManagementPage from './pages/UserManagementPage'
 import AssetManagementPage from './pages/AssetManagementPage'
@@ -33,6 +34,7 @@ export const router = createBrowserRouter([
       { path: '/course/new/setup', element: <SetupPage /> },
       { path: '/course/:id/setup', element: <SetupPage /> },
       { path: '/course/:id', element: <PageEditorPage /> },
+      { path: '/course/:id/storyboard', element: <StoryboardPage /> },
       { path: '/course-structure-demo', element: <CourseStructureDemoPage /> },
     ],
   },

--- a/new-ui-source/src/types/storyboard.ts
+++ b/new-ui-source/src/types/storyboard.ts
@@ -84,13 +84,13 @@ export const INSERT_META: Record<
   Exclude<StoryboardInsertKind, 'text' | 'image' | 'video' | 'audio' | 'heading'>,
   { label: string; category: PlaceholderCategory; adaptComponent: string }
 > = {
-  groupedContent: { label: 'Grouped Content', category: 'group', adaptComponent: 'block' },
+  groupedContent: { label: 'Grouped Content', category: 'group', adaptComponent: 'laerdal-narrative' },
   h5p: { label: 'H5P', category: 'media', adaptComponent: 'adapt-laerdal-h5p' },
   laerdalForm: { label: 'Laerdal Form', category: 'survey', adaptComponent: 'adapt-laerdal-form' },
   mcq: { label: 'MCQ', category: 'assessment', adaptComponent: 'adapt-contrib-mcq' },
   gmcq: { label: 'Graphic MCQ', category: 'assessment', adaptComponent: 'adapt-contrib-gmcq' },
   matching: { label: 'Matching', category: 'assessment', adaptComponent: 'adapt-contrib-matching' },
-  reorder: { label: 'Sentence Reordering', category: 'assessment', adaptComponent: 'adapt-contrib-textInput' },
+  reorder: { label: 'Sentence Reordering', category: 'assessment', adaptComponent: 'adapt-contrib-resequence' },
   textInput: { label: 'Text Input', category: 'assessment', adaptComponent: 'adapt-contrib-textInput' },
   slider: { label: 'Slider', category: 'assessment', adaptComponent: 'adapt-contrib-slider' },
   hotgraphic: { label: 'Hot Graphic', category: 'interactive', adaptComponent: 'adapt-contrib-hotgraphic' },
@@ -117,6 +117,8 @@ export interface McqOption {
   correct: boolean;
   /** Optional image reference for Graphic MCQ (gmcq). */
   image?: string;
+  /** Answer-specific feedback shown when this option is selected. */
+  feedback?: string;
 }
 export interface MatchPair {
   prompt: string;
@@ -128,37 +130,54 @@ export interface SliderConfig {
   step: number;
   correct: number;
 }
+/** Whole-question feedback (maps to Adapt `_feedback`). */
+export interface AssessmentFeedback {
+  correct: string;
+  incorrect: string;
+  incorrectNotFinal: string;
+  partlyCorrectFinal: string;
+  partlyCorrectNotFinal: string;
+}
 
 export interface AssessmentData {
   question: string;
+  showTitle?: boolean;
   options?: McqOption[]; // mcq, gmcq
   pairs?: MatchPair[]; // matching
   items?: string[]; // reorder — array order is the correct order
   answers?: string[]; // textInput — acceptable answers
   slider?: SliderConfig; // slider
+  feedback?: AssessmentFeedback; // whole-question feedback (all kinds)
+}
+
+export function emptyFeedback(): AssessmentFeedback {
+  return { correct: '', incorrect: '', incorrectNotFinal: '', partlyCorrectFinal: '', partlyCorrectNotFinal: '' };
 }
 
 export function defaultAssessmentData(kind: AssessmentKind): AssessmentData {
+  const base = { showTitle: true, feedback: emptyFeedback() };
   switch (kind) {
     case 'mcq':
     case 'gmcq':
       return {
+        ...base,
         question: '',
         options: [
-          { text: '', correct: true },
-          { text: '', correct: false },
+          { text: 'Correct answer', correct: true, feedback: '' },
+          { text: 'Incorrect option', correct: false, feedback: '' },
+          { text: 'Incorrect option', correct: false, feedback: '' },
         ],
       };
     case 'matching':
-      return { question: '', pairs: [{ prompt: '', answer: '' }] };
+      return { ...base, question: '', pairs: [{ prompt: '', answer: '' }] };
     case 'reorder':
-      return { question: '', items: ['', ''] };
+      return { ...base, question: '', items: ['', ''] };
     case 'textInput':
-      return { question: '', answers: [''] };
+      return { ...base, question: '', answers: [''] };
     case 'slider':
-      return { question: '', slider: { min: 0, max: 10, step: 1, correct: 5 } };
+      return { ...base, question: '', slider: { min: 0, max: 10, step: 1, correct: 5 } };
     default:
-      return { question: '' };
+      return { ...base, question: '' };
   }
 }
 
@@ -205,6 +224,106 @@ export function validateAssessment(kind: AssessmentKind, data: AssessmentData): 
   return issues;
 }
 
+// Assessment card → Adapt question-component fields (`_items` + `_feedback` +
+// per-kind extras). Shapes follow adapt-contrib question components; approximate
+// where the exact Laerdal schema differs (verify against the installed plugin).
+export function buildAssessmentFields(kind: AssessmentKind, data: AssessmentData): Record<string, unknown> {
+  const patch: Record<string, unknown> = {};
+  const fb = data.feedback;
+  if (fb) {
+    patch._feedback = {
+      correct: fb.correct,
+      _incorrect: { final: fb.incorrect, notFinal: fb.incorrectNotFinal },
+      _partlyCorrect: { final: fb.partlyCorrectFinal, notFinal: fb.partlyCorrectNotFinal },
+    };
+  }
+  if (kind === 'mcq' || kind === 'gmcq') {
+    patch._items = (data.options ?? []).map((o) => ({
+      text: o.text,
+      _shouldBeSelected: !!o.correct,
+      feedback: o.feedback ?? '',
+      ...(o.image ? { _graphic: { src: o.image, large: o.image } } : {}),
+    }));
+  } else if (kind === 'matching') {
+    patch._items = (data.pairs ?? []).map((p) => ({
+      text: p.prompt,
+      _options: [{ text: p.answer, _isCorrect: true }],
+    }));
+  } else if (kind === 'reorder') {
+    // adapt-laerdal-sentenceOrdering: `_items[].{ sentence, position }`.
+    patch._items = (data.items ?? []).map((t, i) => ({ sentence: t, position: i + 1 }));
+  } else if (kind === 'textInput') {
+    patch._items = (data.answers ?? []).map((a) => ({ _answers: [a] }));
+  } else if (kind === 'slider') {
+    const s = data.slider;
+    if (s) {
+      patch._scaleStart = s.min;
+      patch._scaleEnd = s.max;
+      patch._scaleStep = s.step;
+      patch._correctAnswer = s.correct;
+    }
+  }
+  return patch;
+}
+
+// Inverse of buildAssessmentFields: reconstruct an AssessmentData card from a
+// saved Adapt question component's `properties` (+ its `body` = question). Used
+// by the reload/read-back path so questions round-trip as cards, not H4+text.
+export function parseAssessmentData(
+  kind: AssessmentKind,
+  props: Record<string, unknown>,
+  question: string
+): AssessmentData {
+  const p = props || {};
+  const fb = (p._feedback as Record<string, unknown>) || {};
+  const inc = (fb._incorrect as Record<string, unknown>) || {};
+  const part = (fb._partlyCorrect as Record<string, unknown>) || {};
+  const feedback: AssessmentFeedback = {
+    correct: String(fb.correct ?? ''),
+    incorrect: String(inc.final ?? ''),
+    incorrectNotFinal: String(inc.notFinal ?? ''),
+    partlyCorrectFinal: String(part.final ?? ''),
+    partlyCorrectNotFinal: String(part.notFinal ?? ''),
+  };
+  const items = Array.isArray(p._items) ? (p._items as Array<Record<string, unknown>>) : [];
+  const data: AssessmentData = { question, showTitle: true, feedback };
+
+  if (kind === 'mcq' || kind === 'gmcq') {
+    data.options = items.map((it) => {
+      const g = (it._graphic as { large?: string; small?: string; src?: string }) || {};
+      return {
+        text: String(it.text ?? ''),
+        correct: !!it._shouldBeSelected,
+        feedback: it.feedback ? String(it.feedback) : undefined,
+        image: g.large || g.small || g.src || undefined,
+      } as McqOption;
+    });
+  } else if (kind === 'matching') {
+    data.pairs = items.map((it) => {
+      const opts = Array.isArray(it._options) ? (it._options as Array<Record<string, unknown>>) : [];
+      return { prompt: String(it.text ?? ''), answer: String(opts[0]?.text ?? '') };
+    });
+  } else if (kind === 'reorder') {
+    data.items = items
+      .slice()
+      .sort((a, b) => Number(a.position ?? 0) - Number(b.position ?? 0))
+      .map((it) => String(it.sentence ?? it.text ?? ''));
+  } else if (kind === 'textInput') {
+    data.answers = items.map((it) => {
+      const ans = Array.isArray(it._answers) ? (it._answers as unknown[]) : [];
+      return String(ans[0] ?? '');
+    });
+  } else if (kind === 'slider') {
+    data.slider = {
+      min: Number(p._scaleStart ?? 0),
+      max: Number(p._scaleEnd ?? 10),
+      step: Number(p._scaleStep ?? 1),
+      correct: Number(p._correctAnswer ?? 0),
+    };
+  }
+  return data;
+}
+
 /** Rollup counts for the Review Center summary + AI guidance (AC7/AC8). */
 export interface StoryboardSummary {
   topics: number;
@@ -228,6 +347,14 @@ export interface StoryboardEditorHandle {
   /** Insert content at the cursor (Add Heading / Add Content / Add Instruction).
    *  `opts.level` sets the heading level (H1–H3) when `kind === 'heading'`. */
   insert(kind: StoryboardInsertKind, opts?: { level?: number }): void;
+  /** Insert a pre-populated component card at the cursor (AI Assistance →
+   *  Insert). `title` seeds the card title; `data` is merged into the card's
+   *  default data (e.g. `{ description }` for a Text component). Returns the new
+   *  block id so the caller can anchor follow-up actions (comments). */
+  insertComponent(
+    kind: StoryboardInsertKind,
+    opts?: { title?: string; data?: Record<string, unknown> }
+  ): string | null;
   /** Plain text of the block at the cursor (for AI actions, AC7). */
   getActiveText(): string;
   /** Replace the cursor block's content with `text` (Improve / Rewrite). */

--- a/new-ui-source/src/types/storyboard.ts
+++ b/new-ui-source/src/types/storyboard.ts
@@ -1,0 +1,255 @@
+// Storyboard authoring — engine-agnostic types (ADAPT-3760).
+//
+// These types deliberately do NOT reference BlockNote. They are the seam
+// described in the spike brief: TOC / toolbar / review / (future) generation
+// code depends only on this module, so swapping the editor engine (BlockNote →
+// TipTap) is a contained change in `components/storyboard/`.
+
+/** Adapt content level a storyboard heading maps to (spec AC4). */
+export type AdaptStructureType = 'topic' | 'section' | 'contentGroup' | 'component';
+
+/**
+ * Heading level → Adapt structure (spec AC4):
+ *   H1 → Topic (contentobject/page), H2 → Section (article),
+ *   H3 → Content Group (block), H4 → Component title.
+ */
+export const HEADING_LEVEL_TO_ADAPT: Record<number, AdaptStructureType> = {
+  1: 'topic',
+  2: 'section',
+  3: 'contentGroup',
+  4: 'component',
+};
+
+/** Heading levels the storyboard editor exposes (H1–H4 → the 4-level map). */
+export const STORYBOARD_HEADING_LEVELS: readonly number[] = [1, 2, 3, 4];
+
+/** Clamp any heading level to a known Adapt structure type. */
+export function adaptTypeForLevel(level: number): AdaptStructureType {
+  return HEADING_LEVEL_TO_ADAPT[level] ?? 'component';
+}
+
+/** A heading extracted from the document (drives the TOC — AC1). */
+export interface StoryboardHeading {
+  /** Stable block id — TOC scroll/anchor + comment anchoring (AC9). */
+  id: string;
+  level: number;
+  text: string;
+  adaptType: AdaptStructureType;
+}
+
+/** Review workflow status (spec AC8). */
+export type ReviewStatus = 'draft' | 'in_review' | 'approved';
+
+/**
+ * Content that can be inserted from the "Add Content" menu (spec AC3/AC5/AC6).
+ * Neutral kinds; the editor maps each to its concrete block(s).
+ */
+export type StoryboardInsertKind =
+  // text & visual
+  | 'text'
+  | 'groupedContent'
+  | 'image'
+  // media
+  | 'video'
+  | 'audio'
+  | 'h5p'
+  // survey
+  | 'laerdalForm'
+  // assessment (AC5)
+  | 'mcq'
+  | 'gmcq'
+  | 'matching'
+  | 'reorder'
+  | 'textInput'
+  | 'slider'
+  // interactive placeholders (AC6)
+  | 'hotgraphic'
+  | 'hotgrid'
+  | 'actionplan'
+  // structural / helper
+  | 'heading'
+  | 'instruction';
+
+/** Category a placeholder block belongs to (drives its rendered style). */
+export type PlaceholderCategory =
+  | 'group'
+  | 'media'
+  | 'survey'
+  | 'assessment'
+  | 'interactive'
+  | 'instruction';
+
+/** Metadata for every non-native insert kind: label, category, Adapt component. */
+export const INSERT_META: Record<
+  Exclude<StoryboardInsertKind, 'text' | 'image' | 'video' | 'audio' | 'heading'>,
+  { label: string; category: PlaceholderCategory; adaptComponent: string }
+> = {
+  groupedContent: { label: 'Grouped Content', category: 'group', adaptComponent: 'block' },
+  h5p: { label: 'H5P', category: 'media', adaptComponent: 'adapt-laerdal-h5p' },
+  laerdalForm: { label: 'Laerdal Form', category: 'survey', adaptComponent: 'adapt-laerdal-form' },
+  mcq: { label: 'MCQ', category: 'assessment', adaptComponent: 'adapt-contrib-mcq' },
+  gmcq: { label: 'Graphic MCQ', category: 'assessment', adaptComponent: 'adapt-contrib-gmcq' },
+  matching: { label: 'Matching', category: 'assessment', adaptComponent: 'adapt-contrib-matching' },
+  reorder: { label: 'Sentence Reordering', category: 'assessment', adaptComponent: 'adapt-contrib-textInput' },
+  textInput: { label: 'Text Input', category: 'assessment', adaptComponent: 'adapt-contrib-textInput' },
+  slider: { label: 'Slider', category: 'assessment', adaptComponent: 'adapt-contrib-slider' },
+  hotgraphic: { label: 'Hot Graphic', category: 'interactive', adaptComponent: 'adapt-contrib-hotgraphic' },
+  hotgrid: { label: 'Hot Grid', category: 'interactive', adaptComponent: 'adapt-laerdal-hotgrid' },
+  actionplan: { label: 'Laerdal Action Plan', category: 'interactive', adaptComponent: 'adapt-laerdal-actionplan' },
+  instruction: { label: 'Instruction', category: 'instruction', adaptComponent: 'instruction' },
+};
+
+// ── Assessment authoring model (spec AC5) ───────────────────────────────────
+// Simplified, generation-ready data captured by the assessment block. Advanced
+// settings (feedback, scoring, attempts) are deliberately omitted — they are
+// configured later in the Page Editor. The Phase 4 generator maps this onto the
+// concrete Adapt component `properties`.
+
+export const ASSESSMENT_KINDS = ['mcq', 'gmcq', 'matching', 'reorder', 'textInput', 'slider'] as const;
+export type AssessmentKind = (typeof ASSESSMENT_KINDS)[number];
+
+export function isAssessmentKind(kind: string): kind is AssessmentKind {
+  return (ASSESSMENT_KINDS as readonly string[]).includes(kind);
+}
+
+export interface McqOption {
+  text: string;
+  correct: boolean;
+  /** Optional image reference for Graphic MCQ (gmcq). */
+  image?: string;
+}
+export interface MatchPair {
+  prompt: string;
+  answer: string;
+}
+export interface SliderConfig {
+  min: number;
+  max: number;
+  step: number;
+  correct: number;
+}
+
+export interface AssessmentData {
+  question: string;
+  options?: McqOption[]; // mcq, gmcq
+  pairs?: MatchPair[]; // matching
+  items?: string[]; // reorder — array order is the correct order
+  answers?: string[]; // textInput — acceptable answers
+  slider?: SliderConfig; // slider
+}
+
+export function defaultAssessmentData(kind: AssessmentKind): AssessmentData {
+  switch (kind) {
+    case 'mcq':
+    case 'gmcq':
+      return {
+        question: '',
+        options: [
+          { text: '', correct: true },
+          { text: '', correct: false },
+        ],
+      };
+    case 'matching':
+      return { question: '', pairs: [{ prompt: '', answer: '' }] };
+    case 'reorder':
+      return { question: '', items: ['', ''] };
+    case 'textInput':
+      return { question: '', answers: [''] };
+    case 'slider':
+      return { question: '', slider: { min: 0, max: 10, step: 1, correct: 5 } };
+    default:
+      return { question: '' };
+  }
+}
+
+/** Return a list of human-readable issues; empty ⇒ generation-ready (AC5). */
+export function validateAssessment(kind: AssessmentKind, data: AssessmentData): string[] {
+  const issues: string[] = [];
+  if (!data.question || !data.question.trim()) issues.push('Question text is required.');
+
+  switch (kind) {
+    case 'mcq':
+    case 'gmcq': {
+      const opts = data.options ?? [];
+      const filled = opts.filter((o) => o.text.trim());
+      if (filled.length < 2) issues.push('Add at least two answer options.');
+      if (!filled.some((o) => o.correct)) issues.push('Mark at least one option correct.');
+      break;
+    }
+    case 'matching': {
+      const pairs = (data.pairs ?? []).filter((p) => p.prompt.trim() && p.answer.trim());
+      if (pairs.length < 1) issues.push('Add at least one complete prompt/answer pair.');
+      break;
+    }
+    case 'reorder': {
+      const items = (data.items ?? []).filter((i) => i.trim());
+      if (items.length < 2) issues.push('Add at least two items to reorder.');
+      break;
+    }
+    case 'textInput': {
+      const answers = (data.answers ?? []).filter((a) => a.trim());
+      if (answers.length < 1) issues.push('Add at least one acceptable answer.');
+      break;
+    }
+    case 'slider': {
+      const s = data.slider;
+      if (!s) issues.push('Configure the slider range.');
+      else {
+        if (s.min >= s.max) issues.push('Minimum must be less than maximum.');
+        if (s.correct < s.min || s.correct > s.max) issues.push('Correct value must be within the range.');
+        if (s.step <= 0) issues.push('Step must be greater than zero.');
+      }
+      break;
+    }
+  }
+  return issues;
+}
+
+/** Rollup counts for the Review Center summary + AI guidance (AC7/AC8). */
+export interface StoryboardSummary {
+  topics: number;
+  sections: number;
+  contentItems: number;
+  assets: number;
+  textBlocks: number;
+  hasVisual: boolean;
+  hasAssessment: boolean;
+}
+
+/** Persisted document — opaque; owned by the active editor engine. */
+export type StoryboardDocument = unknown;
+
+/** Imperative handle exposed by any storyboard editor implementation. */
+export interface StoryboardEditorHandle {
+  getDocument(): StoryboardDocument;
+  setDocument(doc: StoryboardDocument): void;
+  getHeadings(): StoryboardHeading[];
+  getSummary(): StoryboardSummary;
+  /** Insert content at the cursor (Add Heading / Add Content / Add Instruction).
+   *  `opts.level` sets the heading level (H1–H3) when `kind === 'heading'`. */
+  insert(kind: StoryboardInsertKind, opts?: { level?: number }): void;
+  /** Plain text of the block at the cursor (for AI actions, AC7). */
+  getActiveText(): string;
+  /** Replace the cursor block's content with `text` (Improve / Rewrite). */
+  replaceActive(text: string): void;
+  /** Insert a paragraph after the cursor block (Summarize / Suggest). */
+  insertAfterActive(text: string): void;
+  /** Scroll to / select a block by id (TOC navigation, AC1). */
+  focusBlock(blockId: string): void;
+}
+
+/** The block the cursor is currently in (drives block-anchored comments, AC9). */
+export interface ActiveBlockInfo {
+  id: string;
+  text: string;
+  type: string;
+}
+
+/** Props accepted by any storyboard editor implementation. */
+export interface StoryboardEditorProps {
+  initialDocument?: StoryboardDocument;
+  editable?: boolean;
+  onChange?: (doc: StoryboardDocument, headings: StoryboardHeading[]) => void;
+  /** Reports the active (cursor) block so the Review panel can anchor comments. */
+  onActiveBlock?: (block: ActiveBlockInfo | null) => void;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@babel/preset-env": "^7.19.4",
         "@xmldom/xmldom": "^0.9.10",
         "adm-zip": "^0.5.10",
-        "archiver": "^7.0.1",
+        "archiver": "^3.1.1",
         "async": "^3.2.6",
         "bcrypt-nodejs": "0.0.3",
         "body-parser": "^1.20.3",
@@ -76,8 +76,10 @@
         "node-webvtt": "^1.9.4",
         "nodemailer": "^8.0.11",
         "optimist": "^0.6.1",
+        "p-limit": "^7.3.0",
         "passport": "^0.6.0",
         "passport-local": "^1.0.0",
+        "pdfkit": "^0.15.2",
         "rate-limit-redis": "^4.2.0",
         "redis": "^4.6.12",
         "request": "^2.88.0",
@@ -2916,102 +2918,6 @@
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "license": "MIT"
-    },
-    "node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -3127,16 +3033,6 @@
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
-      }
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@redis/bloom": {
@@ -3952,6 +3848,19 @@
       "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
       "optional": true
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz",
+      "integrity": "sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@swc/helpers/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -4010,18 +3919,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -4153,161 +4050,81 @@
       }
     },
     "node_modules/archiver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
-      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
+      "integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
       "license": "MIT",
       "dependencies": {
-        "archiver-utils": "^5.0.2",
-        "async": "^3.2.4",
-        "buffer-crc32": "^1.0.0",
-        "readable-stream": "^4.0.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^3.0.0",
-        "zip-stream": "^6.0.1"
+        "archiver-utils": "^2.1.0",
+        "async": "^2.6.3",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.1.4",
+        "readable-stream": "^3.4.0",
+        "tar-stream": "^2.1.0",
+        "zip-stream": "^2.1.2"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 6"
       }
     },
     "node_modules/archiver-utils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
-      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
       "license": "MIT",
       "dependencies": {
-        "glob": "^10.0.0",
+        "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
-        "is-stream": "^2.0.1",
         "lazystream": "^1.0.0",
-        "lodash": "^4.17.15",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
         "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
+        "readable-stream": "^2.0.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 6"
       }
     },
-    "node_modules/archiver-utils/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/archiver-utils/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+    "node_modules/archiver-utils/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/archiver-utils/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "license": "MIT",
       "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/archiver/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "license": "MIT",
       "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
+        "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/archiver/node_modules/buffer-crc32": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
-      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/archiver/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+    "node_modules/archiver/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "license": "MIT",
       "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "lodash": "^4.17.14"
       }
     },
     "node_modules/argparse": {
@@ -4478,9 +4295,12 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/available-typed-arrays": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -4500,20 +4320,6 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
-    },
-    "node_modules/b4a": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
-      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
-      }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.5",
@@ -4568,98 +4374,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
-    },
-    "node_modules/bare-events": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
-      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "bare-abort-controller": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-fs": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
-      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.5.4",
-        "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4",
-        "bare-url": "^2.2.2",
-        "fast-fifo": "^1.3.2"
-      },
-      "engines": {
-        "bare": ">=1.16.0"
-      },
-      "peerDependencies": {
-        "bare-buffer": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-buffer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-os": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
-      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "bare": ">=1.14.0"
-      }
-    },
-    "node_modules/bare-path": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
-      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-os": "^3.0.1"
-      }
-    },
-    "node_modules/bare-stream": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
-      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.8.1",
-        "streamx": "^2.25.0",
-        "teex": "^1.0.1"
-      },
-      "peerDependencies": {
-        "bare-abort-controller": "*",
-        "bare-buffer": "*",
-        "bare-events": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        },
-        "bare-buffer": {
-          "optional": true
-        },
-        "bare-events": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-url": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
-      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-path": "^3.0.0"
-      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -4834,10 +4548,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
     },
     "node_modules/browserslist": {
       "version": "4.21.10",
@@ -4952,12 +4682,17 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5442,71 +5177,48 @@
       "dev": true
     },
     "node_modules/compress-commons": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
-      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
+      "integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
       "license": "MIT",
       "dependencies": {
-        "crc-32": "^1.2.0",
-        "crc32-stream": "^6.0.0",
-        "is-stream": "^2.0.1",
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^3.0.1",
         "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
+        "readable-stream": "^2.3.6"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 6"
       }
     },
-    "node_modules/compress-commons/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/compress-commons/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+    "node_modules/compress-commons/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/compress-commons/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "license": "MIT",
       "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/compress-commons/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/compressible": {
@@ -5811,69 +5523,26 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
+    "node_modules/crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.1.0"
       }
     },
     "node_modules/crc32-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
-      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
+      "integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
       "license": "MIT",
       "dependencies": {
-        "crc-32": "^1.2.0",
-        "readable-stream": "^4.0.0"
+        "crc": "^3.4.4",
+        "readable-stream": "^3.4.0"
       },
       "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/crc32-stream/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/crc32-stream/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": ">= 6.9.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -5899,6 +5568,12 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "deprecated": "Active development of CryptoJS has been discontinued. This library is no longer maintained."
     },
     "node_modules/css-select": {
       "version": "5.1.0",
@@ -6050,6 +5725,56 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deep-equal/node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -6094,11 +5819,28 @@
         "native-promise-only": "^0.8.1"
       }
     },
-    "node_modules/define-properties": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
-      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       },
@@ -6174,6 +5916,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="
     },
     "node_modules/diff": {
       "version": "3.5.1",
@@ -6350,12 +6097,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "license": "MIT"
-    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -6433,6 +6174,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/entities": {
@@ -6559,6 +6309,25 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -6678,37 +6447,10 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/eventemitter2": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha512-K7J4xq5xAD5jHsGM5ReWXRTFa3JRGofHiMcVgQ8PRwgWxzjHpMWCIzsmyf60+mh8KLsqYPcjUMa0AC4hd6lPyQ=="
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
-    "node_modules/events-universal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
-      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.7.0"
-      }
     },
     "node_modules/execa": {
       "version": "0.10.0",
@@ -6924,12 +6666,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
-    "node_modules/fast-fifo": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -7248,12 +6984,42 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
-    "node_modules/for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+    "node_modules/fontkit": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
+      "integrity": "sha512-HkW/8Lrk8jl18kzQHvAw9aTHe1cqsyx5sDnxncx652+CIfhawokEPkeM3BoIC+z/Xv7a0yMr0f3pRRwhGH455g==",
       "dependencies": {
-        "is-callable": "^1.1.3"
+        "@swc/helpers": "^0.3.13",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "deep-equal": "^2.0.5",
+        "dfa": "^1.2.0",
+        "restructure": "^2.0.1",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.3.1",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/fontkit/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/for-in": {
@@ -7279,34 +7045,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
       "integrity": "sha512-J+ler7Ta54FwwNcx6wQRDhTIbNeyDcARMkOcguEqnEdtm0jKvN3Li3PDAb2Du3ubJYEWfYL83XMROXdsXAXycw=="
-    },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/foreground-child/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/forever-agent": {
       "version": "0.6.1",
@@ -7389,6 +7127,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -8114,11 +7858,11 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dependencies": {
-        "get-intrinsic": "^1.1.1"
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8495,13 +8239,13 @@
       }
     },
     "node_modules/internal-slot": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
-      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dependencies": {
-        "get-intrinsic": "^1.2.0",
-        "has": "^1.0.3",
-        "side-channel": "^1.0.4"
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8547,6 +8291,21 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-array-buffer": {
@@ -8709,6 +8468,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
@@ -8783,6 +8553,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-shared-array-buffer": {
@@ -8873,12 +8654,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
       "dependencies": {
         "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8931,20 +8738,11 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
+    "node_modules/jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info."
     },
     "node_modules/js-stringify": {
       "version": "1.0.2",
@@ -9403,6 +9201,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/linkify-it": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
@@ -9455,6 +9270,30 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -9465,6 +9304,12 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "1.0.2",
@@ -10183,15 +10028,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -10901,6 +10737,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -11252,14 +11103,14 @@
       }
     },
     "node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
       "dependencies": {
-        "p-try": "^2.0.0"
+        "yocto-queue": "^1.2.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -11274,6 +11125,20 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-timeout": {
@@ -11308,12 +11173,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "license": "BlueOak-1.0.0"
     },
     "node_modules/pako": {
       "version": "1.0.11",
@@ -11503,28 +11362,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
-    },
     "node_modules/path-to-regexp": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
@@ -11535,6 +11372,18 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
+    },
+    "node_modules/pdfkit": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.15.2.tgz",
+      "integrity": "sha512-s3GjpdBFSCaeDSX/v73MI5UsPqH1kjKut2AXCgxQ5OH10lPVOu5q5vLAG0OCpz/EYqKsTSw1WHpENqMvp43RKg==",
+      "dependencies": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^1.8.1",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.0.2",
+        "png-js": "^1.0.0"
+      }
     },
     "node_modules/peberminta": {
       "version": "0.10.0",
@@ -11590,6 +11439,22 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/png-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/pptxgenjs": {
@@ -11678,15 +11543,6 @@
       "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -11973,15 +11829,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/readdir-glob": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
-      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.1.0"
-      }
-    },
     "node_modules/rechoir": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
@@ -12040,13 +11887,16 @@
       "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
-      "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "functions-have-names": "^1.2.3"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12220,6 +12070,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/restructure": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-2.0.1.tgz",
+      "integrity": "sha512-e0dOpjm5DseomnXx2M5lpdZ5zoHqF1+bqdMJUohoYVVQa7cBdnk7fdmeI6byNWP/kiME72EeTiSypTCVnpLiDg=="
     },
     "node_modules/ret": {
       "version": "0.1.15",
@@ -12462,6 +12317,36 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
@@ -12838,23 +12723,24 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/streamx": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
-      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
-      "license": "MIT",
-      "dependencies": {
-        "events-universal": "^1.0.0",
-        "fast-fifo": "^1.3.2",
-        "text-decoder": "^1.1.0"
       }
     },
     "node_modules/string_decoder": {
@@ -12927,21 +12813,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/string.prototype.trim": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
@@ -12988,19 +12859,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -13139,33 +12997,19 @@
       }
     },
     "node_modules/tar-stream": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
-      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "license": "MIT",
       "dependencies": {
-        "b4a": "^1.6.4",
-        "bare-fs": "^4.5.5",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
-    "node_modules/teex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
-      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
-      "license": "MIT",
-      "dependencies": {
-        "streamx": "^2.12.5"
-      }
-    },
-    "node_modules/text-decoder": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
-      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.6.4"
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/text-hex": {
@@ -13182,6 +13026,11 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
     },
     "node_modules/titleize": {
       "version": "2.1.0",
@@ -13505,6 +13354,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/unicode-property-aliases-ecmascript": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
@@ -13512,6 +13370,20 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
     },
     "node_modules/universalify": {
       "version": "0.1.2",
@@ -13867,21 +13739,40 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/which-module": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
-      "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dependencies": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -14020,57 +13911,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -14259,58 +14099,29 @@
         "fd-slicer": "~1.1.0"
       }
     },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/zip-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
-      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.3.tgz",
+      "integrity": "sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==",
       "license": "MIT",
       "dependencies": {
-        "archiver-utils": "^5.0.0",
-        "compress-commons": "^6.0.2",
-        "readable-stream": "^4.0.0"
+        "archiver-utils": "^2.1.0",
+        "compress-commons": "^2.1.1",
+        "readable-stream": "^3.4.0"
       },
       "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/zip-stream/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/zip-stream/node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": ">= 6"
       }
     }
   },
@@ -16283,64 +16094,6 @@
       "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
       "optional": true
     },
-    "@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "requires": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "6.2.2",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-          "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="
-        },
-        "ansi-styles": {
-          "version": "6.2.3",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-          "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="
-        },
-        "emoji-regex": {
-          "version": "9.2.2",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-          "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
-        },
-        "string-width": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-          "requires": {
-            "eastasianwidth": "^0.2.0",
-            "emoji-regex": "^9.2.2",
-            "strip-ansi": "^7.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-          "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-          "requires": {
-            "ansi-regex": "^6.2.2"
-          }
-        },
-        "wrap-ansi": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-          "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-          "requires": {
-            "ansi-styles": "^6.1.0",
-            "string-width": "^5.0.1",
-            "strip-ansi": "^7.0.1"
-          }
-        }
-      }
-    },
     "@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -16443,12 +16196,6 @@
       "requires": {
         "sparse-bitfield": "^3.0.3"
       }
-    },
-    "@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "optional": true
     },
     "@redis/bloom": {
       "version": "1.2.0",
@@ -17217,6 +16964,21 @@
         }
       }
     },
+    "@swc/helpers": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz",
+      "integrity": "sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==",
+      "requires": {
+        "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
     "@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -17267,14 +17029,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "requires": {
-        "event-target-shim": "^5.0.0"
-      }
     },
     "accepts": {
       "version": "1.3.8",
@@ -17364,98 +17118,71 @@
       }
     },
     "archiver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
-      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-3.1.1.tgz",
+      "integrity": "sha512-5Hxxcig7gw5Jod/8Gq0OneVgLYET+oNHcxgWItq4TbhOzRLKNAFUb9edAftiMKXvXfCB0vbGrJdZDNq0dWMsxg==",
       "requires": {
-        "archiver-utils": "^5.0.2",
-        "async": "^3.2.4",
-        "buffer-crc32": "^1.0.0",
-        "readable-stream": "^4.0.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^3.0.0",
-        "zip-stream": "^6.0.1"
+        "archiver-utils": "^2.1.0",
+        "async": "^2.6.3",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.1.4",
+        "readable-stream": "^3.4.0",
+        "tar-stream": "^2.1.0",
+        "zip-stream": "^2.1.2"
       },
       "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+        "async": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+          "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
           "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "buffer-crc32": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
-          "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w=="
-        },
-        "readable-stream": {
-          "version": "4.7.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-          "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10",
-            "string_decoder": "^1.3.0"
+            "lodash": "^4.18.0"
           }
         }
       }
     },
     "archiver-utils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
-      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
       "requires": {
-        "glob": "^10.0.0",
+        "glob": "^7.1.4",
         "graceful-fs": "^4.2.0",
-        "is-stream": "^2.0.1",
         "lazystream": "^1.0.0",
-        "lodash": "^4.18.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
         "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
+        "readable-stream": "^2.0.0"
       },
       "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "glob": {
-          "version": "10.5.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-          "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-          "requires": {
-            "foreground-child": "^3.1.0",
-            "jackspeak": "^3.1.2",
-            "minimatch": "^3.1.4",
-            "minipass": "^7.1.2",
-            "package-json-from-dist": "^1.0.0",
-            "path-scurry": "^1.11.1"
-          }
-        },
-        "is-stream": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
         "readable-stream": {
-          "version": "4.7.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-          "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
           "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10",
-            "string_decoder": "^1.3.0"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -17584,9 +17311,12 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "available-typed-arrays": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "requires": {
+        "possible-typed-array-names": "^1.0.0"
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -17597,12 +17327,6 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
-    },
-    "b4a": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
-      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-      "requires": {}
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.4.5",
@@ -17643,55 +17367,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
-    "bare-events": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
-      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
-      "requires": {}
-    },
-    "bare-fs": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
-      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
-      "requires": {
-        "bare-events": "^2.5.4",
-        "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4",
-        "bare-url": "^2.2.2",
-        "fast-fifo": "^1.3.2"
-      }
-    },
-    "bare-os": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
-      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ=="
-    },
-    "bare-path": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
-      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
-      "requires": {
-        "bare-os": "^3.0.1"
-      }
-    },
-    "bare-stream": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
-      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
-      "requires": {
-        "b4a": "^1.8.1",
-        "streamx": "^2.25.0",
-        "teex": "^1.0.1"
-      }
-    },
-    "bare-url": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
-      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
-      "requires": {
-        "bare-path": "^3.0.0"
-      }
     },
     "base64-js": {
       "version": "1.5.1",
@@ -17825,10 +17500,26 @@
         "fill-range": "^7.1.1"
       }
     },
+    "brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "requires": {
+        "base64-js": "^1.1.2"
+      }
+    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
+    },
+    "browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "requires": {
+        "pako": "~1.0.5"
+      }
     },
     "browserslist": {
       "version": "4.21.10",
@@ -17889,12 +17580,14 @@
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
     },
     "call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
       }
     },
     "call-bind-apply-helpers": {
@@ -18238,41 +17931,41 @@
       "dev": true
     },
     "compress-commons": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
-      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-2.1.1.tgz",
+      "integrity": "sha512-eVw6n7CnEMFzc3duyFVrQEuY1BlHR3rYsSztyG32ibGMW722i3C6IizEGMFmfMU+A+fALvBIwxN3czffTcdA+Q==",
       "requires": {
-        "crc-32": "^1.2.0",
-        "crc32-stream": "^6.0.0",
-        "is-stream": "^2.0.1",
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^3.0.1",
         "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
+        "readable-stream": "^2.3.6"
       },
       "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "is-stream": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
         "readable-stream": {
-          "version": "4.7.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-          "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
           "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10",
-            "string_decoder": "^1.3.0"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -18497,41 +18190,21 @@
         "vary": "^1"
       }
     },
-    "crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="
+    "crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "requires": {
+        "buffer": "^5.1.0"
+      }
     },
     "crc32-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
-      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-3.0.1.tgz",
+      "integrity": "sha512-mctvpXlbzsvK+6z8kJwSJ5crm7yBwrQMTybJzMw1O4lLGJqjlDCXY2Zw7KheiA6XBEcBmfLx1D88mjRGVJtY9w==",
       "requires": {
-        "crc-32": "^1.2.0",
-        "readable-stream": "^4.0.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "readable-stream": {
-          "version": "4.7.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-          "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10",
-            "string_decoder": "^1.3.0"
-          }
-        }
+        "crc": "^3.4.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "cross-spawn": {
@@ -18552,6 +18225,11 @@
           "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         }
       }
+    },
+    "crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "css-select": {
       "version": "5.1.0",
@@ -18649,6 +18327,46 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
     },
+    "deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
+      "requires": {
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "isarray": "^2.0.5",
+        "object-is": "^1.1.5",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
+        "which-collection": "^1.0.1",
+        "which-typed-array": "^1.1.13"
+      },
+      "dependencies": {
+        "object.assign": {
+          "version": "4.1.7",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+          "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+          "requires": {
+            "call-bind": "^1.0.8",
+            "call-bound": "^1.0.3",
+            "define-properties": "^1.2.1",
+            "es-object-atoms": "^1.0.0",
+            "has-symbols": "^1.1.0",
+            "object-keys": "^1.1.1"
+          }
+        }
+      }
+    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -18680,11 +18398,22 @@
         "native-promise-only": "^0.8.1"
       }
     },
-    "define-properties": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
-      "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+    "define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "requires": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      }
+    },
+    "define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "requires": {
+        "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
       }
@@ -18728,6 +18457,11 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="
+    },
+    "dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="
     },
     "diff": {
       "version": "3.5.1",
@@ -18864,11 +18598,6 @@
         }
       }
     },
-    "eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
-    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -18933,6 +18662,14 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
       "integrity": "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A=="
+    },
+    "end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "entities": {
       "version": "2.2.0",
@@ -19031,6 +18768,22 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
     },
+    "es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      }
+    },
     "es-object-atoms": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
@@ -19105,28 +18858,10 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
     },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
-    },
     "eventemitter2": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "integrity": "sha512-K7J4xq5xAD5jHsGM5ReWXRTFa3JRGofHiMcVgQ8PRwgWxzjHpMWCIzsmyf60+mh8KLsqYPcjUMa0AC4hd6lPyQ=="
-    },
-    "events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
-    },
-    "events-universal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
-      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
-      "requires": {
-        "bare-events": "^2.7.0"
-      }
     },
     "execa": {
       "version": "0.10.0",
@@ -19283,11 +19018,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
-    },
-    "fast-fifo": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -19524,12 +19254,35 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
-    "for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+    "fontkit": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
+      "integrity": "sha512-HkW/8Lrk8jl18kzQHvAw9aTHe1cqsyx5sDnxncx652+CIfhawokEPkeM3BoIC+z/Xv7a0yMr0f3pRRwhGH455g==",
       "requires": {
-        "is-callable": "^1.1.3"
+        "@swc/helpers": "^0.3.13",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "deep-equal": "^2.0.5",
+        "dfa": "^1.2.0",
+        "restructure": "^2.0.1",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.3.1",
+        "unicode-trie": "^2.0.0"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+          "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
+        }
+      }
+    },
+    "for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "requires": {
+        "is-callable": "^1.2.7"
       }
     },
     "for-in": {
@@ -19549,22 +19302,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
       "integrity": "sha512-J+ler7Ta54FwwNcx6wQRDhTIbNeyDcARMkOcguEqnEdtm0jKvN3Li3PDAb2Du3ubJYEWfYL83XMROXdsXAXycw=="
-    },
-    "foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "requires": {
-        "cross-spawn": "^6.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "dependencies": {
-        "signal-exit": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
-        }
-      }
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -19613,6 +19350,11 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
       "version": "8.1.0",
@@ -20122,11 +19864,11 @@
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
     },
     "has-property-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "requires": {
-        "get-intrinsic": "^1.1.1"
+        "es-define-property": "^1.0.0"
       }
     },
     "has-proto": {
@@ -20380,13 +20122,13 @@
       }
     },
     "internal-slot": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
-      "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "requires": {
-        "get-intrinsic": "^1.2.0",
-        "has": "^1.0.3",
-        "side-channel": "^1.0.4"
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
       }
     },
     "interpret": {
@@ -20416,6 +20158,15 @@
       "requires": {
         "is-relative": "^1.0.0",
         "is-windows": "^1.0.1"
+      }
+    },
+    "is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "requires": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       }
     },
     "is-array-buffer": {
@@ -20513,6 +20264,11 @@
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="
     },
+    "is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="
+    },
     "is-negative-zero": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
@@ -20560,6 +20316,11 @@
       "requires": {
         "is-unc-path": "^1.0.0"
       }
+    },
+    "is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg=="
     },
     "is-shared-array-buffer": {
       "version": "1.0.2",
@@ -20616,12 +20377,26 @@
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
     },
+    "is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w=="
+    },
     "is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
       "requires": {
         "call-bind": "^1.0.2"
+      }
+    },
+    "is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "requires": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
       }
     },
     "is-what": {
@@ -20662,14 +20437,10 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
-    "jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "requires": {
-        "@isaacs/cliui": "^8.0.2",
-        "@pkgjs/parseargs": "^0.11.0"
-      }
+    "jpeg-exif": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/jpeg-exif/-/jpeg-exif-1.1.4.tgz",
+      "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ=="
     },
     "js-stringify": {
       "version": "1.0.2",
@@ -21033,6 +20804,22 @@
         }
       }
     },
+    "linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "requires": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+          "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="
+        }
+      }
+    },
     "linkify-it": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
@@ -21070,6 +20857,26 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+    },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA=="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -21080,6 +20887,11 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg=="
+    },
+    "lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw=="
     },
     "log-symbols": {
       "version": "1.0.2",
@@ -21601,11 +21413,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
-    "minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="
-    },
     "mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -22103,6 +21910,15 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
     },
+    "object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "requires": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      }
+    },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -22354,11 +22170,11 @@
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="
     },
     "p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-7.3.0.tgz",
+      "integrity": "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==",
       "requires": {
-        "p-try": "^2.0.0"
+        "yocto-queue": "^1.2.1"
       }
     },
     "p-locate": {
@@ -22367,6 +22183,16 @@
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "requires": {
         "p-limit": "^2.0.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        }
       }
     },
     "p-timeout": {
@@ -22389,11 +22215,6 @@
       "requires": {
         "p-timeout": "^3.0.0"
       }
-    },
-    "package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
     },
     "pako": {
       "version": "1.0.11",
@@ -22525,22 +22346,6 @@
       "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
       "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ=="
     },
-    "path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "requires": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "10.4.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
-        }
-      }
-    },
     "path-to-regexp": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
@@ -22550,6 +22355,18 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
+    },
+    "pdfkit": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.15.2.tgz",
+      "integrity": "sha512-s3GjpdBFSCaeDSX/v73MI5UsPqH1kjKut2AXCgxQ5OH10lPVOu5q5vLAG0OCpz/EYqKsTSw1WHpENqMvp43RKg==",
+      "requires": {
+        "crypto-js": "^4.2.0",
+        "fontkit": "^1.8.1",
+        "jpeg-exif": "^1.1.4",
+        "linebreak": "^1.0.2",
+        "png-js": "^1.0.0"
+      }
     },
     "peberminta": {
       "version": "0.10.0",
@@ -22588,6 +22405,19 @@
       "requires": {
         "irregular-plurals": "^1.0.0"
       }
+    },
+    "png-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.1.0.tgz",
+      "integrity": "sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==",
+      "requires": {
+        "browserify-zlib": "^0.2.0"
+      }
+    },
+    "possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="
     },
     "pptxgenjs": {
       "version": "4.0.1",
@@ -22661,11 +22491,6 @@
           "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
         }
       }
-    },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -22901,14 +22726,6 @@
         "util-deprecate": "^1.0.1"
       }
     },
-    "readdir-glob": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
-      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
-      "requires": {
-        "minimatch": "^3.1.4"
-      }
-    },
     "rechoir": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
@@ -22957,13 +22774,16 @@
       "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
     },
     "regexp.prototype.flags": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
-      "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "functions-have-names": "^1.2.3"
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
       }
     },
     "regexpu-core": {
@@ -23091,6 +22911,11 @@
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
+    },
+    "restructure": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-2.0.1.tgz",
+      "integrity": "sha512-e0dOpjm5DseomnXx2M5lpdZ5zoHqF1+bqdMJUohoYVVQa7cBdnk7fdmeI6byNWP/kiME72EeTiSypTCVnpLiDg=="
     },
     "ret": {
       "version": "0.1.15",
@@ -23287,6 +23112,30 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+    },
+    "set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "requires": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      }
+    },
+    "set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "requires": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      }
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -23569,20 +23418,19 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
     },
+    "stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      }
+    },
     "streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
-    },
-    "streamx": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
-      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
-      "requires": {
-        "events-universal": "^1.0.0",
-        "fast-fifo": "^1.3.2",
-        "text-decoder": "^1.1.0"
-      }
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -23632,16 +23480,6 @@
         "strip-ansi": "^6.0.1"
       }
     },
-    "string-width-cjs": {
-      "version": "npm:string-width@4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "requires": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      }
-    },
     "string.prototype.trim": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
@@ -23674,14 +23512,6 @@
     },
     "strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "requires": {
-        "ansi-regex": "^5.0.1"
-      }
-    },
-    "strip-ansi-cjs": {
-      "version": "npm:strip-ansi@6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "requires": {
@@ -23793,30 +23623,15 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "tar-stream": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
-      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "requires": {
-        "b4a": "^1.6.4",
-        "bare-fs": "^4.5.5",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
-    "teex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
-      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
-      "requires": {
-        "streamx": "^2.12.5"
-      }
-    },
-    "text-decoder": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
-      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
-      "requires": {
-        "b4a": "^1.6.4"
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
       }
     },
     "text-hex": {
@@ -23833,6 +23648,11 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
     },
     "titleize": {
       "version": "2.1.0",
@@ -24060,10 +23880,35 @@
       "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.1.0.tgz",
       "integrity": "sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA=="
     },
+    "unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "requires": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "unicode-property-aliases-ecmascript": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
       "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w=="
+    },
+    "unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "requires": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      },
+      "dependencies": {
+        "pako": {
+          "version": "0.2.9",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+          "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
+        }
+      }
     },
     "universalify": {
       "version": "0.1.2",
@@ -24326,21 +24171,34 @@
         "is-symbol": "^1.0.3"
       }
     },
+    "which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "requires": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      }
+    },
     "which-module": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
     },
     "which-typed-array": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
-      "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "requires": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
       }
     },
     "wide-align": {
@@ -24440,39 +24298,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        }
-      }
-    },
-    "wrap-ansi-cjs": {
-      "version": "npm:wrap-ansi@7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "requires": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -24631,37 +24456,19 @@
         "fd-slicer": "~1.1.0"
       }
     },
+    "yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="
+    },
     "zip-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
-      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.1.3.tgz",
+      "integrity": "sha512-EkXc2JGcKhO5N5aZ7TmuNo45budRaFGHOmz24wtJR7znbNqDPmdZtUauKX6et8KAVseAMBOyWJqEpXcHTBsh7Q==",
       "requires": {
-        "archiver-utils": "^5.0.0",
-        "compress-commons": "^6.0.2",
-        "readable-stream": "^4.0.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
-        "readable-stream": {
-          "version": "4.7.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-          "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10",
-            "string_decoder": "^1.3.0"
-          }
-        }
+        "archiver-utils": "^2.1.0",
+        "compress-commons": "^2.1.1",
+        "readable-stream": "^3.4.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "p-limit": "^7.3.0",
     "passport": "^0.6.0",
     "passport-local": "^1.0.0",
+    "pdfkit": "^0.15.2",
     "rate-limit-redis": "^4.2.0",
     "redis": "^4.6.12",
     "request": "^2.88.0",

--- a/plugins/content/storyboard/index.js
+++ b/plugins/content/storyboard/index.js
@@ -1,0 +1,39 @@
+// Storyboard content-type plugin (ADAPT-3760 / ADAPT-3779, AC8).
+//
+// Registers a `storyboard` Mongoose model (schema-backed via model.schema) and
+// a dedicated REST surface under /api/storyboard/{documents,comments,audit}.
+// documentJson and _generatedContentMap are stored as JSON strings and (de)
+// serialised at the route boundary — see routes/requestHandlers.js.
+//
+// NB: the legacy `plugins/output/storyboard` plugin also owns /api/storyboard/*
+// (word/zip/import). Our routes are namespaced under distinct sub-paths
+// (documents / comments / audit) so they never collide. permissions.ignoreRoute
+// is idempotent, so registering it here is safe even when that plugin is off.
+
+const contentmanager = require('../../../lib/contentmanager');
+const ContentPlugin = contentmanager.ContentPlugin;
+const permissions = require('../../../lib/permissions');
+const Routes = require('./routes');
+
+class StoryboardContent extends ContentPlugin {
+  getModelName = () => 'storyboard';
+
+  getChildType = () => false;
+
+  // TODO(Phase 5): real ownership/course-scoped permissions. For now allow all
+  // (matches the templating content plugin) — access is gated by the engine
+  // session; the storyboard routes carry their own auth checks.
+  hasPermission = (action, userId, tenantId, contentItem, next) => next(null, true);
+
+  getMiddleware = (server, callback) => {
+    this.server = server;
+    callback(this.addMiddleware.bind(this));
+  };
+
+  addMiddleware = () => {
+    permissions.ignoreRoute(/\/api\/storyboard\/?.*$/);
+    this.routes = new Routes();
+  };
+}
+
+module.exports = StoryboardContent;

--- a/plugins/content/storyboard/model.schema
+++ b/plugins/content/storyboard/model.schema
@@ -1,0 +1,46 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "id": "http://jsonschema.net",
+  "$ref": "http://localhost/system/tenantObject.schema",
+  "properties": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "default": "Untitled Storyboard",
+      "inputType": "Text",
+      "validators": ["required"]
+    },
+    "_courseId": {
+      "type": "objectid",
+      "required": true
+    },
+    "_tenantId": {
+      "type": "objectid",
+      "required": true
+    },
+    "createdBy": {
+      "type": "objectid",
+      "required": false,
+      "ref": "user"
+    },
+    "status": {
+      "type": "string",
+      "required": true,
+      "default": "draft"
+    },
+    "version": {
+      "type": "number",
+      "required": true,
+      "default": 1
+    },
+    "documentJson": {
+      "type": "string",
+      "default": "[]"
+    },
+    "_generatedContentMap": {
+      "type": "string",
+      "default": "{}"
+    }
+  }
+}

--- a/plugins/content/storyboard/package.json
+++ b/plugins/content/storyboard/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "adapt-content-storyboard",
+  "displayName": "Storyboard",
+  "version": "0.1.0",
+  "main": "index",
+  "dependencies": {}
+}

--- a/plugins/content/storyboard/routes/index.js
+++ b/plugins/content/storyboard/routes/index.js
@@ -1,0 +1,43 @@
+// REST routes for the storyboard feature (ADAPT-3779, AC8/AC9).
+// All under /api/storyboard/* (rest prefixes /api). Sub-paths chosen to avoid
+// collision with the legacy output/storyboard plugin (word/zip/import/...).
+
+const rest = require('../../../../lib/rest');
+const h = require('./requestHandlers');
+
+class Routes {
+  constructor() {
+    this.register();
+  }
+
+  register() {
+    // ── Storyboard documents ──────────────────────────────────────────────
+    rest.post('/storyboard/documents', h.createStoryboard);
+    // `/course/:courseId` uses a literal segment so it never clashes with `/:id`.
+    rest.get('/storyboard/documents/course/:courseId', h.getStoryboardByCourse);
+    rest.get('/storyboard/documents/:id', h.getStoryboard);
+    rest.put('/storyboard/documents/:id', h.updateStoryboard);
+    rest.put('/storyboard/documents/:id/status', h.setStoryboardStatus);
+    rest.delete('/storyboard/documents/:id', h.deleteStoryboard);
+
+    // ── Comments (AC9) ────────────────────────────────────────────────────
+    rest.get('/storyboard/documents/:id/comments', h.listComments);
+    rest.post('/storyboard/documents/:id/comments', h.addComment);
+    rest.put('/storyboard/comments/:commentId', h.updateComment);
+    rest.delete('/storyboard/comments/:commentId', h.deleteComment);
+
+    // ── Audit trail (AC8) — append-only, no update/delete ─────────────────
+    rest.get('/storyboard/documents/:id/audit', h.listAudit);
+    rest.post('/storyboard/documents/:id/audit', h.addAudit);
+
+    // ── AI assistance (AC7) — server-side proxy ───────────────────────────
+    rest.post('/storyboard/ai', h.handleAi);
+
+    // ── Import / Export (AC10) ────────────────────────────────────────────
+    rest.get('/storyboard/documents/:id/export/word', h.exportWord);
+    rest.get('/storyboard/documents/:id/export/pdf', h.exportPdf);
+    rest.post('/storyboard/import/:format', h.importDocument);
+  }
+}
+
+exports = module.exports = Routes;

--- a/plugins/content/storyboard/routes/requestHandlers.js
+++ b/plugins/content/storyboard/routes/requestHandlers.js
@@ -1,0 +1,375 @@
+// Request handlers for /api/storyboard/* (ADAPT-3779).
+//
+// documentJson / _generatedContentMap / audit.meta are stored as JSON strings
+// in Mongo (robust round-trip of arbitrary BlockNote JSON, independent of the
+// custom schema importer) and exposed as parsed objects over the API.
+
+const app = require('../../../../')();
+const db = require('../utils/database');
+const ai = require('../utils/aiClient');
+const convert = require('../utils/documentConvert');
+
+const STATUSES = ['draft', 'in_review', 'approved'];
+const AUDIT_EVENTS = ['status_change', 'generated', 'imported'];
+const AI_ACTIONS = ['improve', 'rewrite', 'summarize', 'suggest'];
+
+// Resolve the current user + tenant. Prefer passport's req.user, fall back to
+// the usermanager (same convention as the templating plugin).
+function userCtx(req) {
+  const user = req && req.user && req.user._id ? req.user : app.usermanager.getCurrentUser();
+  return {
+    userId: user && user._id,
+    tenantId: user && user.tenant && user.tenant._id,
+  };
+}
+
+function safeParse(value, fallback) {
+  if (typeof value !== 'string') return value == null ? fallback : value;
+  try {
+    return JSON.parse(value);
+  } catch (e) {
+    return fallback;
+  }
+}
+
+function toPlain(doc) {
+  return doc && typeof doc.toObject === 'function' ? doc.toObject() : doc;
+}
+
+function serializeStoryboard(doc) {
+  const o = toPlain(doc);
+  if (!o) return o;
+  return {
+    ...o,
+    documentJson: safeParse(o.documentJson, []),
+    _generatedContentMap: safeParse(o._generatedContentMap, {}),
+  };
+}
+
+function serializeAudit(doc) {
+  const o = toPlain(doc);
+  if (!o) return o;
+  return { ...o, meta: safeParse(o.meta, {}) };
+}
+
+function fail(res, error, message) {
+  console.error(`[storyboard] ${message}:`, error);
+  return res.status(500).json({ error: message });
+}
+
+// ── Storyboard documents ────────────────────────────────────────────────────
+
+async function createStoryboard(req, res) {
+  try {
+    const { userId, tenantId } = userCtx(req);
+    const body = req.body || {};
+    if (!body._courseId) return res.status(400).json({ error: '_courseId is required' });
+
+    const data = {
+      _courseId: body._courseId,
+      _tenantId: tenantId,
+      createdBy: userId,
+      title: body.title || 'Untitled Storyboard',
+      status: STATUSES.includes(body.status) ? body.status : 'draft',
+      version: 1,
+      documentJson: JSON.stringify(body.documentJson != null ? body.documentJson : []),
+      _generatedContentMap: JSON.stringify(body._generatedContentMap != null ? body._generatedContentMap : {}),
+    };
+    const created = await db.create('storyboard', data);
+    return res.status(201).json(serializeStoryboard(created));
+  } catch (error) {
+    return fail(res, error, 'Failed to create storyboard');
+  }
+}
+
+async function getStoryboardByCourse(req, res) {
+  try {
+    const results = await db.retrieve('storyboard', { _courseId: req.params.courseId });
+    const rec = Array.isArray(results) && results.length ? results[0] : null;
+    return res.status(200).json(rec ? serializeStoryboard(rec) : null);
+  } catch (error) {
+    return fail(res, error, 'Failed to retrieve storyboard by course');
+  }
+}
+
+async function getStoryboard(req, res) {
+  try {
+    const results = await db.retrieve('storyboard', { _id: req.params.id });
+    if (!Array.isArray(results) || !results.length) {
+      return res.status(404).json({ error: 'Storyboard not found' });
+    }
+    return res.status(200).json(serializeStoryboard(results[0]));
+  } catch (error) {
+    return fail(res, error, 'Failed to retrieve storyboard');
+  }
+}
+
+async function updateStoryboard(req, res) {
+  try {
+    const { userId } = userCtx(req);
+    const body = req.body || {};
+    const delta = { updatedBy: userId };
+    if (typeof body.title === 'string') delta.title = body.title;
+    if (STATUSES.includes(body.status)) delta.status = body.status;
+    if (typeof body.version === 'number') delta.version = body.version;
+    if (body.documentJson !== undefined) delta.documentJson = JSON.stringify(body.documentJson);
+    if (body._generatedContentMap !== undefined) {
+      delta._generatedContentMap = JSON.stringify(body._generatedContentMap);
+    }
+
+    await db.update('storyboard', { _id: req.params.id }, delta);
+    const results = await db.retrieve('storyboard', { _id: req.params.id });
+    return res.status(200).json(serializeStoryboard(results[0]));
+  } catch (error) {
+    return fail(res, error, 'Failed to update storyboard');
+  }
+}
+
+// Change status AND append an immutable status_change audit event (AC8).
+async function setStoryboardStatus(req, res) {
+  try {
+    const { userId, tenantId } = userCtx(req);
+    const status = (req.body || {}).status;
+    if (!STATUSES.includes(status)) {
+      return res.status(400).json({ error: `status must be one of ${STATUSES.join(', ')}` });
+    }
+    const existing = await db.retrieve('storyboard', { _id: req.params.id });
+    if (!Array.isArray(existing) || !existing.length) {
+      return res.status(404).json({ error: 'Storyboard not found' });
+    }
+    const current = toPlain(existing[0]);
+    const fromStatus = current.status;
+
+    await db.update('storyboard', { _id: req.params.id }, { status, updatedBy: userId });
+    await db.create('storyboardaudit', {
+      _storyboardId: req.params.id,
+      _courseId: current._courseId,
+      _tenantId: tenantId,
+      createdBy: userId,
+      event: 'status_change',
+      fromStatus,
+      toStatus: status,
+      meta: '{}',
+    });
+
+    const updated = await db.retrieve('storyboard', { _id: req.params.id });
+    return res.status(200).json(serializeStoryboard(updated[0]));
+  } catch (error) {
+    return fail(res, error, 'Failed to change storyboard status');
+  }
+}
+
+async function deleteStoryboard(req, res) {
+  try {
+    await db.destroy('storyboard', { _id: req.params.id });
+    return res.status(200).json({ success: true });
+  } catch (error) {
+    return fail(res, error, 'Failed to delete storyboard');
+  }
+}
+
+// ── Comments (AC9) ───────────────────────────────────────────────────────────
+
+async function listComments(req, res) {
+  try {
+    const results = (await db.retrieve('storyboardcomment', { _storyboardId: req.params.id })) || [];
+    const sorted = results
+      .map(toPlain)
+      .sort((a, b) => new Date(a.createdAt || 0) - new Date(b.createdAt || 0));
+    return res.status(200).json(sorted);
+  } catch (error) {
+    return fail(res, error, 'Failed to list comments');
+  }
+}
+
+async function addComment(req, res) {
+  try {
+    const { userId, tenantId } = userCtx(req);
+    const body = req.body || {};
+    if (!body.blockId) return res.status(400).json({ error: 'blockId is required' });
+    if (!body.body) return res.status(400).json({ error: 'body is required' });
+
+    const data = {
+      _storyboardId: req.params.id,
+      _courseId: body._courseId,
+      _tenantId: tenantId,
+      createdBy: userId,
+      blockId: body.blockId,
+      body: body.body,
+      resolved: false,
+    };
+    if (body._parentCommentId) data._parentCommentId = body._parentCommentId;
+
+    const created = await db.create('storyboardcomment', data);
+    return res.status(201).json(toPlain(created));
+  } catch (error) {
+    return fail(res, error, 'Failed to add comment');
+  }
+}
+
+async function updateComment(req, res) {
+  try {
+    const { userId } = userCtx(req);
+    const body = req.body || {};
+    const delta = { updatedBy: userId };
+    if (typeof body.body === 'string') delta.body = body.body;
+    if (typeof body.resolved === 'boolean') delta.resolved = body.resolved;
+
+    await db.update('storyboardcomment', { _id: req.params.commentId }, delta);
+    const results = await db.retrieve('storyboardcomment', { _id: req.params.commentId });
+    if (!Array.isArray(results) || !results.length) {
+      return res.status(404).json({ error: 'Comment not found' });
+    }
+    return res.status(200).json(toPlain(results[0]));
+  } catch (error) {
+    return fail(res, error, 'Failed to update comment');
+  }
+}
+
+async function deleteComment(req, res) {
+  try {
+    await db.destroy('storyboardcomment', { _id: req.params.commentId });
+    return res.status(200).json({ success: true });
+  } catch (error) {
+    return fail(res, error, 'Failed to delete comment');
+  }
+}
+
+// ── Audit trail (AC8) — append-only ──────────────────────────────────────────
+
+async function listAudit(req, res) {
+  try {
+    const results = (await db.retrieve('storyboardaudit', { _storyboardId: req.params.id })) || [];
+    const sorted = results
+      .map(serializeAudit)
+      .sort((a, b) => new Date(b.createdAt || 0) - new Date(a.createdAt || 0));
+    return res.status(200).json(sorted);
+  } catch (error) {
+    return fail(res, error, 'Failed to list audit events');
+  }
+}
+
+async function addAudit(req, res) {
+  try {
+    const { userId, tenantId } = userCtx(req);
+    const body = req.body || {};
+    if (!AUDIT_EVENTS.includes(body.event)) {
+      return res.status(400).json({ error: `event must be one of ${AUDIT_EVENTS.join(', ')}` });
+    }
+    const data = {
+      _storyboardId: req.params.id,
+      _courseId: body._courseId,
+      _tenantId: tenantId,
+      createdBy: userId,
+      event: body.event,
+      fromStatus: body.fromStatus,
+      toStatus: body.toStatus,
+      meta: JSON.stringify(body.meta != null ? body.meta : {}),
+    };
+    const created = await db.create('storyboardaudit', data);
+    return res.status(201).json(serializeAudit(created));
+  } catch (error) {
+    return fail(res, error, 'Failed to add audit event');
+  }
+}
+
+// ── AI assistance (AC7) — server-side proxy, key never leaves the server ─────
+
+async function handleAi(req, res) {
+  try {
+    const body = req.body || {};
+    const action = AI_ACTIONS.includes(body.action) ? body.action : 'improve';
+    const text = String(body.text || '');
+    if (!text.trim()) return res.status(400).json({ error: 'text is required' });
+    const result = await ai.run(action, text, body.context);
+    return res.status(200).json({ text: result });
+  } catch (error) {
+    const code = error && error.statusCode ? error.statusCode : 500;
+    console.error('[storyboard] AI action failed:', error && error.message);
+    return res.status(code).json({ error: (error && error.message) || 'AI request failed' });
+  }
+}
+
+// ── Import / Export (AC10) ───────────────────────────────────────────────────
+// Binary is exchanged as base64 in JSON so it flows through the standard JSON
+// client (no multipart/multer wiring needed).
+
+async function exportWord(req, res) {
+  try {
+    const results = await db.retrieve('storyboard', { _id: req.params.id });
+    if (!Array.isArray(results) || !results.length) {
+      return res.status(404).json({ error: 'Storyboard not found' });
+    }
+    const rec = toPlain(results[0]);
+    const blocks = safeParse(rec.documentJson, []);
+    const buffer = await convert.blocksToDocx(blocks, rec.title || 'Storyboard');
+    const safeName = String(rec.title || 'storyboard').replace(/[^\w.-]+/g, '_');
+    return res.status(200).json({
+      filename: `${safeName}.docx`,
+      mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      dataBase64: buffer.toString('base64'),
+    });
+  } catch (error) {
+    return fail(res, error, 'Failed to export Word document');
+  }
+}
+
+async function exportPdf(req, res) {
+  try {
+    const results = await db.retrieve('storyboard', { _id: req.params.id });
+    if (!Array.isArray(results) || !results.length) {
+      return res.status(404).json({ error: 'Storyboard not found' });
+    }
+    const rec = toPlain(results[0]);
+    const blocks = safeParse(rec.documentJson, []);
+    const buffer = await convert.blocksToPdf(blocks, rec.title || 'Storyboard');
+    const safeName = String(rec.title || 'storyboard').replace(/[^\w.-]+/g, '_');
+    return res.status(200).json({
+      filename: `${safeName}.pdf`,
+      mime: 'application/pdf',
+      dataBase64: buffer.toString('base64'),
+    });
+  } catch (error) {
+    return fail(res, error, 'Failed to export PDF document');
+  }
+}
+
+async function importDocument(req, res) {
+  try {
+    const format = req.params.format;
+    const b64 = (req.body || {}).dataBase64;
+    if (!b64) return res.status(400).json({ error: 'dataBase64 is required' });
+    const buffer = Buffer.from(b64, 'base64');
+
+    let blocks;
+    if (format === 'word') blocks = await convert.wordToBlocks(buffer);
+    else if (format === 'pptx') blocks = convert.pptxToBlocks(buffer);
+    else if (format === 'pdf') blocks = await convert.pdfToBlocks(buffer);
+    else return res.status(400).json({ error: `Unsupported import format: ${format}` });
+
+    return res.status(200).json({ blocks });
+  } catch (error) {
+    const code = error && error.statusCode ? error.statusCode : 500;
+    console.error('[storyboard] import failed:', error && error.message);
+    return res.status(code).json({ error: (error && error.message) || 'Import failed' });
+  }
+}
+
+module.exports = {
+  createStoryboard,
+  getStoryboardByCourse,
+  getStoryboard,
+  updateStoryboard,
+  setStoryboardStatus,
+  deleteStoryboard,
+  listComments,
+  addComment,
+  updateComment,
+  deleteComment,
+  listAudit,
+  addAudit,
+  handleAi,
+  exportWord,
+  exportPdf,
+  importDocument,
+};

--- a/plugins/content/storyboard/routes/requestHandlers.js
+++ b/plugins/content/storyboard/routes/requestHandlers.js
@@ -11,7 +11,7 @@ const convert = require('../utils/documentConvert');
 
 const STATUSES = ['draft', 'in_review', 'approved'];
 const AUDIT_EVENTS = ['status_change', 'generated', 'imported'];
-const AI_ACTIONS = ['improve', 'rewrite', 'summarize', 'suggest'];
+const AI_ACTIONS = ['improve', 'rewrite', 'summarize', 'suggest', 'shorten', 'lengthen', 'spelling', 'custom'];
 
 // Resolve the current user + tenant. Prefer passport's req.user, fall back to
 // the usermanager (same convention as the templating plugin).
@@ -280,8 +280,17 @@ async function handleAi(req, res) {
     const body = req.body || {};
     const action = AI_ACTIONS.includes(body.action) ? body.action : 'improve';
     const text = String(body.text || '');
-    if (!text.trim()) return res.status(400).json({ error: 'text is required' });
-    const result = await ai.run(action, text, body.context);
+    const instruction = String(body.instruction || '');
+    // 'custom' (free-text) may generate from scratch with only an instruction;
+    // every other action operates on `text`.
+    if (action === 'custom') {
+      if (!text.trim() && !instruction.trim()) {
+        return res.status(400).json({ error: 'text or instruction is required' });
+      }
+    } else if (!text.trim()) {
+      return res.status(400).json({ error: 'text is required' });
+    }
+    const result = await ai.run(action, text, body.context, instruction);
     return res.status(200).json({ text: result });
   } catch (error) {
     const code = error && error.statusCode ? error.statusCode : 500;
@@ -301,9 +310,12 @@ async function exportWord(req, res) {
       return res.status(404).json({ error: 'Storyboard not found' });
     }
     const rec = toPlain(results[0]);
+    // Prefer the course title (passed by the client) so the document heading
+    // and filename match the course, not the internal storyboard record title.
+    const docTitle = (req.query && req.query.title) || rec.title || 'Storyboard';
     const blocks = safeParse(rec.documentJson, []);
-    const buffer = await convert.blocksToDocx(blocks, rec.title || 'Storyboard');
-    const safeName = String(rec.title || 'storyboard').replace(/[^\w.-]+/g, '_');
+    const buffer = await convert.blocksToDocx(blocks, docTitle);
+    const safeName = String(docTitle).replace(/[^\w.-]+/g, '_') || 'storyboard';
     return res.status(200).json({
       filename: `${safeName}.docx`,
       mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
@@ -321,9 +333,10 @@ async function exportPdf(req, res) {
       return res.status(404).json({ error: 'Storyboard not found' });
     }
     const rec = toPlain(results[0]);
+    const docTitle = (req.query && req.query.title) || rec.title || 'Storyboard';
     const blocks = safeParse(rec.documentJson, []);
-    const buffer = await convert.blocksToPdf(blocks, rec.title || 'Storyboard');
-    const safeName = String(rec.title || 'storyboard').replace(/[^\w.-]+/g, '_');
+    const buffer = await convert.blocksToPdf(blocks, docTitle);
+    const safeName = String(docTitle).replace(/[^\w.-]+/g, '_') || 'storyboard';
     return res.status(200).json({
       filename: `${safeName}.pdf`,
       mime: 'application/pdf',

--- a/plugins/content/storyboard/utils/aiClient.js
+++ b/plugins/content/storyboard/utils/aiClient.js
@@ -1,0 +1,97 @@
+// Server-side AI client for the storyboard (ADAPT-3760, Phase 6 / AC7).
+//
+// Mirrors the LEATS Azure OpenAI pattern (plugins/services/translation/routes/
+// leats/leatsClient.js): the API key stays on the server (config or env), never
+// in the browser. Uses Node's global fetch (Node 18+).
+
+const configuration = require('../../../../lib/configuration');
+
+const PLACEHOLDERS = new Set(['', 'CHANGE_ME', 'YOUR_KEY', 'undefined', 'null']);
+
+function cfg(key, envKey, fallback) {
+  let v;
+  try {
+    v = configuration.getConfig(key);
+  } catch (e) {
+    v = undefined;
+  }
+  if (v == null || v === '') v = process.env[envKey];
+  if (v == null || v === '') v = fallback;
+  return v;
+}
+
+// Prefer storyboard-specific config, then fall back to the shared Samaritan
+// (ckEditor AI) credentials already used elsewhere in the tool.
+function getSettings() {
+  const key = cfg('storyboardAiKey', 'STORYBOARD_AI_KEY', cfg('ckEditorAIApiKey', 'CKEditor_AI_ASST_API_KEY', ''));
+  const endpoint = String(
+    cfg('storyboardAiEndpoint', 'STORYBOARD_AI_ENDPOINT', 'https://p-ais-ne-ais-adapt.openai.azure.com')
+  )
+    .trim()
+    .replace(/\/+$/, '');
+  const deployment = String(cfg('storyboardAiDeployment', 'STORYBOARD_AI_DEPLOYMENT', 'gpt-4o-mini')).trim();
+  const apiVersion = String(cfg('storyboardAiApiVersion', 'STORYBOARD_AI_APIVERSION', '2025-01-01-preview')).trim();
+  return { key: String(key || '').trim(), endpoint, deployment, apiVersion };
+}
+
+function isConfigured() {
+  const s = getSettings();
+  return !PLACEHOLDERS.has(s.key) && !PLACEHOLDERS.has(s.endpoint);
+}
+
+const SYSTEM_PROMPTS = {
+  improve:
+    'You improve instructional e-learning content. Improve the clarity, grammar and flow of the text without changing its meaning. Return ONLY the improved text, with no preamble or quotes.',
+  rewrite:
+    'You rewrite instructional e-learning content to be clear, concise and engaging while preserving meaning and reading level. Return ONLY the rewritten text.',
+  summarize:
+    'You summarise instructional e-learning content. Produce a concise summary of the text. Return ONLY the summary.',
+  suggest:
+    'You are an instructional designer. Given the content, suggest concrete improvements and additional content ideas. Return a short markdown bullet list.',
+};
+
+// Run an AI action on `text`. Returns the assistant message content.
+async function run(action, text, context) {
+  const s = getSettings();
+  if (PLACEHOLDERS.has(s.key) || PLACEHOLDERS.has(s.endpoint)) {
+    const err = new Error('Storyboard AI is not configured on the server.');
+    err.statusCode = 501;
+    throw err;
+  }
+  const system = SYSTEM_PROMPTS[action] || SYSTEM_PROMPTS.improve;
+  const user = (context ? `Course: ${context}\n\n` : '') + String(text || '');
+  const url = `${s.endpoint}/openai/deployments/${s.deployment}/chat/completions?api-version=${s.apiVersion}`;
+
+  let resp;
+  try {
+    resp = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'api-key': s.key },
+      body: JSON.stringify({
+        messages: [
+          { role: 'system', content: system },
+          { role: 'user', content: user },
+        ],
+        temperature: 0.7,
+        max_completion_tokens: 2048,
+      }),
+    });
+  } catch (e) {
+    const err = new Error(`Azure OpenAI request failed: ${e.message}`);
+    err.statusCode = 502;
+    throw err;
+  }
+
+  if (!resp.ok) {
+    const detail = await resp.text().catch(() => '');
+    const err = new Error(`Azure OpenAI error ${resp.status}: ${detail.slice(0, 200)}`);
+    err.statusCode = 502;
+    throw err;
+  }
+
+  const data = await resp.json().catch(() => null);
+  const content = data && data.choices && data.choices[0] && data.choices[0].message && data.choices[0].message.content;
+  return content || '';
+}
+
+module.exports = { run, isConfigured };

--- a/plugins/content/storyboard/utils/aiClient.js
+++ b/plugins/content/storyboard/utils/aiClient.js
@@ -48,10 +48,23 @@ const SYSTEM_PROMPTS = {
     'You summarise instructional e-learning content. Produce a concise summary of the text. Return ONLY the summary.',
   suggest:
     'You are an instructional designer. Given the content, suggest concrete improvements and additional content ideas. Return a short markdown bullet list.',
+  // Samaritan-parity actions (match the CKEditor "Samaritan Assistance" tool).
+  shorten:
+    'Make this text shorter while preserving its complete meaning. Return ONLY the shortened text, with no preamble or quotes.',
+  lengthen:
+    'Make this text longer with relevant details while preserving its core meaning. Return ONLY the expanded text, with no preamble or quotes.',
+  spelling:
+    'Check and correct spelling and grammar without changing the meaning. Return ONLY the corrected text, with no preamble or quotes.',
+  // Free-text: the user's own instruction drives the model (edit selection or
+  // generate from scratch). The instruction is injected into the user message.
+  custom:
+    'You are Samaritan, an assistant for authoring instructional e-learning content. Follow the user instruction precisely. Return ONLY the resulting content, with no preamble, explanation or quotes.',
 };
 
-// Run an AI action on `text`. Returns the assistant message content.
-async function run(action, text, context) {
+// Run an AI action on `text`. For action === 'custom', `instruction` carries the
+// user's free-text request (and `text` is the optional content to operate on).
+// Returns the assistant message content.
+async function run(action, text, context, instruction) {
   const s = getSettings();
   if (PLACEHOLDERS.has(s.key) || PLACEHOLDERS.has(s.endpoint)) {
     const err = new Error('Storyboard AI is not configured on the server.');
@@ -59,7 +72,13 @@ async function run(action, text, context) {
     throw err;
   }
   const system = SYSTEM_PROMPTS[action] || SYSTEM_PROMPTS.improve;
-  const user = (context ? `Course: ${context}\n\n` : '') + String(text || '');
+  const instr = String(instruction || '').trim();
+  const srcText = String(text || '');
+  const coursePrefix = context ? `Course: ${context}\n\n` : '';
+  const user =
+    action === 'custom'
+      ? coursePrefix + (srcText ? `${srcText}\n\nInstruction: ${instr}` : instr)
+      : coursePrefix + srcText;
   const url = `${s.endpoint}/openai/deployments/${s.deployment}/chat/completions?api-version=${s.apiVersion}`;
 
   let resp;

--- a/plugins/content/storyboard/utils/database.js
+++ b/plugins/content/storyboard/utils/database.js
@@ -1,0 +1,36 @@
+// Promisified CRUD wrappers over the content manager, scoped to the current
+// request's tenant/user (the content manager resolves tenant from the session
+// user). Mirrors plugins/content/templating/utils/database.js.
+
+const app = require('../../../../')();
+
+function create(type, data) {
+  return new Promise((resolve, reject) => {
+    app.contentmanager.create(type, data, (err, result) => (err ? reject(err) : resolve(result)));
+  });
+}
+
+function retrieve(type, search, options) {
+  return new Promise((resolve, reject) => {
+    app.contentmanager.retrieve(type, search, options || {}, (err, results) =>
+      err ? reject(err) : resolve(results)
+    );
+  });
+}
+
+function update(type, search, delta) {
+  return new Promise((resolve, reject) => {
+    app.contentmanager.update(type, search, delta, (err, result) => (err ? reject(err) : resolve(result)));
+  });
+}
+
+// force=true skips the (course) permission pre-check; access is already gated
+// by the route's own auth. The dispatch layer forwards (search, force, cb) to
+// the plugin's destroy(search, force, next).
+function destroy(type, search) {
+  return new Promise((resolve, reject) => {
+    app.contentmanager.destroy(type, search, true, (err) => (err ? reject(err) : resolve()));
+  });
+}
+
+module.exports = { create, retrieve, update, destroy };

--- a/plugins/content/storyboard/utils/database.js
+++ b/plugins/content/storyboard/utils/database.js
@@ -24,12 +24,13 @@ function update(type, search, delta) {
   });
 }
 
-// force=true skips the (course) permission pre-check; access is already gated
-// by the route's own auth. The dispatch layer forwards (search, force, cb) to
-// the plugin's destroy(search, force, next).
+// force=false so the content plugin's hasPermission gates the delete (see
+// ContentPlugin.destroy in lib/contentmanager.js). We do NOT hard-bypass
+// permissions here — the storyboard plugins currently allow the action, and
+// when real ownership/course-scoped checks land they'll be enforced.
 function destroy(type, search) {
   return new Promise((resolve, reject) => {
-    app.contentmanager.destroy(type, search, true, (err) => (err ? reject(err) : resolve()));
+    app.contentmanager.destroy(type, search, false, (err) => (err ? reject(err) : resolve()));
   });
 }
 

--- a/plugins/content/storyboard/utils/documentConvert.js
+++ b/plugins/content/storyboard/utils/documentConvert.js
@@ -1,0 +1,213 @@
+// Storyboard ⇄ document conversion (ADAPT-3760, Phase 7 / AC10).
+//
+// Export: BlockNote document → Word (.docx) via the `docx` lib.
+// Import:  .docx (mammoth) / .pptx (adm-zip, best-effort) / .pdf (pdf-parse if
+//          installed) → BlockNote blocks, preserving heading hierarchy.
+
+const { Document, Packer, Paragraph, HeadingLevel, TextRun } = require('docx');
+
+const HEADING_LEVEL = {
+  1: HeadingLevel.HEADING_1,
+  2: HeadingLevel.HEADING_2,
+  3: HeadingLevel.HEADING_3,
+  4: HeadingLevel.HEADING_4,
+};
+
+function inlineToText(content) {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content.map((n) => (n && typeof n.text === 'string' ? n.text : '')).join('');
+}
+
+function safeParse(value, fallback) {
+  if (typeof value !== 'string') return value == null ? fallback : value;
+  try {
+    return JSON.parse(value);
+  } catch (e) {
+    return fallback;
+  }
+}
+
+function stripTags(html) {
+  return String(html || '')
+    .replace(/<[^>]*>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .trim();
+}
+
+// ── Export → .docx ──────────────────────────────────────────────────────────
+
+async function blocksToDocx(blocks, title) {
+  const children = [];
+  if (title) children.push(new Paragraph({ text: title, heading: HeadingLevel.TITLE }));
+
+  for (const b of Array.isArray(blocks) ? blocks : []) {
+    const text = inlineToText(b && b.content);
+    const props = (b && b.props) || {};
+    if (b && b.type === 'heading') {
+      children.push(new Paragraph({ text, heading: HEADING_LEVEL[props.level] || HeadingLevel.HEADING_4 }));
+    } else if (b && b.type === 'sbAssessment') {
+      const data = safeParse(props.data, {});
+      children.push(
+        new Paragraph({
+          children: [
+            new TextRun({ text: `[Assessment: ${props.kind || ''}] `, bold: true }),
+            new TextRun(data.question || ''),
+          ],
+        })
+      );
+    } else if (b && b.type === 'sbPlaceholder') {
+      children.push(
+        new Paragraph({
+          children: [
+            new TextRun({ text: `[${props.label || 'Placeholder'}] `, bold: true }),
+            new TextRun(props.title || ''),
+          ],
+        })
+      );
+    } else if (text) {
+      children.push(new Paragraph(text));
+    }
+  }
+
+  const doc = new Document({ sections: [{ children }] });
+  return Packer.toBuffer(doc);
+}
+
+// ── Export → .pdf ────────────────────────────────────────────────────────────
+// Server-side PDF via pdfkit (pure-JS, no native deps). Renders the same block
+// shapes as the Word export: a title, headings (sized by level), assessment /
+// placeholder call-outs, and paragraphs.
+
+const PDF_HEADING_SIZE = { 1: 20, 2: 16, 3: 14, 4: 12 };
+
+function blocksToPdf(blocks, title) {
+  const PDFDocument = require('pdfkit');
+  return new Promise((resolve, reject) => {
+    try {
+      const doc = new PDFDocument({ margin: 56, size: 'A4' });
+      const chunks = [];
+      doc.on('data', (c) => chunks.push(c));
+      doc.on('end', () => resolve(Buffer.concat(chunks)));
+      doc.on('error', reject);
+
+      if (title) {
+        doc.font('Helvetica-Bold').fontSize(24).text(title);
+        doc.moveDown(0.8);
+      }
+
+      for (const b of Array.isArray(blocks) ? blocks : []) {
+        const text = inlineToText(b && b.content);
+        const props = (b && b.props) || {};
+        if (b && b.type === 'heading') {
+          const size = PDF_HEADING_SIZE[props.level] || 12;
+          doc.font('Helvetica-Bold').fontSize(size).text(text || '');
+          doc.moveDown(0.4);
+        } else if (b && b.type === 'sbAssessment') {
+          const data = safeParse(props.data, {});
+          doc.font('Helvetica-Bold').fontSize(11).text(`[Assessment: ${props.kind || ''}]`, { continued: true });
+          doc.font('Helvetica').text(` ${data.question || ''}`);
+          doc.moveDown(0.3);
+        } else if (b && b.type === 'sbComponent') {
+          const data = safeParse(props.data, {});
+          doc.font('Helvetica-Bold').fontSize(11).text(`[${props.kind || 'Component'}]`, { continued: true });
+          doc.font('Helvetica').text(` ${props.title || ''}`);
+          if (data.description) doc.font('Helvetica').fontSize(11).text(data.description);
+          doc.moveDown(0.3);
+        } else if (b && b.type === 'sbPlaceholder') {
+          doc.font('Helvetica-Bold').fontSize(11).text(`[${props.label || 'Placeholder'}]`, { continued: true });
+          doc.font('Helvetica').text(` ${props.title || ''}`);
+          doc.moveDown(0.3);
+        } else if (text) {
+          doc.font('Helvetica').fontSize(11).text(text);
+          doc.moveDown(0.3);
+        }
+      }
+
+      doc.end();
+    } catch (e) {
+      reject(e);
+    }
+  });
+}
+
+// ── Import → BlockNote blocks ────────────────────────────────────────────────
+
+// Convert block-level HTML (h1–h6 / p / li) into blocks, preserving headings.
+function htmlToBlocks(html) {
+  const blocks = [];
+  const re = /<(h[1-6]|p|li)[^>]*>([\s\S]*?)<\/\1>/gi;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const tag = m[1].toLowerCase();
+    const text = stripTags(m[2]);
+    if (!text) continue;
+    if (tag[0] === 'h') {
+      const level = Math.min(parseInt(tag[1], 10) || 1, 4);
+      blocks.push({ type: 'heading', props: { level }, content: text });
+    } else {
+      blocks.push({ type: 'paragraph', content: text });
+    }
+  }
+  if (!blocks.length) {
+    stripTags(html)
+      .split(/\n+/)
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .forEach((t) => blocks.push({ type: 'paragraph', content: t }));
+  }
+  return blocks;
+}
+
+async function wordToBlocks(buffer) {
+  const mammoth = require('mammoth');
+  const { value: html } = await mammoth.convertToHtml({ buffer });
+  return htmlToBlocks(html);
+}
+
+// Best-effort PPTX: read slide XML text runs; each slide → an H2 + paragraphs.
+function pptxToBlocks(buffer) {
+  const AdmZip = require('adm-zip');
+  const zip = new AdmZip(buffer);
+  const slideNo = (name) => parseInt((name.match(/slide(\d+)\.xml$/) || [])[1] || '0', 10);
+  const slides = zip
+    .getEntries()
+    .filter((e) => /^ppt\/slides\/slide\d+\.xml$/.test(e.entryName))
+    .sort((a, b) => slideNo(a.entryName) - slideNo(b.entryName));
+
+  const blocks = [];
+  slides.forEach((entry, i) => {
+    const xml = entry.getData().toString('utf8');
+    const texts = (xml.match(/<a:t>([\s\S]*?)<\/a:t>/g) || [])
+      .map((t) => stripTags(t))
+      .filter(Boolean);
+    blocks.push({ type: 'heading', props: { level: 2 }, content: `Slide ${i + 1}` });
+    texts.forEach((t) => blocks.push({ type: 'paragraph', content: t }));
+  });
+  return blocks;
+}
+
+// PDF is best-effort and requires the optional pdf-parse package.
+async function pdfToBlocks(buffer) {
+  let pdfParse;
+  try {
+    pdfParse = require('pdf-parse');
+  } catch (e) {
+    const err = new Error('PDF import requires the optional "pdf-parse" package (not installed).');
+    err.statusCode = 501;
+    throw err;
+  }
+  const data = await pdfParse(buffer);
+  return String(data.text || '')
+    .split(/\n{2,}/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((t) => ({ type: 'paragraph', content: t }));
+}
+
+module.exports = { blocksToDocx, blocksToPdf, wordToBlocks, pptxToBlocks, pdfToBlocks };

--- a/plugins/content/storyboardaudit/index.js
+++ b/plugins/content/storyboardaudit/index.js
@@ -1,0 +1,19 @@
+// Storyboard audit content-type plugin (ADAPT-3779, AC8).
+//
+// Model-only: registers the `storyboardaudit` Mongoose model. Records are an
+// append-only, immutable trail of workflow events (status_change / generated /
+// imported). The routes served by the `storyboard` plugin expose only
+// list + append — never update or delete.
+
+const contentmanager = require('../../../lib/contentmanager');
+const ContentPlugin = contentmanager.ContentPlugin;
+
+class StoryboardAuditContent extends ContentPlugin {
+  getModelName = () => 'storyboardaudit';
+
+  getChildType = () => false;
+
+  hasPermission = (action, userId, tenantId, contentItem, next) => next(null, true);
+}
+
+module.exports = StoryboardAuditContent;

--- a/plugins/content/storyboardaudit/model.schema
+++ b/plugins/content/storyboardaudit/model.schema
@@ -1,0 +1,41 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "id": "http://jsonschema.net",
+  "$ref": "http://localhost/system/tenantObject.schema",
+  "properties": {
+    "_storyboardId": {
+      "type": "objectid",
+      "required": true
+    },
+    "_courseId": {
+      "type": "objectid",
+      "required": false
+    },
+    "event": {
+      "type": "string",
+      "required": true
+    },
+    "fromStatus": {
+      "type": "string",
+      "required": false
+    },
+    "toStatus": {
+      "type": "string",
+      "required": false
+    },
+    "meta": {
+      "type": "string",
+      "default": "{}"
+    },
+    "_tenantId": {
+      "type": "objectid",
+      "required": true
+    },
+    "createdBy": {
+      "type": "objectid",
+      "required": false,
+      "ref": "user"
+    }
+  }
+}

--- a/plugins/content/storyboardaudit/package.json
+++ b/plugins/content/storyboardaudit/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "adapt-content-storyboardaudit",
+  "displayName": "Storyboard Audit",
+  "version": "0.1.0",
+  "main": "index",
+  "dependencies": {}
+}

--- a/plugins/content/storyboardcomment/index.js
+++ b/plugins/content/storyboardcomment/index.js
@@ -1,0 +1,20 @@
+// Storyboard comment content-type plugin (ADAPT-3779, AC9).
+//
+// Model-only: it registers the `storyboardcomment` Mongoose model. Its REST
+// surface is served by the `storyboard` plugin under /api/storyboard/*.
+// A comment anchors to a document block (blockId), supports threaded replies
+// (_parentCommentId) and a resolved flag; author/timestamps come from
+// trackedObject via the tenantObject $ref.
+
+const contentmanager = require('../../../lib/contentmanager');
+const ContentPlugin = contentmanager.ContentPlugin;
+
+class StoryboardCommentContent extends ContentPlugin {
+  getModelName = () => 'storyboardcomment';
+
+  getChildType = () => false;
+
+  hasPermission = (action, userId, tenantId, contentItem, next) => next(null, true);
+}
+
+module.exports = StoryboardCommentContent;

--- a/plugins/content/storyboardcomment/model.schema
+++ b/plugins/content/storyboardcomment/model.schema
@@ -1,0 +1,42 @@
+{
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "id": "http://jsonschema.net",
+  "$ref": "http://localhost/system/tenantObject.schema",
+  "properties": {
+    "_storyboardId": {
+      "type": "objectid",
+      "required": true
+    },
+    "_courseId": {
+      "type": "objectid",
+      "required": false
+    },
+    "blockId": {
+      "type": "string",
+      "required": true
+    },
+    "_parentCommentId": {
+      "type": "objectid",
+      "required": false
+    },
+    "body": {
+      "type": "string",
+      "required": true,
+      "default": ""
+    },
+    "resolved": {
+      "type": "boolean",
+      "default": false
+    },
+    "_tenantId": {
+      "type": "objectid",
+      "required": true
+    },
+    "createdBy": {
+      "type": "objectid",
+      "required": false,
+      "ref": "user"
+    }
+  }
+}

--- a/plugins/content/storyboardcomment/package.json
+++ b/plugins/content/storyboardcomment/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "adapt-content-storyboardcomment",
+  "displayName": "Storyboard Comment",
+  "version": "0.1.0",
+  "main": "index",
+  "dependencies": {}
+}


### PR DESCRIPTION

## 📋 Context

**JIRA:** [ADAPT-3760](https://laerdal.atlassian.net/browse/ADAPT-3760) — Storyboard Authoring in Adapt Studio

A document-first (Word/Notion-style) planning → authoring → review → AI → course-generation layer inside Adapt Studio (`new-ui-source`, served at `/new`). Authors draft a course as a rich document and generate a real Adapt course from it, backed by the existing authoring engine + DAM.

> This is the **initial version for testing** — feature-complete for the core authoring/generation loop, with known items still to verify against a live instance (see **Not yet verified**).

## ✨ What & Why

| Area | Change |
|---|---|
| **Authoring** | BlockNote editor: Topic/Section/Content Group headings + categorised **Add Content** menu (Text & Visual / Media / Survey / Assessment / Interactive). |
| **Content cards** | Text, Grouped Content/Accordion, Image, Video, Audio, H5P, Laerdal Form — rich edit + read-only preview; DAM media picker. |
| **Assessments** | MCQ, Graphic MCQ, Matching, Reorder, Text Input, Slider (per-option feedback + feedback groups). |
| **AI (card action)** | Samaritan-style popup (Improve wording / Shorten / Prolong / Correct spelling + free-text “generate from scratch”). Insert/Replace edit the **same** component in place. Server-side proxy only — keys never reach the browser. |
| **Comments (card action)** | Popup backed by the existing `storyboardcomment` plugin (add/reply/resolve/delete), anchored to the block — never alters course structure. |
| **Mapping** | Centralised `api/componentMapping.ts`: each kind resolves against the tenant’s installed `/api/componenttype` using verbatim `_component` values (`accordion`, `sentenceOrdering`, `textinput`, `mcq`, `gmcq`, `matching`, `slider`, `laerdal-h5p`, `laerdal-form`, `graphic`, `media`/`laerdal-media`). |
| **Generation** | Structure rules: Page→Article→Block→Component, **max 2 components/block** (overflow → new blocks with Content Group Heading), default alignment Right, H4-only formatting. |

## 🐛 Fixes in this increment

- **No silent Text fallback** — unmapped kinds are reported in the Save toast and skipped (content stays in the storyboard) instead of becoming a wrong Text component.
- **Full reverse mapping** — media/graphic/accordion/narrative/H5P/form and all assessments round-trip back to cards on reload.
- **Persistence** — plugin fields (`_graphic`/`_media`/`_items`/`_feedback`) now nested under the component’s `properties` object (were dropped at top level).
- **Grouped/Accordion item images** now persist to `_graphic.src` (were storing the preview URL) + per-item `courseasset` links.
- **Phantom Text component** from blank spacer paragraphs removed.
- Removed the top-bar **AI Actions** dropdown (AI/Comment are now component-card actions).
- UI aligned to the Lovable reference (~60% canvas width, course header typography, muted side panels).

## 🧪 How to test

1. Build the frontend and run `node scripts/sync-new-ui.js` (or the deploy pipeline) on the target — `/new` is served from the build. `public/new` is a build artifact and is **not** committed.
2. **Restart the Node server** — AI proxy changes (`plugins/content/storyboard/utils/aiClient.js`, `routes/requestHandlers.js`) load only on restart. Ensure `CKEditor_AI_ASST_API_KEY` (or `STORYBOARD_AI_KEY`) is set.
3. Open a course → Storyboard and verify:
   - Add each content/assessment type → **Save** → **Generate Course** → inspect `_component` + `properties` in the DB → **reload** (component returns as the same card).
   - Card **AI** → prompt → Insert/Replace edits the same component.
   - Card **Comment** → Post → reload → comment persists; course structure unchanged.
   - Grouped/Accordion item image → Save → `properties._items[i]._graphic.src = "course/assets/<file>"`.

## ⚠️ Not yet verified / follow-ups

- **Not runtime-tested against a live engine/Mongo/DAM** — validated via `tsc` + build only. Behaviour depends on what `/api/componenttype` reports; the Save toast names any missing plugins.
- Assessment read-back, H5P asset config, and Laerdal Form field round-trip are minimal (H5P/Form reload as cards without full config).
- `@mention` in comments is a UI affordance only (no mention backend).
- Import (docx/pptx), external Share-for-Review, and real AI enrichment panels are out of scope for this increment.

## ✅ Checklist

- [x] Frontend built + `sync-new-ui.js` run on the test target
- [ ] Node server restarted; AI key configured
- [ ] Smoke-tested add → save → generate → reload per component type
- [x] Two reviewers added (Copilot default)

