### PR TITLE
Bugfix/ADAPT-3760 new UI deps reinstall

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -465,6 +465,21 @@ module.exports = function(grunt) {
       } catch (e) { return false; }
     }
 
+    // Verify every declared dependency is actually installed. A partial or
+    // interrupted install — or one accidentally run at the repo root instead of
+    // new-ui-source — leaves node_modules present but missing packages (e.g.
+    // lucide-react / @blocknote/*), which then fail `tsc && vite build`. Detect
+    // that so we reinstall and self-heal rather than build against a broken tree.
+    function depsComplete() {
+      try {
+        var pkg = JSON.parse(fs.readFileSync(path.join(newUiDir, 'package.json'), 'utf8'));
+        var deps = Object.keys(pkg.dependencies || {});
+        return deps.every(function(d) {
+          return fs.existsSync(path.join(newUiDir, 'node_modules', d, 'package.json'));
+        });
+      } catch (e) { return false; }
+    }
+
     function runSync() {
       var env = Object.assign({}, process.env, { NEW_UI_DIST_PATH: distDir });
       var syncChild = spawn(process.execPath, [syncScript], { stdio: 'inherit', env: env });
@@ -487,9 +502,10 @@ module.exports = function(grunt) {
       });
     }
 
-    // Install when deps are missing OR the oxide native binding is absent
-    // (self-heals a tree installed under the wrong Node). Otherwise skip for speed.
-    if (!fs.existsSync(path.join(newUiDir, 'node_modules')) || !oxideBindingPresent()) {
+    // Install when node_modules is absent, any declared dependency is missing,
+    // OR the oxide native binding is absent (self-heals a tree installed under
+    // the wrong Node / a partial install). Otherwise skip for speed.
+    if (!fs.existsSync(path.join(newUiDir, 'node_modules')) || !depsComplete() || !oxideBindingPresent()) {
       grunt.log.writeln('Installing new-ui-source dependencies ('
         + (node20Bin ? 'Node 20 via ' + node20Src : 'default Node') + ')...');
       npmStep(['install'], 'New UI dependency install', build);

--- a/new-ui-source/.npmrc
+++ b/new-ui-source/.npmrc
@@ -1,0 +1,9 @@
+# BlockNote (@blocknote/core) declares peerOptional dependencies on
+# release-candidate Yjs packages (@y/y@^14.0.0-rc.23, @y/protocols, @y/prosemirror)
+# that npm's strict peer resolver (npm >= 7) cannot satisfy on a clean install —
+# it fails with ERESOLVE. We do NOT use BlockNote's Yjs collaboration (storyboard
+# comments persist via the storyboardcomment backend, not Yjs), so those optional
+# peers are irrelevant. Relax to npm's classic peer behaviour so fresh installs
+# (server / CI, where there is no committed package-lock.json) resolve the same
+# way local installs do.
+legacy-peer-deps=true

--- a/new-ui-source/package.json
+++ b/new-ui-source/package.json
@@ -13,6 +13,8 @@
     "@blocknote/core": "^0.52.1",
     "@blocknote/mantine": "^0.52.1",
     "@blocknote/react": "^0.52.1",
+    "@mantine/core": "^8.3.11",
+    "@mantine/hooks": "^8.3.11",
     "lucide-react": "^1.29.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",


### PR DESCRIPTION
## ✅ PR Completion Checklist

* [ ] PR title follows format: `Prefix: ADAPT-XXXX Brief description`

* [ ] JIRA ID linked in the Context section below
* [ ] Plugin version updated in `bower.json` (if applicable)
* [ ] `npm run test-e2e-dev-pipeline` executed and passing
* [ ] No new issues reported by SonarLint (attach screenshot if applicable)
* [ ] Own diff reviewed before requesting review
* [ ] At least two reviewers added (Copilot set as default)

---

## Context

#### Resolves / Addresses [ADAPT-3760](https://laerdal.atlassian.net/browse/ADAPT-3760)

Added new-ui-source/.npmrc → legacy-peer-deps=true (we don't use BlockNote's Yjs collaboration — comments go through storyboardcomment).
Added @mantine/core + @mantine/hooks (^8.3.11) to dependencies so they install despite legacy-peer-deps.
Verified with a true from-scratch install (removed node_modules and the lock, exactly like the server) → npm install clean, npm run build ✓.
