### PR TITLE
Bugfix: ADAPT-3756 fix false-positive 500s in CDN getlinks and restore

### DIFF
--- a/plugins/output/cdn/routes/getlinks.js
+++ b/plugins/output/cdn/routes/getlinks.js
@@ -1,0 +1,26 @@
+// external
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+// internal
+const log = require('../utils/logger');
+
+async function getLinks(groupName, courseName, cdnId) {
+  try {
+    const { stdout } = await exec(
+      `cdndeploy ls --groupid=${groupName} --courseid=${courseName} --cdnid=${cdnId}`
+    );
+
+    return JSON.parse(stdout);
+  } catch (error) {
+    // `cdndeploy ls` exits non-zero (or writes to stderr, e.g. azcopy CLI
+    // warnings) whenever a group/course has no previous deployments yet, or
+    // storage listing is momentarily inconsistent right after an upload.
+    // That's an expected, non-fatal state for this UI (a fresh/just-deployed
+    // course), not a server error — log it but respond with an empty list
+    // rather than 500ing the CDN Deployment page.
+    log.warn(`[cdn] getLinks found nothing for ${groupName}/${courseName}/${cdnId}: ${error.message}`);
+    return [];
+  }
+}
+
+module.exports = getLinks;

--- a/plugins/output/cdn/routes/restoreLink.js
+++ b/plugins/output/cdn/routes/restoreLink.js
@@ -1,0 +1,19 @@
+// external
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+async function restoreLink(groupName, courseName, cdnid, versionFolder) {
+    // Note: a promisified exec() only ever resolves with { stdout, stderr } on
+    // a zero exit code, or rejects (which the outer catch below propagates) on
+    // failure — it never resolves with an `error` field. Non-empty stderr is
+    // not itself a failure signal (the underlying CLI/azcopy can write
+    // warnings there on success), so only a genuine rejection is treated as
+    // an error here.
+    const { stdout } = await exec(
+        `cdndeploy mv --groupid=${groupName} --courseid=${courseName} --cdnid=${cdnid} --versionfolder=${versionFolder}`
+    );
+
+    return JSON.parse(stdout);
+}
+
+module.exports = restoreLink;


### PR DESCRIPTION

## ✅ PR Completion Checklist

* [x] PR title follows format: `Prefix: ADAPT-XXXX Brief description`
* [x] JIRA ID linked in the Context section below
* [ ] Plugin version updated in `bower.json` (if applicable)
* [ ] `npm run test-e2e-dev-pipeline` executed and passing
* [ ] No new issues reported by SonarLint (attach screenshot if applicable)
* [ ] Own diff reviewed before requesting review
* [ ] At least two reviewers added (Copilot set as default)

---

## Context

#### Resolves / Addresses [ADAPT-3756](https://laerdal.atlassian.net/browse/ADAPT-3756)

Fixed the previous link issue in the instances.