### PR TITLE
Feature: ADAPT-3842-Storyboard UI Changes for Adapt Studio

### DIFF
--- a/new-ui-source/src/api/adaptAuthoring.ts
+++ b/new-ui-source/src/api/adaptAuthoring.ts
@@ -2434,22 +2434,32 @@ export async function getCourseStoryboardBlocks(courseId: string): Promise<unkno
     }
     if (sbKind === "laerdalForm") {
       // Reverse of the generation mapping in storyboardGeneration.ts.
-      const controlFor = (t: string): string => {
+      //
+      // Generation collapses UI "Dropdown" and "Checkbox" onto the same
+      // backend `_inputType: "options"` because Adapt has no boolean control.
+      // The two are distinguished by the shape of the `options` array:
+      //   * Checkbox  → exactly one option (the yes/no marker)
+      //   * Dropdown  → zero or many options
+      // Without this check every Checkbox field would round-trip as a
+      // Dropdown, silently changing the author's intent on reload.
+      const controlFor = (t: string, opts: unknown): string => {
         switch ((t || "").toLowerCase()) {
           case "textarea":
             return "Multi-Line Text";
           case "number":
           case "range":
             return "Number";
-          case "options":
-            return "Dropdown";
+          case "options": {
+            const arr = Array.isArray(opts) ? opts : [];
+            return arr.length === 1 ? "Checkbox" : "Dropdown";
+          }
           default:
             return "Single-Line Text";
         }
       };
       const rawItems = Array.isArray(props._items) ? (props._items as Array<Record<string, unknown>>) : [];
       const fields = rawItems.map((it) => ({
-        control: controlFor(String(it._inputType || "text")),
+        control: controlFor(String(it._inputType || "text"), it.options),
         label: String(it._label || ""),
         placeholder: String(it._placeholder || ""),
         mandatory: !!it._isRequired,

--- a/new-ui-source/src/api/adaptAuthoring.ts
+++ b/new-ui-source/src/api/adaptAuthoring.ts
@@ -652,6 +652,21 @@ export async function getCourseBootstrapData(courseId: string): Promise<CourseBo
   };
 }
 
+/**
+ * Ensure a render shell exists for the course on the Studio surface. Builds the shell
+ * once on a cache miss (matching the course's current theme/menu/plugin fingerprint)
+ * and returns instantly when it is already cached. This is what makes a never-previewed
+ * course renderable without a full grunt rebuild on every open.
+ */
+export async function ensureCoursePreview(
+  tenantId: string,
+  courseId: string,
+): Promise<{ success: boolean; message?: string }> {
+  return apiClient.post<{ success: boolean; message?: string }>(
+    `/studio/ensure/${tenantId}/${courseId}`,
+  );
+}
+
 // ── Navigation Settings ───────────────────────────────────────────────────────
 // The Adapt Studio "Navigation" panel edits a mix of CORE course fields and three
 // togglable extensions, spread across two engine documents:

--- a/new-ui-source/src/api/adaptAuthoring.ts
+++ b/new-ui-source/src/api/adaptAuthoring.ts
@@ -155,16 +155,24 @@ export interface Asset {
   path?: string;
 }
 
-export type AssetKind = "image" | "audio" | "video";
+export type AssetKind = "image" | "audio" | "video" | "h5p";
 
 // Query assets of a given kind from the engine asset manager.
 // GET /api/asset/query?search[mimeType]=<kind>
+// H5P is a `.h5p` (zip) file — the DAM stores those under the generic
+// `application/…` mimetypes rather than a well-known prefix. So for `h5p` we
+// query WITHOUT the mimeType filter and narrow to .h5p files client-side.
 export async function queryAssets(kind: AssetKind, search?: string): Promise<Asset[]> {
-  const params = new URLSearchParams({ "search[mimeType]": kind });
+  const params = new URLSearchParams();
+  if (kind !== "h5p") params.append("search[mimeType]", kind);
   if (search) params.append("search[title]", search);
   try {
     const result = await apiClient.get<Asset[]>(`/api/asset/query?${params}`);
-    return Array.isArray(result) ? result : [];
+    const list = Array.isArray(result) ? result : [];
+    if (kind === "h5p") {
+      return list.filter((a) => /\.h5p$/i.test(a.filename || a.title || ""));
+    }
+    return list;
   } catch {
     return [];
   }
@@ -642,21 +650,6 @@ export async function getCourseBootstrapData(courseId: string): Promise<CourseBo
     themePresetId: config._themePreset || "",
     language: config._defaultLanguage || "",
   };
-}
-
-/**
- * Ensure a render shell exists for the course on the Studio surface. Builds the shell
- * once on a cache miss (matching the course's current theme/menu/plugin fingerprint)
- * and returns instantly when it is already cached. This is what makes a never-previewed
- * course renderable without a full grunt rebuild on every open.
- */
-export async function ensureCoursePreview(
-  tenantId: string,
-  courseId: string,
-): Promise<{ success: boolean; message?: string }> {
-  return apiClient.post<{ success: boolean; message?: string }>(
-    `/studio/ensure/${tenantId}/${courseId}`,
-  );
 }
 
 // ── Navigation Settings ───────────────────────────────────────────────────────
@@ -2416,13 +2409,79 @@ export async function getCourseStoryboardBlocks(courseId: string): Promise<unkno
       });
       return;
     }
-    // H5P and Laerdal Form → their own cards (config round-trips minimally).
+    // H5P and Laerdal Form → their own cards. Config round-trips so a
+    // save/reopen cycle preserves the picked asset / form fields.
     if (sbKind === "h5p") {
-      emitCard(comp, "h5p", { showTitle: true, description: stripHtml(comp.body || ""), instruction: "" });
+      const external = String(props._h5pExternalAsset || "");
+      const asset = String(props.h5pAsset || "");
+      const link = external || asset;
+      const media = link
+        ? {
+            asset: {
+              link,
+              url: external ? external : resolveAssetUrl(asset, assetIdMap),
+              external: !!external,
+            },
+          }
+        : undefined;
+      emitCard(comp, "h5p", {
+        showTitle: true,
+        description: stripHtml(comp.body || ""),
+        instruction: "",
+        media,
+      });
       return;
     }
     if (sbKind === "laerdalForm") {
-      emitCard(comp, "laerdalForm", { showTitle: true, description: stripHtml(comp.body || ""), instruction: "" });
+      // Reverse of the generation mapping in storyboardGeneration.ts.
+      const controlFor = (t: string): string => {
+        switch ((t || "").toLowerCase()) {
+          case "textarea":
+            return "Multi-Line Text";
+          case "number":
+          case "range":
+            return "Number";
+          case "options":
+            return "Dropdown";
+          default:
+            return "Single-Line Text";
+        }
+      };
+      const rawItems = Array.isArray(props._items) ? (props._items as Array<Record<string, unknown>>) : [];
+      const fields = rawItems.map((it) => ({
+        control: controlFor(String(it._inputType || "text")),
+        label: String(it._label || ""),
+        placeholder: String(it._placeholder || ""),
+        mandatory: !!it._isRequired,
+      }));
+      emitCard(comp, "laerdalForm", {
+        showTitle: true,
+        description: stripHtml(comp.body || ""),
+        instruction: "",
+        fields,
+      });
+      return;
+    }
+    // Assessment Results → dedicated card that round-trips its bands and retry.
+    if (sbKind === "assessmentResult") {
+      const rawBands = Array.isArray(props._bands) ? (props._bands as Array<Record<string, unknown>>) : [];
+      const retry = (props._retry as Record<string, unknown>) || {};
+      emitCard(comp, "assessmentResult", {
+        showTitle: true,
+        description: "",
+        instruction: "",
+        result: {
+          assessmentId: String(props._assessmentId || ""),
+          completionBody: String(props._completionBody || ""),
+          retryButton: String(retry.button || "Try again"),
+          retryFeedback: String(retry.feedback || ""),
+          bands: rawBands.map((b) => ({
+            score: Math.max(0, Math.min(100, Number(b._score) || 0)),
+            feedback: String(b.feedback || ""),
+            allowRetry: !!b._allowRetry,
+          })),
+        },
+      });
       return;
     }
     // Unknown / text → H4 heading + body paragraph (text write-back contract).
@@ -2434,8 +2493,19 @@ export async function getCourseStoryboardBlocks(courseId: string): Promise<unkno
     out.push({ id: page._id, type: "heading", props: { level: 1 }, content: label(page) });
     for (const article of childrenOf(articles, page._id)) {
       out.push({ id: article._id, type: "heading", props: { level: 2 }, content: label(article) });
+      // The generation engine caps each Adapt block at 2 components — extra
+      // components are placed in continuation blocks that carry the SAME H3
+      // title. When we round-trip the course, those continuation blocks would
+      // appear as duplicate H3 headings in the Storyboard (and duplicate again
+      // on the next Save/Generate). Merge adjacent same-title H3 blocks so the
+      // Storyboard shows one H3 with all its components in their original order.
+      let prevTitle: string | null = null;
       for (const blk of childrenOf(blocks, article._id)) {
-        out.push({ id: blk._id, type: "heading", props: { level: 3 }, content: label(blk) });
+        const title = label(blk);
+        if (title !== prevTitle) {
+          out.push({ id: blk._id, type: "heading", props: { level: 3 }, content: title });
+          prevTitle = title;
+        }
         for (const comp of childrenOf(components, blk._id)) emitComponent(comp);
       }
     }
@@ -2766,6 +2836,95 @@ export async function getGlobalsDefaults(): Promise<GlobalsObject> {
 export async function getCourseGlobalsMerged(courseId: string): Promise<GlobalsObject> {
   const [stored, defaults] = await Promise.all([getCourseGlobals(courseId), getGlobalsDefaults()]);
   return deepMergeGlobals(defaults, stored);
+}
+
+// ── Course schema defaults (for runtime-critical fields) ────────────────────
+// The Adapt runtime templates and views read a handful of top-level course
+// fields directly — `_buttons`, `_globals`, `_navigation`, `_start`, `_tooltips`,
+// `themeVariables._components` — and crash with `Cannot read properties of
+// undefined` when any of them is missing. Courses created via the minimal
+// `POST /api/courses` flow (new UI) don't get those seeded. This helper
+// deep-merges schema defaults into the persisted course document, filling only
+// missing branches (existing values ALWAYS win) and PATCHes the doc back so
+// preview + publish + Adapt runtime never see an undefined critical field.
+async function computeCourseSchemaDefaults(): Promise<Record<string, unknown>> {
+  if (!mergedSchemaCache) {
+    mergedSchemaCache = await apiClient.get("/api/content/schema");
+  }
+  const courseSchema = (mergedSchemaCache as Record<string, unknown> | null)?.course as
+    | Record<string, unknown>
+    | undefined;
+  if (!courseSchema || typeof courseSchema !== "object") return {};
+  // /api/content/schema returns each schema already unwrapped to `properties`,
+  // so `courseSchema` is directly the map of top-level fields (see contentmanager.js
+  // `filteredSchemas[key] = _.omit(_.pick(schema, 'properties').properties, blackList)`).
+  return buildSchemaDefaults(courseSchema);
+}
+
+function isDeepEmpty(v: unknown): boolean {
+  if (v === undefined || v === null) return true;
+  if (typeof v === "string") return v.trim() === "";
+  if (Array.isArray(v)) return v.length === 0;
+  if (typeof v === "object") return Object.keys(v as object).length === 0;
+  return false;
+}
+
+/**
+ * Seed any missing top-level course-schema defaults onto the persisted course
+ * document. Existing authored values are ALWAYS preserved (deep-merged wins);
+ * only branches that are absent or empty get filled from the schema. Idempotent
+ * — a second call with the same doc is a no-op.
+ */
+export async function seedMissingCourseDefaults(courseId: string): Promise<void> {
+  try {
+    const [defaults, course] = await Promise.all([
+      computeCourseSchemaDefaults(),
+      apiClient.get<Record<string, unknown>>(`/api/content/course/${courseId}`),
+    ]);
+
+    const patch: Record<string, unknown> = {};
+
+    for (const [k, defaultVal] of Object.entries(defaults || {})) {
+      const existing = course[k];
+      if (isDeepEmpty(existing)) {
+        patch[k] = defaultVal;
+        continue;
+      }
+      if (
+        defaultVal &&
+        typeof defaultVal === "object" &&
+        !Array.isArray(defaultVal) &&
+        typeof existing === "object" &&
+        existing &&
+        !Array.isArray(existing)
+      ) {
+        // Deep-merge to backfill any missing sub-keys (existing sub-value wins).
+        const merged = deepMergeGlobals(defaultVal as GlobalsObject, existing as GlobalsObject);
+        if (JSON.stringify(merged) !== JSON.stringify(existing)) {
+          patch[k] = merged;
+        }
+      }
+    }
+
+    // `themeVariables` is NOT part of the course JSON schema — the theme plugin
+    // stores per-theme customizations under this key, and the schema for it
+    // comes from the applied theme's `properties.variables`. Runtime theme code
+    // (e.g. adapt-laerdal-life-v2 `themeComponentView.js` line ~33) dereferences
+    // `Adapt.course.get('themeVariables')._components?._canShowFinalMarking`.
+    // The inner `?.` protects `_components` but NOT the outer object, so when
+    // `themeVariables` is undefined the framework crashes with
+    //   TypeError: Cannot read properties of undefined (reading '_components')
+    // Guarantee at least an empty object so `undefined._components → {}._components`.
+    if (course.themeVariables === undefined || course.themeVariables === null) {
+      patch.themeVariables = {};
+    }
+
+    if (Object.keys(patch).length) {
+      await apiClient.put(`/api/content/course/${courseId}`, patch);
+    }
+  } catch (err) {
+    console.warn("Failed to seed missing course schema defaults", err);
+  }
 }
 
 interface CreateContentResult { _id: string }

--- a/new-ui-source/src/api/componentMapping.ts
+++ b/new-ui-source/src/api/componentMapping.ts
@@ -24,6 +24,8 @@ export type StoryboardComponentKind =
   | 'reorder'
   | 'textInput'
   | 'slider'
+  | 'checklist'
+  | 'assessmentResult'
   | 'hotgraphic'
   | 'hotgrid'
   | 'actionplan'
@@ -43,7 +45,9 @@ export const COMPONENT_CANDIDATES: Record<StoryboardComponentKind, string[]> = {
   matching: ['matching'],
   reorder: ['sentenceOrdering'],
   textInput: ['textinput'],
-  slider: ['slider'],
+  slider: ['slider', 'laerdal-slider'],
+  checklist: ['laerdal-checklist'],
+  assessmentResult: ['assessmentResults'],
   hotgraphic: ['laerdal-hotgraphic', 'hotgraphic'],
   hotgrid: ['hotgrid'],
   actionplan: ['actionplan', 'laerdal-actionplan'],
@@ -85,6 +89,9 @@ const REVERSE: Record<string, StoryboardComponentKind | 'media'> = {
   sentenceOrdering: 'reorder',
   textinput: 'textInput',
   slider: 'slider',
+  'laerdal-slider': 'slider',
+  'laerdal-checklist': 'checklist',
+  assessmentResults: 'assessmentResult',
   'laerdal-hotgraphic': 'hotgraphic',
   hotgraphic: 'hotgraphic',
   hotgrid: 'hotgrid',
@@ -97,5 +104,5 @@ export function reverseKind(component?: string): StoryboardComponentKind | 'medi
   return REVERSE[component] ?? null;
 }
 
-export const ASSESSMENT_KINDS = new Set<string>(['mcq', 'gmcq', 'matching', 'reorder', 'textInput', 'slider']);
+export const ASSESSMENT_KINDS = new Set<string>(['mcq', 'gmcq', 'matching', 'reorder', 'textInput', 'slider', 'checklist']);
 export const isAssessmentComponentKind = (k: string): boolean => ASSESSMENT_KINDS.has(k);

--- a/new-ui-source/src/api/storyboardGeneration.ts
+++ b/new-ui-source/src/api/storyboardGeneration.ts
@@ -371,8 +371,11 @@ function parseDocToTree(doc: unknown[], resolveExisting: (id: string) => string 
         comp.assessmentPatch = { _items: items };
       } else if (kind === "assessmentResult") {
         // adapt-contrib-assessmentResults: bind to an article-level assessment
-        // (`_assessmentId`), render bands ordered high\u2192low, offer retry, and
-        // template the completion body with `{{scoreAsPercent}}` etc.
+        // (`_assessmentId`), emit bands sorted ascending by `_score` (the
+        // plugin walks the array and picks the highest band whose `_score`
+        // ≤ the learner's score, so ascending order is the required contract),
+        // offer retry, and template the completion body with
+        // `{{scoreAsPercent}}` etc.
         const r = data.result || {};
         const bands = Array.isArray(r.bands) ? r.bands : [];
         comp.assessmentPatch = {

--- a/new-ui-source/src/api/storyboardGeneration.ts
+++ b/new-ui-source/src/api/storyboardGeneration.ts
@@ -18,6 +18,7 @@ import {
   createBlock,
   createComponent,
   linkContentAsset,
+  seedMissingCourseDefaults,
 } from "./adaptAuthoring";
 import {
   buildAssessmentFields,
@@ -103,6 +104,9 @@ interface GenComponent {
   pendingImage?: ImageData;
   pendingMedia?: MediaData;
   pendingItems?: Array<{ title?: string; body?: string; image?: string; imageAssetId?: string }>;
+  /** GMCQ per-option images that came from the DAM — linked as courseassets
+   *  after the component is created so publish resolves them. */
+  pendingOptionImages?: Array<{ image?: string; imageAssetId?: string }>;
 }
 interface GenGroup {
   sourceBlockId?: string;
@@ -278,6 +282,14 @@ function parseDocToTree(doc: unknown[], resolveExisting: (id: string) => string 
         image?: ImageData;
         media?: MediaData;
         items?: Array<{ title?: string; body?: string; image?: string }>;
+        fields?: Array<{ control?: string; label?: string; placeholder?: string; mandatory?: boolean }>;
+        result?: {
+          assessmentId?: string;
+          completionBody?: string;
+          retryButton?: string;
+          retryFeedback?: string;
+          bands?: Array<{ score?: number; feedback?: string; allowRetry?: boolean }>;
+        };
       }>(raw.props && raw.props.data, {});
       // `componentKey` now holds the STORYBOARD KIND; the Adapt _component is
       // resolved later via resolveAdaptComponent against installed types.
@@ -301,6 +313,89 @@ function parseDocToTree(doc: unknown[], resolveExisting: (id: string) => string 
       } else if (kind === "groupedContent") {
         comp.pendingKind = "groupedContent";
         comp.pendingItems = data.items;
+      } else if (kind === "h5p") {
+        // laerdal-h5p accepts EITHER a DAM asset (`h5pAsset`) OR an external
+        // embed URL (`_h5pExternalAsset`). External asset refs write the URL;
+        // picked DAM assets write the course-relative link AND record a
+        // courseasset link below so publish can resolve it.
+        const asset = data.media?.asset;
+        const patch: Record<string, unknown> = { instruction: "" };
+        if (asset?.external || (asset?.link && /^https?:\/\//i.test(asset.link))) {
+          patch._h5pExternalAsset = asset.link || asset.url || "";
+        } else if (asset?.link) {
+          patch.h5pAsset = asset.link;
+        }
+        comp.assessmentPatch = patch;
+        comp.assetLink = asset?.link;
+        comp.assetId = asset?.assetId;
+      } else if (kind === "laerdalForm") {
+        // laerdal-form `_items[]` mirrors the sbComponent form-field editor.
+        // Backend accepts these `_inputType` values:
+        // text|textarea|email|url|range|hidden|tel|options|number.
+        const inputTypeFor = (ctl: string): string => {
+          switch ((ctl || "").toLowerCase()) {
+            case "multi-line text":
+              return "textarea";
+            case "number":
+              return "number";
+            case "dropdown":
+              return "options";
+            case "checkbox":
+              // No boolean type on the backend; render as a single-option
+              // multi-select so the field persists and validates.
+              return "options";
+            case "single-line text":
+            default:
+              return "text";
+          }
+        };
+        const slugify = (s: string, i: number) =>
+          (s || `field-${i + 1}`)
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "-")
+            .replace(/^-+|-+$/g, "") || `field-${i + 1}`;
+        const items = (data.fields || []).map((f, i) => {
+          const _inputType = inputTypeFor(f.control || "");
+          const item: Record<string, unknown> = {
+            _inputType,
+            _label: f.label || "",
+            _name: slugify(f.label || "", i),
+            _isRequired: !!f.mandatory,
+            _placeholder: f.placeholder || "",
+          };
+          if (_inputType === "options" && (f.control || "").toLowerCase() === "checkbox") {
+            item.options = [{ text: f.placeholder || "Yes", value: "yes" }];
+          }
+          return item;
+        });
+        comp.assessmentPatch = { _items: items };
+      } else if (kind === "assessmentResult") {
+        // adapt-contrib-assessmentResults: bind to an article-level assessment
+        // (`_assessmentId`), render bands ordered high\u2192low, offer retry, and
+        // template the completion body with `{{scoreAsPercent}}` etc.
+        const r = data.result || {};
+        const bands = Array.isArray(r.bands) ? r.bands : [];
+        comp.assessmentPatch = {
+          _assessmentId: (r.assessmentId || "").trim() || undefined,
+          _completionBody: r.completionBody || "",
+          _isVisibleBeforeCompletion: false,
+          _setCompletionOn: "pass",
+          _resetType: "hard",
+          _retry: {
+            button: r.retryButton || "Try again",
+            feedback: r.retryFeedback || "",
+            _routeToAssessment: true,
+          },
+          _bands: bands
+            .slice()
+            .sort((a, b) => (Number(a.score) || 0) - (Number(b.score) || 0))
+            .map((b) => ({
+              _score: Math.max(0, Math.min(100, Number(b.score) || 0)),
+              feedback: b.feedback || "",
+              feedbackNotFinal: b.feedback || "",
+              _allowRetry: !!b.allowRetry,
+            })),
+        };
       }
     } else if (type === "sbAssessment") {
       const kind = ((raw.props && raw.props.kind) || "mcq") as AssessmentKind;
@@ -313,6 +408,13 @@ function parseDocToTree(doc: unknown[], resolveExisting: (id: string) => string 
         body: data.question || "",
         assessmentPatch: buildAssessmentFields(kind, data),
       };
+      // GMCQ: record per-option DAM-asset ids so we can create the courseasset
+      // publish links after the component is created.
+      if (kind === "gmcq" && Array.isArray(data.options)) {
+        comp.pendingOptionImages = data.options
+          .filter((o) => o.image && o.imageAssetId)
+          .map((o) => ({ image: o.image, imageAssetId: o.imageAssetId }));
+      }
     } else if (type === "sbPlaceholder") {
       const label = (raw.props && (raw.props.title || raw.props.label)) || "Placeholder";
       const rawLabel = (raw.props && raw.props.label) || "";
@@ -575,9 +677,10 @@ export async function generateStoryboardCourse(
         let cSort = 1;
         for (const c of g.components) {
           const bodyHtml = bodyHtmlOf(c);
-          // Default component alignment is Right (spec: newly generated blocks
-          // hold up to 2 right-aligned components).
-          const layout: "right" = "right";
+          // Default component alignment is Left. New components added to the
+          // Storyboard are always generated (and saved) with left alignment so
+          // the Storyboard sequence and layout match the generated course.
+          const layout: "left" = "left";
           // Resolve the storyboard kind → installed Adapt component (source of
           // truth). null = unsupported (NO text fallback).
           const resolvedType = getType(c.componentKey);
@@ -637,6 +740,20 @@ export async function generateStoryboardCourse(
               }
             }
           }
+          // GMCQ per-option images need their own courseasset link so publish
+          // can copy the image into the exported course.
+          if (Array.isArray(c.pendingOptionImages)) {
+            for (const opt of c.pendingOptionImages) {
+              const fn = filenameFromLink(opt?.image);
+              if (fn && opt?.imageAssetId) {
+                try {
+                  await linkContentAsset(courseId, "component", compId, grpId, fn, opt.imageAssetId);
+                } catch {
+                  /* best-effort */
+                }
+              }
+            }
+          }
           cSort += 1;
         }
       }
@@ -662,6 +779,24 @@ export async function generateStoryboardCourse(
         /* already removed by a cascade */
       }
     }
+  }
+
+  // Seed the course's top-level schema defaults (`_globals`, `_buttons`,
+  // `_navigation`, `_start`, `_tooltips`, `themeVariables`, …) into any branches
+  // still missing on the course document. The Adapt runtime templates and views
+  // dereference these directly at render time:
+  //   • questionModel/buttonsView → `Adapt.course.get('_buttons')._<state>.ariaLabel`
+  //   • themeComponentView        → `Adapt.course.get('themeVariables')._components...`
+  //   • mcq template / a11y       → `_globals._accessibility._ariaLabels.*`
+  //   • buttons/question globals  → `_globals._components._<plugin>.aria*`
+  // Missing branches used to crash preview with
+  //   TypeError: Cannot read properties of undefined (reading '_ariaLabels' | 'ariaLabel' | '_components')
+  // Existing authored values are ALWAYS preserved (deep-merge, existing wins),
+  // and the call is idempotent. Non-fatal to the generation itself.
+  try {
+    await seedMissingCourseDefaults(courseId);
+  } catch (err) {
+    console.warn("Storyboard generation: failed to seed course schema defaults", err);
   }
 
   return { created, updated, deleted, blockToContent, missingTypes: [...unsupported] };

--- a/new-ui-source/src/components/common/AssetPickerModal.tsx
+++ b/new-ui-source/src/components/common/AssetPickerModal.tsx
@@ -13,6 +13,9 @@ const KIND_TEXT: Record<AssetKind, { heading: string; confirm: string; noun: str
   image: { heading: "Select an Image", confirm: "Select Image", noun: "image", accept: "image/*" },
   audio: { heading: "Select an Audio File", confirm: "Select Audio", noun: "audio file", accept: "audio/*" },
   video: { heading: "Select a Video", confirm: "Select Video", noun: "video", accept: "video/*" },
+  // H5P files are `.h5p` (zip) archives — the DAM mimeType prefix filter can't
+  // match them, so we constrain uploads and browsing to that extension.
+  h5p:   { heading: "Select an H5P File", confirm: "Select H5P", noun: "H5P file", accept: ".h5p,application/zip,application/x-zip-compressed,application/octet-stream" },
 };
 
 function toAssetLink(asset: Asset): string {
@@ -58,6 +61,12 @@ export default function AssetPickerModal({ onSelect, onClose, assetType = "image
     const file = e.target.files?.[0];
     if (!file) return;
     e.target.value = "";
+    // For H5P we require the `.h5p` extension — the browser's `accept` filter is
+    // a hint, not a guarantee, and the DAM has no server-side H5P mime.
+    if (assetType === "h5p" && !/\.h5p$/i.test(file.name)) {
+      setUploadError("Please choose a .h5p file.");
+      return;
+    }
     setUploading(true);
     setUploadError(null);
     try {
@@ -201,6 +210,11 @@ export default function AssetPickerModal({ onSelect, onClose, assetType = "image
                           {assetType === "audio" ? (
                             <>
                               <path d="M9 18V5l12-2v13" /><circle cx="6" cy="18" r="3" /><circle cx="18" cy="16" r="3" />
+                            </>
+                          ) : assetType === "h5p" ? (
+                            <>
+                              {/* Puzzle piece \u2014 recognisable H5P glyph */}
+                              <path d="M20.5 11H19V7a2 2 0 0 0-2-2h-4V3.5a2.5 2.5 0 0 0-5 0V5H4a2 2 0 0 0-2 2v3.8h1.5a2.2 2.2 0 0 1 0 4.4H2V19a2 2 0 0 0 2 2h3.8v-1.5a2.2 2.2 0 0 1 4.4 0V21H16a2 2 0 0 0 2-2v-4h1.5a2.5 2.5 0 0 0 0-5z" />
                             </>
                           ) : (
                             <>

--- a/new-ui-source/src/components/storyboard/AddContentMenu.tsx
+++ b/new-ui-source/src/components/storyboard/AddContentMenu.tsx
@@ -1,5 +1,8 @@
 // "Add Content" dropdown (spec AC3/AC5/AC6). Categorised insert menu matching
-// the reference: Text & Visual / Media / Survey / Assessment / Interactive.
+// the Figma design (Course Creation Center → StoryboardPanel
+// `CONTENT_TYPE_CATALOG`): Text & Visual / Media / Survey / Assessment.
+// Icons, labels, order and grouping are 1:1 with that catalog so the two
+// surfaces stay in lockstep.
 //
 // Rendered in a portal with fixed positioning so it can never be clipped or
 // mis-stacked by the editor's scroll/overflow/backdrop-blur ancestors (that was
@@ -12,20 +15,17 @@ import {
   Type,
   Layers,
   Image as ImageIcon,
-  Video,
-  AudioLines,
+  Film,
+  Mic,
   Puzzle,
   ClipboardList,
+  CheckSquare,
+  LayoutList,
+  PenLine,
+  ArrowUpDown,
   ListChecks,
-  Images,
-  Shuffle,
-  ArrowDownUp,
-  TextCursorInput,
   SlidersHorizontal,
-  Target,
-  Grid3x3,
-  ListTodo,
-  Rows3,
+  Trophy,
   ChevronDown,
 } from 'lucide-react';
 import type { StoryboardInsertKind } from '@/types/storyboard';
@@ -40,6 +40,8 @@ interface MenuGroup {
   items: MenuItem[];
 }
 
+// Groups + order mirror `CONTENT_TYPE_CATALOG` in the Figma Make source
+// (StoryboardPanel.tsx) exactly. Do not add/reorder without updating both.
 const GROUPS: MenuGroup[] = [
   {
     label: 'Text & Visual',
@@ -52,32 +54,26 @@ const GROUPS: MenuGroup[] = [
   {
     label: 'Media',
     items: [
-      { kind: 'video', label: 'Video', Icon: Video },
-      { kind: 'audio', label: 'Audio', Icon: AudioLines },
+      { kind: 'video', label: 'Video', Icon: Film },
+      { kind: 'audio', label: 'Audio', Icon: Mic },
       { kind: 'h5p', label: 'H5P', Icon: Puzzle },
     ],
   },
-  { label: 'Survey', items: [{ kind: 'laerdalForm', label: 'Laerdal Form', Icon: ClipboardList }] },
+  {
+    label: 'Survey',
+    items: [{ kind: 'laerdalForm', label: 'Laerdal Form', Icon: ClipboardList }],
+  },
   {
     label: 'Assessment',
     items: [
-      { kind: 'mcq', label: 'MCQ', Icon: ListChecks },
-      { kind: 'gmcq', label: 'Graphic MCQ', Icon: Images },
-      { kind: 'matching', label: 'Matching', Icon: Shuffle },
-      { kind: 'reorder', label: 'Sentence Reordering', Icon: ArrowDownUp },
-      { kind: 'textInput', label: 'Text Input', Icon: TextCursorInput },
+      { kind: 'mcq', label: 'MCQ', Icon: CheckSquare },
+      { kind: 'gmcq', label: 'GMCQ', Icon: CheckSquare },
+      { kind: 'matching', label: 'Matching', Icon: LayoutList },
+      { kind: 'textInput', label: 'Text Input', Icon: PenLine },
+      { kind: 'reorder', label: 'Sentence Reordering', Icon: ArrowUpDown },
+      { kind: 'checklist', label: 'Checklist', Icon: ListChecks },
       { kind: 'slider', label: 'Slider', Icon: SlidersHorizontal },
-    ],
-  },
-  {
-    label: 'Interactive',
-    items: [
-      // Accordion has no distinct storyboard block yet — map it to Grouped
-      // Content (heading + body rows), per product decision.
-      { kind: 'groupedContent', label: 'Accordion', Icon: Rows3 },
-      { kind: 'hotgraphic', label: 'Hot Graphic', Icon: Target },
-      { kind: 'hotgrid', label: 'Hot Grid', Icon: Grid3x3 },
-      { kind: 'actionplan', label: 'Laerdal Action Plan', Icon: ListTodo },
+      { kind: 'assessmentResult', label: 'Assessment Result', Icon: Trophy },
     ],
   },
 ];
@@ -139,32 +135,41 @@ export default function AddContentMenu({ onInsert }: { onInsert: (kind: Storyboa
         ref={btnRef}
         type="button"
         onClick={() => setOpen((o) => !o)}
-        className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-secondary"
+        className="sb-toolbar-btn"
+        aria-haspopup="menu"
+        aria-expanded={open}
       >
         <Plus className="h-3.5 w-3.5" /> Add Content
-        <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+        <ChevronDown className="h-3.5 w-3.5" style={{ color: 'var(--life-color-text-subtle)' }} />
       </button>
 
       {open &&
         createPortal(
           <div
             ref={menuRef}
-            style={{ position: 'fixed', left: pos.left, top: pos.top, width: MENU_WIDTH, maxHeight: pos.maxHeight }}
-            className="z-[1000] overflow-y-auto rounded-md border bg-background py-1 shadow-lg"
+            role="menu"
+            className="sb-menu"
+            style={{
+              position: 'fixed',
+              left: pos.left,
+              top: pos.top,
+              width: MENU_WIDTH,
+              maxHeight: pos.maxHeight,
+              zIndex: 1000,
+            }}
           >
             {GROUPS.map((group) => (
               <div key={group.label}>
-                <div className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                  {group.label}
-                </div>
+                <div className="sb-menu-group-label">{group.label}</div>
                 {group.items.map(({ kind, label, Icon }) => (
                   <button
                     key={label}
                     type="button"
+                    role="menuitem"
                     onClick={() => choose(kind)}
-                    className="flex w-full items-center gap-2.5 px-3 py-1.5 text-sm hover:bg-muted"
+                    className="sb-menu-item"
                   >
-                    <Icon className="h-4 w-4 text-muted-foreground" />
+                    <Icon className="sb-menu-item-icon h-4 w-4" />
                     {label}
                   </button>
                 ))}

--- a/new-ui-source/src/components/storyboard/AiAssistPopover.tsx
+++ b/new-ui-source/src/components/storyboard/AiAssistPopover.tsx
@@ -97,20 +97,36 @@ export default function AiAssistPopover({
   const canApply = !!result && !loading;
 
   return createPortal(
-    <div className="fixed inset-0 z-[1100] flex items-start justify-center bg-black/20 pt-24" onMouseDown={onClose}>
+    <div
+      className="fixed inset-0 z-[1100] flex items-start justify-center pt-24"
+      style={{ background: 'rgba(4, 30, 41, 0.35)' }}
+      onMouseDown={onClose}
+    >
       <div
-        className="w-[min(92vw,520px)] rounded-xl border bg-background p-5 shadow-2xl"
+        className="w-[min(92vw,520px)] p-5"
+        style={{
+          borderRadius: 12,
+          background: 'var(--life-color-bg-surface-default)',
+          border: '1px solid var(--life-color-border-subtle)',
+          boxShadow: 'var(--elevation-lg)',
+          fontFamily: 'var(--font-family-primary)',
+        }}
         onMouseDown={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="mb-4 flex items-center gap-2">
           <HeartHandshake className="h-5 w-5" style={{ color: 'var(--samaritan)' }} />
-          <h3 className="text-base font-semibold">Samaritan Assistance</h3>
-          <div className="ml-auto flex items-center gap-1 text-muted-foreground">
+          <h3 style={{ fontSize: 16, fontWeight: 700, color: 'var(--life-color-text-default)' }}>
+            Samaritan Assistance
+          </h3>
+          <div
+            className="ml-auto flex items-center gap-1"
+            style={{ color: 'var(--life-color-text-subtle)' }}
+          >
             <span title="Improve, shorten, prolong or spell-check the content, or type your own instruction.">
               <HelpCircle className="h-4 w-4" />
             </span>
-            <button type="button" onClick={onClose} title="Close" className="rounded p-1 hover:bg-muted">
+            <button type="button" onClick={onClose} title="Close" className="sb-panel-collapse-btn">
               <X className="h-4 w-4" />
             </button>
           </div>
@@ -119,8 +135,14 @@ export default function AiAssistPopover({
         {/* Content / result */}
         {result ? (
           <div
-            className="mb-3 max-h-56 overflow-y-auto whitespace-pre-wrap rounded-lg border p-3 text-sm"
-            style={{ background: 'linear-gradient(90deg, #FBDBFB 0%, #E0E6FA 100%)' }}
+            className="mb-3 max-h-56 overflow-y-auto whitespace-pre-wrap p-3"
+            style={{
+              borderRadius: 'var(--radius)',
+              border: '1px solid color-mix(in oklab, var(--samaritan) 30%, transparent)',
+              background: 'linear-gradient(90deg, #FBDBFB 0%, #E0E6FA 100%)',
+              fontSize: 13,
+              color: 'var(--life-color-text-default)',
+            }}
           >
             {result}
           </div>
@@ -131,14 +153,28 @@ export default function AiAssistPopover({
             placeholder="Add your content here..."
             rows={4}
             disabled={loading}
-            className="mb-3 w-full resize-y rounded-lg bg-muted/60 p-3 text-sm outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+            className="mb-3 w-full resize-y p-3 outline-none"
+            style={{
+              borderRadius: 'var(--radius)',
+              background: 'var(--life-color-bg-surface-subtle)',
+              border: '1px solid var(--life-color-border-subtle)',
+              fontSize: 13,
+              color: 'var(--life-color-text-default)',
+              opacity: loading ? 0.6 : 1,
+            }}
           />
         )}
 
         {loading && (
-          <div className="mb-3 text-sm text-muted-foreground">Loading response from Samaritan…</div>
+          <div className="mb-3" style={{ fontSize: 13, color: 'var(--life-color-text-subtle)' }}>
+            Loading response from Samaritan…
+          </div>
         )}
-        {error && <div className="mb-3 text-sm text-red-600">{error}</div>}
+        {error && (
+          <div className="mb-3" style={{ fontSize: 13, color: 'var(--life-color-text-critical)' }}>
+            {error}
+          </div>
+        )}
 
         {/* Quick actions */}
         {!result && (
@@ -149,7 +185,8 @@ export default function AiAssistPopover({
                 type="button"
                 disabled={loading}
                 onClick={() => void run(a.action)}
-                className="rounded-full border px-3 py-1.5 text-sm hover:bg-secondary disabled:opacity-50"
+                className="sb-toolbar-btn"
+                style={{ borderRadius: 9999, fontSize: 13 }}
               >
                 {a.label}
               </button>
@@ -158,7 +195,14 @@ export default function AiAssistPopover({
         )}
 
         {/* Free-text prompt */}
-        <div className="mb-4 flex items-center gap-2 rounded-full border px-3 py-1.5">
+        <div
+          className="mb-4 flex items-center gap-2 px-3 py-1.5"
+          style={{
+            borderRadius: 9999,
+            border: '1px solid var(--life-color-border-subtle)',
+            background: 'var(--life-color-bg-surface-default)',
+          }}
+        >
           <input
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
@@ -167,14 +211,16 @@ export default function AiAssistPopover({
             }}
             placeholder="Ask Samaritan to edit or generate from scratch..."
             disabled={loading}
-            className="min-w-0 flex-1 bg-transparent text-sm outline-none disabled:opacity-60"
+            className="min-w-0 flex-1 bg-transparent outline-none"
+            style={{ fontSize: 13, color: 'var(--life-color-text-default)', opacity: loading ? 0.6 : 1 }}
           />
           <button
             type="button"
             onClick={submitPrompt}
             disabled={loading}
             title="Send"
-            className="rounded-full p-1 text-muted-foreground hover:bg-muted disabled:opacity-50"
+            className="sb-panel-collapse-btn"
+            style={{ borderRadius: 9999 }}
           >
             <Send className="h-4 w-4" />
           </button>
@@ -187,16 +233,12 @@ export default function AiAssistPopover({
             onClick={tryAgain}
             disabled={!lastRun.current || loading}
             title="Try again"
-            className="rounded-md p-2 text-muted-foreground hover:bg-muted disabled:opacity-40"
+            className="sb-panel-collapse-btn"
           >
             <RefreshCw className="h-4 w-4" />
           </button>
           <div className="ml-auto flex items-center gap-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded-md border px-3 py-1.5 text-sm hover:bg-secondary"
-            >
+            <button type="button" onClick={onClose} className="sb-toolbar-btn">
               Dismiss
             </button>
             <button
@@ -207,7 +249,7 @@ export default function AiAssistPopover({
               }}
               disabled={!canApply}
               title="Replace the current block's content"
-              className="rounded-md border px-3 py-1.5 text-sm hover:bg-secondary disabled:opacity-40"
+              className="sb-toolbar-btn"
             >
               Replace
             </button>
@@ -219,8 +261,7 @@ export default function AiAssistPopover({
               }}
               disabled={!canApply}
               title="Insert the generated content"
-              className="rounded-md px-4 py-1.5 text-sm font-semibold text-primary-foreground hover:opacity-90 disabled:opacity-40"
-              style={{ background: 'var(--primary)' }}
+              className="sb-toolbar-btn sb-toolbar-btn-primary"
             >
               Insert
             </button>

--- a/new-ui-source/src/components/storyboard/AiGuidance.tsx
+++ b/new-ui-source/src/components/storyboard/AiGuidance.tsx
@@ -30,12 +30,25 @@ export default function AiGuidance({ summary }: { summary: StoryboardSummary }) 
   if (hints.length === 0) return null;
 
   return (
-    <div className="rounded-lg border border-samaritan/30 bg-samaritan/5 p-3">
-      <div className="mb-2 flex items-center gap-1.5 text-sm font-semibold" style={{ color: 'var(--samaritan)' }}>
+    <div className="sb-card sb-card--samaritan" style={{ fontFamily: 'var(--font-family-primary)' }}>
+      <div
+        className="mb-2 flex items-center gap-1.5"
+        style={{ fontSize: 13, fontWeight: 700, color: 'var(--samaritan)' }}
+      >
         <Sparkles className="h-4 w-4" />
         AI guidance
       </div>
-      <ul className="space-y-1.5 text-[13px] leading-snug text-muted-foreground">
+      <ul
+        className="space-y-1.5"
+        style={{
+          fontSize: 13,
+          lineHeight: 1.45,
+          color: 'var(--life-color-text-muted)',
+          margin: 0,
+          padding: 0,
+          listStyle: 'none',
+        }}
+      >
         {hints.map((h, i) => (
           <li key={i}>• {h}</li>
         ))}

--- a/new-ui-source/src/components/storyboard/BlockNoteStoryboardEditor.tsx
+++ b/new-ui-source/src/components/storyboard/BlockNoteStoryboardEditor.tsx
@@ -45,6 +45,7 @@ const COMPONENT_CARD_KINDS = new Set<StoryboardInsertKind>([
   'audio',
   'h5p',
   'laerdalForm',
+  'assessmentResult',
 ]);
 
 const DEFAULT_CONTENT: PartialBlock[] = [

--- a/new-ui-source/src/components/storyboard/CommentPopover.tsx
+++ b/new-ui-source/src/components/storyboard/CommentPopover.tsx
@@ -84,40 +84,63 @@ export default function CommentPopover({
   };
 
   return createPortal(
-    <div className="fixed inset-0 z-[1100] flex items-start justify-center bg-black/20 pt-24" onMouseDown={onClose}>
+    <div
+      className="fixed inset-0 z-[1100] flex items-start justify-center pt-24"
+      style={{ background: 'rgba(4, 30, 41, 0.35)' }}
+      onMouseDown={onClose}
+    >
       <div
-        className="w-[min(92vw,420px)] rounded-xl border bg-background p-4 shadow-2xl"
+        className="w-[min(92vw,420px)] p-4"
+        style={{
+          borderRadius: 12,
+          background: 'var(--life-color-bg-surface-default)',
+          border: '1px solid var(--life-color-border-subtle)',
+          boxShadow: 'var(--elevation-lg)',
+          fontFamily: 'var(--font-family-primary)',
+        }}
         onMouseDown={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="mb-3 flex items-center gap-2">
-          <span className="truncate text-[11px] font-semibold uppercase tracking-wide text-muted-foreground" title={blockLabel}>
+          <span
+            className="truncate"
+            title={blockLabel}
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              letterSpacing: '0.06em',
+              color: 'var(--life-color-text-subtle)',
+            }}
+          >
             {blockLabel}
           </span>
-          <button type="button" onClick={onClose} title="Close" className="ml-auto rounded p-1 hover:bg-muted">
+          <button type="button" onClick={onClose} title="Close" className="ml-auto sb-panel-collapse-btn">
             <X className="h-4 w-4" />
           </button>
         </div>
 
         {!blockId ? (
-          <p className="mb-3 text-sm text-muted-foreground">
+          <p className="mb-3" style={{ fontSize: 13, color: 'var(--life-color-text-subtle)' }}>
             Place the cursor in a block to comment on it.
           </p>
         ) : (
           <div className="mb-3 max-h-64 space-y-2 overflow-y-auto">
             {tops.length === 0 && !loading && (
-              <p className="text-sm text-muted-foreground">No comments yet.</p>
+              <p style={{ fontSize: 13, color: 'var(--life-color-text-subtle)' }}>No comments yet.</p>
             )}
             {tops.map((top) => (
-              <div key={top._id} className="rounded-lg border p-2.5">
+              <div key={top._id} className="sb-card">
                 <div className="mb-1 flex items-center gap-1">
-                  <span className="text-[11px] text-muted-foreground">{timeAgo(top.createdAt)}</span>
+                  <span style={{ fontSize: 11, color: 'var(--life-color-text-subtle)' }}>
+                    {timeAgo(top.createdAt)}
+                  </span>
                   <div className="ml-auto flex items-center gap-1">
                     <button
                       type="button"
                       title={top.resolved ? 'Reopen' : 'Resolve'}
                       onClick={() => onResolve(top._id, !top.resolved)}
-                      className="grid h-6 w-6 place-items-center rounded text-muted-foreground hover:bg-muted"
+                      className="sb-panel-collapse-btn"
                     >
                       {top.resolved ? <RotateCcw className="h-3.5 w-3.5" /> : <Check className="h-3.5 w-3.5" />}
                     </button>
@@ -125,20 +148,39 @@ export default function CommentPopover({
                       type="button"
                       title="Delete"
                       onClick={() => onDelete(top._id)}
-                      className="grid h-6 w-6 place-items-center rounded text-muted-foreground hover:bg-muted"
+                      className="sb-panel-collapse-btn"
                     >
                       <Trash2 className="h-3.5 w-3.5" />
                     </button>
                   </div>
                 </div>
-                <p className="whitespace-pre-wrap text-sm text-foreground">{top.body}</p>
+                <p
+                  className="whitespace-pre-wrap"
+                  style={{ fontSize: 13, color: 'var(--life-color-text-default)' }}
+                >
+                  {top.body}
+                </p>
 
                 {repliesOf(top._id).map((r) => (
-                  <div key={r._id} className="mt-2 flex gap-1.5 border-l-2 border-border pl-2">
-                    <CornerDownRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  <div
+                    key={r._id}
+                    className="mt-2 flex gap-1.5 pl-2"
+                    style={{ borderLeft: '2px solid var(--life-color-border-subtle)' }}
+                  >
+                    <CornerDownRight
+                      className="mt-0.5 h-3.5 w-3.5 shrink-0"
+                      style={{ color: 'var(--life-color-text-subtle)' }}
+                    />
                     <div className="min-w-0">
-                      <p className="whitespace-pre-wrap text-sm text-foreground">{r.body}</p>
-                      <p className="mt-0.5 text-[11px] text-muted-foreground">{timeAgo(r.createdAt)}</p>
+                      <p
+                        className="whitespace-pre-wrap"
+                        style={{ fontSize: 13, color: 'var(--life-color-text-default)' }}
+                      >
+                        {r.body}
+                      </p>
+                      <p style={{ marginTop: 2, fontSize: 11, color: 'var(--life-color-text-subtle)' }}>
+                        {timeAgo(r.createdAt)}
+                      </p>
                     </div>
                   </div>
                 ))}
@@ -157,9 +199,27 @@ export default function CommentPopover({
                         value={reply.text}
                         onChange={(e) => setReply({ id: top._id, text: e.target.value })}
                         placeholder="Reply…"
-                        className="flex-1 rounded border border-border bg-background px-2 py-1 text-sm outline-none focus:border-primary"
+                        className="flex-1 rounded px-2 py-1 outline-none"
+                        style={{
+                          fontSize: 13,
+                          border: '1px solid var(--life-color-border-subtle)',
+                          background: 'var(--life-color-bg-surface-default)',
+                          color: 'var(--life-color-text-default)',
+                        }}
                       />
-                      <button type="submit" disabled={!reply.text.trim() || busy} className="text-xs font-medium text-primary disabled:opacity-40">
+                      <button
+                        type="submit"
+                        disabled={!reply.text.trim() || busy}
+                        style={{
+                          fontSize: 12,
+                          fontWeight: 600,
+                          color: 'var(--life-color-text-primary)',
+                          opacity: reply.text.trim() && !busy ? 1 : 0.4,
+                          background: 'none',
+                          border: 'none',
+                          cursor: reply.text.trim() && !busy ? 'pointer' : 'not-allowed',
+                        }}
+                      >
                         Reply
                       </button>
                     </form>
@@ -167,7 +227,15 @@ export default function CommentPopover({
                     <button
                       type="button"
                       onClick={() => setReply({ id: top._id, text: '' })}
-                      className="mt-1.5 text-xs font-medium text-primary"
+                      style={{
+                        marginTop: 6,
+                        fontSize: 12,
+                        fontWeight: 600,
+                        color: 'var(--life-color-text-primary)',
+                        background: 'none',
+                        border: 'none',
+                        cursor: 'pointer',
+                      }}
                     >
                       Reply
                     </button>
@@ -188,14 +256,21 @@ export default function CommentPopover({
               }}
               placeholder="Comment... use @ to mention"
               rows={2}
-              className="mb-2 w-full resize-y rounded-lg bg-muted/60 p-2.5 text-sm outline-none focus:ring-2 focus:ring-ring"
+              className="mb-2 w-full resize-y p-2.5 outline-none"
+              style={{
+                borderRadius: 'var(--radius)',
+                background: 'var(--life-color-bg-surface-subtle)',
+                border: '1px solid var(--life-color-border-subtle)',
+                fontSize: 13,
+                color: 'var(--life-color-text-default)',
+              }}
             />
             <div className="flex items-center gap-2">
               <button
                 type="button"
                 onClick={() => setBody((b) => `${b}@`)}
                 title="Mention someone"
-                className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-sm hover:bg-secondary"
+                className="sb-toolbar-btn"
               >
                 <AtSign className="h-3.5 w-3.5" /> Mention
               </button>
@@ -203,8 +278,7 @@ export default function CommentPopover({
                 type="button"
                 onClick={() => void post()}
                 disabled={!body.trim() || busy}
-                className="ml-auto rounded-md px-4 py-1.5 text-sm font-semibold text-primary-foreground hover:opacity-90 disabled:opacity-40"
-                style={{ background: 'var(--primary)' }}
+                className="ml-auto sb-toolbar-btn sb-toolbar-btn-primary"
               >
                 Post
               </button>

--- a/new-ui-source/src/components/storyboard/ContentsPanel.tsx
+++ b/new-ui-source/src/components/storyboard/ContentsPanel.tsx
@@ -1,6 +1,7 @@
-// Left panel — "CONTENTS": TOC tree (top) + AI guidance (bottom). Spec AC1/AC7.
+// Left panel — "CONTENTS": TOC tree (top) + AI guidance (bottom).
+// Spec AC1/AC7, Figma-aligned (ADAPT-3842) — LIFE tokens via .sb-panel utility.
 
-import { ListTree, ChevronDown } from 'lucide-react';
+import { ListTree, PanelLeftClose } from 'lucide-react';
 import type { StoryboardHeading, StoryboardSummary } from '@/types/storyboard';
 import TableOfContents from './TableOfContents';
 import AiGuidance from './AiGuidance';
@@ -19,9 +20,9 @@ export default function ContentsPanel({
   onCollapse?: () => void;
 }) {
   return (
-    <div className="flex h-full flex-col bg-muted/20">
-      <div className="flex items-center justify-between border-b bg-muted/40 px-3 py-2.5 backdrop-blur">
-        <div className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+    <div className="sb-panel" style={{ fontFamily: 'var(--font-family-primary)' }}>
+      <div className="sb-panel-header">
+        <div className="sb-panel-title">
           <ListTree className="h-4 w-4" />
           Contents
         </div>
@@ -30,18 +31,21 @@ export default function ContentsPanel({
             type="button"
             aria-label="Collapse contents"
             onClick={onCollapse}
-            className="grid h-6 w-6 place-items-center rounded text-muted-foreground hover:bg-muted"
+            className="sb-panel-collapse-btn"
           >
-            <ChevronDown className="h-4 w-4" />
+            <PanelLeftClose className="h-4 w-4" />
           </button>
         )}
       </div>
 
-      <nav className="flex-1 overflow-y-auto p-2">
+      <nav className="flex-1 overflow-y-auto px-2 py-3">
         <TableOfContents headings={headings} activeId={activeId} onNavigate={onNavigate} />
       </nav>
 
-      <div className="border-t p-3">
+      <div
+        className="p-3"
+        style={{ borderTop: '1px solid var(--life-color-border-subtle)', background: 'var(--life-color-bg-surface-default)' }}
+      >
         <AiGuidance summary={summary} />
       </div>
     </div>

--- a/new-ui-source/src/components/storyboard/DocumentToolbar.tsx
+++ b/new-ui-source/src/components/storyboard/DocumentToolbar.tsx
@@ -1,7 +1,7 @@
-// Center toolbar above the canvas (spec AC2/AC3/AC7).
-//   Row 1: STORYBOARD DOCUMENT · Add Heading · Add Content · Add Instruction
-//   Row 2: Enrich with AI
-// (References and JSON state are hidden for Phase 1.)
+// Center toolbar above the canvas (spec AC2/AC3/AC7, Figma-aligned ADAPT-3842).
+//   Row 1: STORYBOARD DOCUMENT · Add Heading · Add Content · Add Instruction ·
+//          (Refresh from course)
+//   Row 2: Enrich with AI (Samaritan-accented outline button)
 
 import { FileText, Info, RefreshCw, Sparkles } from 'lucide-react';
 import type { StoryboardInsertKind } from '@/types/storyboard';
@@ -20,9 +20,25 @@ export default function DocumentToolbar({
   onRefresh?: () => void;
 }) {
   return (
-    <div className="border-b bg-background/95 px-8 py-2 backdrop-blur">
+    <div
+      className="px-8 py-2.5"
+      style={{
+        background: 'var(--life-color-bg-surface-default)',
+        borderBottom: '1px solid var(--life-color-border-subtle)',
+        fontFamily: 'var(--font-family-primary)',
+      }}
+    >
       <div className="flex flex-wrap items-center gap-2">
-        <div className="mr-1 flex items-center gap-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+        <div
+          className="mr-1 inline-flex items-center gap-1.5"
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            textTransform: 'uppercase',
+            letterSpacing: '0.08em',
+            color: 'var(--life-color-text-subtle)',
+          }}
+        >
           <FileText className="h-4 w-4" /> Storyboard Document
         </div>
         <HeadingMenu onSelect={onInsertHeading} />
@@ -30,7 +46,7 @@ export default function DocumentToolbar({
         <button
           type="button"
           onClick={() => onInsert('instruction')}
-          className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-secondary"
+          className="sb-toolbar-btn"
         >
           <Info className="h-3.5 w-3.5" /> Add Instruction
         </button>
@@ -39,23 +55,18 @@ export default function DocumentToolbar({
             type="button"
             onClick={onRefresh}
             title="Reload the storyboard from the latest course content"
-            className="ml-auto inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-secondary"
+            className="sb-toolbar-btn ml-auto"
           >
             <RefreshCw className="h-3.5 w-3.5" /> Refresh from course
           </button>
         )}
       </div>
 
-      <div className="mt-1.5 flex flex-wrap items-center gap-2">
+      <div className="mt-2 flex flex-wrap items-center gap-2">
         <button
           type="button"
           onClick={onEnrichAI}
-          className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:opacity-90"
-          style={{
-            borderColor: 'color-mix(in oklab, var(--samaritan) 30%, transparent)',
-            background: 'color-mix(in oklab, var(--samaritan) 8%, transparent)',
-            color: 'var(--samaritan)',
-          }}
+          className="sb-toolbar-btn sb-toolbar-btn-samaritan"
         >
           <Sparkles className="h-3.5 w-3.5" /> Enrich with AI
         </button>

--- a/new-ui-source/src/components/storyboard/GenerateDialog.tsx
+++ b/new-ui-source/src/components/storyboard/GenerateDialog.tsx
@@ -1,4 +1,4 @@
-// Generate-course dialog (ADAPT-3760, Phase 4 / AC11).
+// Generate-course dialog (ADAPT-3760, Phase 4 / AC11, Figma-aligned ADAPT-3842).
 // Shows a pre-generation validation report + plan summary, then the result.
 
 import { Loader2, X, AlertTriangle, CheckCircle2, ArrowRight } from 'lucide-react';
@@ -6,9 +6,25 @@ import type { GenerationPlan, GenerationResult } from '@/api/storyboardGeneratio
 
 function Stat({ label, value }: { label: string; value: number }) {
   return (
-    <div className="rounded-lg border p-2 text-center">
-      <div className="text-lg font-semibold text-foreground">{value}</div>
-      <div className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</div>
+    <div
+      className="p-2 text-center"
+      style={{
+        border: '1px solid var(--life-color-border-subtle)',
+        borderRadius: 'var(--radius)',
+        background: 'var(--life-color-bg-surface-subtle)',
+      }}
+    >
+      <div style={{ fontSize: 18, fontWeight: 700, color: 'var(--life-color-text-default)' }}>{value}</div>
+      <div
+        style={{
+          fontSize: 11,
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
+          color: 'var(--life-color-text-subtle)',
+        }}
+      >
+        {label}
+      </div>
     </div>
   );
 }
@@ -29,16 +45,35 @@ export default function GenerateDialog({
   const blocked = !!plan && plan.issues.length > 0;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-6" onClick={running ? undefined : onClose}>
-      <div className="w-full max-w-lg rounded-lg border bg-background shadow-lg" onClick={(e) => e.stopPropagation()}>
-        <div className="flex items-center justify-between border-b px-4 py-2.5">
-          <h3 className="text-sm font-semibold">Generate Course</h3>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-6"
+      style={{ background: 'rgba(4, 30, 41, 0.45)', fontFamily: 'var(--font-family-primary)' }}
+      onClick={running ? undefined : onClose}
+    >
+      <div
+        className="w-full max-w-lg"
+        style={{
+          background: 'var(--life-color-bg-surface-default)',
+          border: '1px solid var(--life-color-border-subtle)',
+          borderRadius: 'var(--radius)',
+          boxShadow: 'var(--elevation-lg)',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div
+          className="flex items-center justify-between px-4 py-2.5"
+          style={{ borderBottom: '1px solid var(--life-color-border-subtle)' }}
+        >
+          <h3 style={{ fontSize: 14, fontWeight: 700, color: 'var(--life-color-text-default)' }}>
+            Generate Course
+          </h3>
           <button
             type="button"
             aria-label="Close"
             onClick={onClose}
             disabled={running}
-            className="grid h-7 w-7 place-items-center rounded text-muted-foreground hover:bg-muted disabled:opacity-40"
+            className="sb-panel-collapse-btn"
+            style={{ opacity: running ? 0.4 : 1 }}
           >
             <X className="h-4 w-4" />
           </button>
@@ -47,19 +82,27 @@ export default function GenerateDialog({
         <div className="p-4">
           {result ? (
             <div className="text-center">
-              <CheckCircle2 className="mx-auto mb-2 h-8 w-8 text-[#166534]" />
-              <p className="text-sm font-medium text-foreground">Course generated.</p>
-              <p className="mt-1 text-sm text-muted-foreground">
+              <CheckCircle2
+                className="mx-auto mb-2 h-8 w-8"
+                style={{ color: 'var(--life-color-text-positive)' }}
+              />
+              <p style={{ fontSize: 14, fontWeight: 600, color: 'var(--life-color-text-default)' }}>
+                Course generated.
+              </p>
+              <p style={{ marginTop: 4, fontSize: 13, color: 'var(--life-color-text-subtle)' }}>
                 {result.created} created · {result.updated} updated · {result.deleted} removed
               </p>
             </div>
           ) : !plan ? (
-            <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+            <div
+              className="flex items-center justify-center gap-2 py-8"
+              style={{ fontSize: 13, color: 'var(--life-color-text-subtle)' }}
+            >
               <Loader2 className="h-4 w-4 animate-spin" /> Analysing storyboard…
             </div>
           ) : (
             <>
-              <p className="mb-3 text-sm text-muted-foreground">
+              <p className="mb-3" style={{ fontSize: 13, color: 'var(--life-color-text-subtle)' }}>
                 This will map your storyboard headings onto the Adapt course structure.
               </p>
               <div className="mb-3 grid grid-cols-4 gap-2">
@@ -70,7 +113,16 @@ export default function GenerateDialog({
               </div>
 
               {plan.willDelete > 0 && (
-                <div className="mb-3 flex items-start gap-2 rounded-md border border-[#fcd34d] bg-[#fffbeb] p-2.5 text-sm text-[#92400e]">
+                <div
+                  className="mb-3 flex items-start gap-2 p-2.5"
+                  style={{
+                    border: '1px solid var(--life-color-border-warning)',
+                    background: 'var(--life-color-bg-surface-warning-subtle)',
+                    color: 'var(--life-color-text-warning)',
+                    borderRadius: 'var(--radius)',
+                    fontSize: 13,
+                  }}
+                >
                   <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
                   <span>
                     {plan.willDelete} existing course item(s) not present in the storyboard will be <b>removed</b>.
@@ -79,46 +131,56 @@ export default function GenerateDialog({
               )}
 
               {plan.issues.map((msg, i) => (
-                <div key={`i${i}`} className="mb-1.5 flex items-start gap-2 rounded-md border border-[#fca5a5] bg-[#fef2f2] p-2 text-sm text-[#991b1b]">
+                <div
+                  key={`i${i}`}
+                  className="mb-1.5 flex items-start gap-2 p-2"
+                  style={{
+                    border: '1px solid var(--life-color-border-critical)',
+                    background: 'var(--life-color-bg-surface-critical-subtle)',
+                    color: 'var(--life-color-text-critical)',
+                    borderRadius: 'var(--radius)',
+                    fontSize: 13,
+                  }}
+                >
                   <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" /> {msg}
                 </div>
               ))}
               {plan.warnings.slice(0, 5).map((msg, i) => (
-                <div key={`w${i}`} className="mb-1.5 text-xs text-[#92400e]">
+                <div
+                  key={`w${i}`}
+                  className="mb-1.5"
+                  style={{ fontSize: 12, color: 'var(--life-color-text-warning)' }}
+                >
                   ⚠ {msg}
                 </div>
               ))}
               {plan.warnings.length > 5 && (
-                <div className="text-xs text-muted-foreground">…and {plan.warnings.length - 5} more.</div>
+                <div style={{ fontSize: 12, color: 'var(--life-color-text-subtle)' }}>
+                  …and {plan.warnings.length - 5} more.
+                </div>
               )}
             </>
           )}
         </div>
 
-        <div className="flex justify-end gap-2 border-t px-4 py-2.5">
+        <div
+          className="flex justify-end gap-2 px-4 py-2.5"
+          style={{ borderTop: '1px solid var(--life-color-border-subtle)' }}
+        >
           {result ? (
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded-md bg-[color:var(--primary)] px-4 py-1.5 text-sm font-semibold text-primary-foreground"
-            >
+            <button type="button" onClick={onClose} className="sb-toolbar-btn sb-toolbar-btn-primary">
               Done
             </button>
           ) : (
             <>
-              <button
-                type="button"
-                onClick={onClose}
-                disabled={running}
-                className="rounded-md border px-3 py-1.5 text-sm hover:bg-secondary disabled:opacity-40"
-              >
+              <button type="button" onClick={onClose} disabled={running} className="sb-toolbar-btn">
                 Cancel
               </button>
               <button
                 type="button"
                 onClick={onConfirm}
                 disabled={!plan || blocked || running}
-                className="inline-flex items-center gap-1.5 rounded-md bg-[color:var(--primary)] px-4 py-1.5 text-sm font-semibold text-primary-foreground disabled:opacity-40"
+                className="sb-toolbar-btn sb-toolbar-btn-primary"
               >
                 {running ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <ArrowRight className="h-3.5 w-3.5" />}
                 {running ? 'Generating…' : 'Generate'}

--- a/new-ui-source/src/components/storyboard/HeadingMenu.tsx
+++ b/new-ui-source/src/components/storyboard/HeadingMenu.tsx
@@ -1,27 +1,31 @@
-// "Add Heading" dropdown (spec AC4). Matches the Lovable design: a HEADINGS
-// group offering H1 — Topic / H2 — Section / H3 — Content Group Heading.
+// "Add Heading" dropdown (spec AC4, Figma-aligned ADAPT-3842).
 //
-// Rendered in a portal with fixed positioning so it can never be clipped or
-// mis-stacked by the editor's scroll/overflow/backdrop-blur ancestors — the
-// same treatment as AddContentMenu.
+// Matches the Figma "Course Creation Center" HeadingDropdown: each option is
+// a two-line row with a bold H1/H2/H3 badge (`.sb-heading-chip`) and the
+// Topic / Section / Content Group label + descriptor. Rendered in a portal
+// with fixed positioning so it can never be clipped or mis-stacked by the
+// editor's scroll/overflow/backdrop-blur ancestors — same treatment as
+// AddContentMenu.
 
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Heading1, ChevronDown } from 'lucide-react';
 
 interface HeadingOption {
-  level: number;
-  label: string;
+  level: 1 | 2 | 3;
+  chip: string;
+  title: string;
+  desc: string;
 }
 
 // H1–H3 only (H4/component is authored via Add Content cards).
 const HEADINGS: HeadingOption[] = [
-  { level: 1, label: 'H1 — Topic' },
-  { level: 2, label: 'H2 — Section' },
-  { level: 3, label: 'H3 — Content Group Heading' },
+  { level: 1, chip: 'H1', title: 'H1 — Topic',         desc: 'Top-level heading' },
+  { level: 2, chip: 'H2', title: 'H2 — Section',       desc: 'Under a Topic' },
+  { level: 3, chip: 'H3', title: 'H3 — Content Group', desc: 'Under a Section' },
 ];
 
-const MENU_WIDTH = 240;
+const MENU_WIDTH = 260;
 
 export default function HeadingMenu({ onSelect }: { onSelect: (level: number) => void }) {
   const [open, setOpen] = useState(false);
@@ -68,34 +72,64 @@ export default function HeadingMenu({ onSelect }: { onSelect: (level: number) =>
         ref={btnRef}
         type="button"
         onClick={() => setOpen((o) => !o)}
-        className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-secondary"
+        className="sb-toolbar-btn"
+        aria-haspopup="menu"
+        aria-expanded={open}
       >
         <Heading1 className="h-3.5 w-3.5" /> Add Heading
-        <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+        <ChevronDown className="h-3.5 w-3.5" style={{ color: 'var(--life-color-text-subtle)' }} />
       </button>
 
       {open &&
         createPortal(
           <div
             ref={menuRef}
-            style={{ position: 'fixed', left: pos.left, top: pos.top, width: MENU_WIDTH, maxHeight: pos.maxHeight }}
-            className="z-[1000] overflow-y-auto rounded-md border bg-background py-1 shadow-lg"
+            role="menu"
+            className="sb-menu"
+            style={{
+              position: 'fixed',
+              left: pos.left,
+              top: pos.top,
+              width: MENU_WIDTH,
+              maxHeight: pos.maxHeight,
+              zIndex: 1000,
+            }}
           >
-            <div className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-              Headings
-            </div>
-            {HEADINGS.map(({ level, label }) => (
+            <div className="sb-menu-group-label">Headings</div>
+            {HEADINGS.map(({ level, chip, title, desc }) => (
               <button
                 key={level}
                 type="button"
+                role="menuitem"
                 onClick={() => choose(level)}
-                className="flex w-full items-center px-3 py-1.5 text-sm hover:bg-muted"
+                className="sb-menu-item"
               >
-                {label}
+                <span className="sb-heading-chip">{chip}</span>
+                <span style={{ display: 'flex', flexDirection: 'column', gap: 1, minWidth: 0 }}>
+                  <span
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 600,
+                      color: 'var(--life-color-text-default)',
+                      lineHeight: 1.25,
+                    }}
+                  >
+                    {title}
+                  </span>
+                  <span
+                    style={{
+                      fontSize: 11,
+                      color: 'var(--life-color-text-subtle)',
+                      lineHeight: 1.3,
+                    }}
+                  >
+                    {desc}
+                  </span>
+                </span>
               </button>
             ))}
           </div>,
-          document.body
+          document.body,
         )}
     </>
   );

--- a/new-ui-source/src/components/storyboard/ReviewCenter.tsx
+++ b/new-ui-source/src/components/storyboard/ReviewCenter.tsx
@@ -15,9 +15,12 @@ type Tab = 'open' | 'resolved' | 'approvals' | 'activity';
 
 function SummaryRow({ label, value }: { label: string; value: string | number }) {
   return (
-    <div className="flex items-center justify-between py-1 text-sm">
-      <span className="text-muted-foreground">{label}</span>
-      <span className="font-medium text-foreground">{value}</span>
+    <div
+      className="flex items-center justify-between py-1"
+      style={{ fontSize: 13, fontFamily: 'var(--font-family-primary)' }}
+    >
+      <span style={{ color: 'var(--life-color-text-subtle)' }}>{label}</span>
+      <span style={{ fontWeight: 600, color: 'var(--life-color-text-default)' }}>{value}</span>
     </div>
   );
 }
@@ -41,9 +44,19 @@ interface CommentThreadProps {
 function CommentThread({ top, replies, label, onReply, onResolve, onDelete }: CommentThreadProps) {
   const [reply, setReply] = useState('');
   return (
-    <div className="rounded-lg border p-2.5">
+    <div className="sb-card" style={{ fontFamily: 'var(--font-family-primary)' }}>
       <div className="mb-1 flex items-center gap-2">
-        <span className="truncate text-[11px] font-semibold uppercase tracking-wide text-muted-foreground" title={label}>
+        <span
+          className="truncate"
+          title={label}
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            textTransform: 'uppercase',
+            letterSpacing: '0.06em',
+            color: 'var(--life-color-text-subtle)',
+          }}
+        >
           {label}
         </span>
         <div className="ml-auto flex items-center gap-1">
@@ -51,7 +64,7 @@ function CommentThread({ top, replies, label, onReply, onResolve, onDelete }: Co
             type="button"
             title={top.resolved ? 'Reopen' : 'Resolve'}
             onClick={() => onResolve(top._id, !top.resolved)}
-            className="grid h-6 w-6 place-items-center rounded text-muted-foreground hover:bg-muted"
+            className="sb-panel-collapse-btn"
           >
             {top.resolved ? <RotateCcw className="h-3.5 w-3.5" /> : <Check className="h-3.5 w-3.5" />}
           </button>
@@ -59,21 +72,42 @@ function CommentThread({ top, replies, label, onReply, onResolve, onDelete }: Co
             type="button"
             title="Delete"
             onClick={() => onDelete(top._id)}
-            className="grid h-6 w-6 place-items-center rounded text-muted-foreground hover:bg-muted"
+            className="sb-panel-collapse-btn"
           >
             <Trash2 className="h-3.5 w-3.5" />
           </button>
         </div>
       </div>
-      <p className="whitespace-pre-wrap text-sm text-foreground">{top.body}</p>
-      <p className="mt-0.5 text-[11px] text-muted-foreground">{timeAgo(top.createdAt)}</p>
+      <p
+        className="whitespace-pre-wrap"
+        style={{ fontSize: 13, color: 'var(--life-color-text-default)' }}
+      >
+        {top.body}
+      </p>
+      <p style={{ marginTop: 2, fontSize: 11, color: 'var(--life-color-text-subtle)' }}>
+        {timeAgo(top.createdAt)}
+      </p>
 
       {replies.map((r) => (
-        <div key={r._id} className="mt-2 flex gap-1.5 border-l-2 border-border pl-2">
-          <CornerDownRight className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <div
+          key={r._id}
+          className="mt-2 flex gap-1.5 pl-2"
+          style={{ borderLeft: '2px solid var(--life-color-border-subtle)' }}
+        >
+          <CornerDownRight
+            className="mt-0.5 h-3.5 w-3.5 shrink-0"
+            style={{ color: 'var(--life-color-text-subtle)' }}
+          />
           <div className="min-w-0">
-            <p className="whitespace-pre-wrap text-sm text-foreground">{r.body}</p>
-            <p className="mt-0.5 text-[11px] text-muted-foreground">{timeAgo(r.createdAt)}</p>
+            <p
+              className="whitespace-pre-wrap"
+              style={{ fontSize: 13, color: 'var(--life-color-text-default)' }}
+            >
+              {r.body}
+            </p>
+            <p style={{ marginTop: 2, fontSize: 11, color: 'var(--life-color-text-subtle)' }}>
+              {timeAgo(r.createdAt)}
+            </p>
           </div>
         </div>
       ))}
@@ -93,9 +127,27 @@ function CommentThread({ top, replies, label, onReply, onResolve, onDelete }: Co
             value={reply}
             onChange={(e) => setReply(e.target.value)}
             placeholder="Reply…"
-            className="flex-1 rounded border border-border bg-background px-2 py-1 text-sm outline-none focus:border-primary"
+            className="flex-1 rounded px-2 py-1 outline-none"
+            style={{
+              fontSize: 13,
+              border: '1px solid var(--life-color-border-subtle)',
+              background: 'var(--life-color-bg-surface-default)',
+              color: 'var(--life-color-text-default)',
+            }}
           />
-          <button type="submit" disabled={!reply.trim()} className="text-xs font-medium text-primary disabled:opacity-40">
+          <button
+            type="submit"
+            disabled={!reply.trim()}
+            style={{
+              fontSize: 12,
+              fontWeight: 600,
+              color: 'var(--life-color-text-primary)',
+              opacity: reply.trim() ? 1 : 0.4,
+              background: 'none',
+              border: 'none',
+              cursor: reply.trim() ? 'pointer' : 'not-allowed',
+            }}
+          >
             Reply
           </button>
         </form>
@@ -150,23 +202,38 @@ export default function ReviewCenter({
   };
 
   return (
-    <aside className="flex h-full flex-col bg-muted/20">
-      <div className="flex items-center justify-between border-b bg-muted/40 px-4 py-2.5 backdrop-blur">
-        <h2 className="text-sm font-semibold text-foreground">Review Center</h2>
+    <aside className="sb-panel" style={{ fontFamily: 'var(--font-family-primary)' }}>
+      <div className="sb-panel-header">
+        <h2 className="sb-panel-title">Review Center</h2>
         {onCollapse && (
           <button
             type="button"
             aria-label="Collapse review center"
             onClick={onCollapse}
-            className="grid h-6 w-6 place-items-center rounded text-muted-foreground hover:bg-muted"
+            className="sb-panel-collapse-btn"
           >
             <PanelRightClose className="h-4 w-4" />
           </button>
         )}
       </div>
 
-      <div className="border-b px-4 py-3">
-        <div className="mb-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+      <div
+        className="px-4 py-3"
+        style={{
+          borderBottom: '1px solid var(--life-color-border-subtle)',
+          background: 'var(--life-color-bg-surface-default)',
+        }}
+      >
+        <div
+          className="mb-1"
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            textTransform: 'uppercase',
+            letterSpacing: '0.08em',
+            color: 'var(--life-color-text-subtle)',
+          }}
+        >
           Storyboard Summary
         </div>
         <SummaryRow label="Topics" value={summary.topics} />
@@ -178,28 +245,52 @@ export default function ReviewCenter({
         <SummaryRow label="Status" value={status.replace('_', ' ')} />
       </div>
 
-      <div className="flex items-center gap-4 border-b px-4">
-        {tabs.map((t) => (
-          <button
-            key={t.id}
-            type="button"
-            onClick={() => setTab(t.id)}
-            className={`-mb-px border-b-2 py-2 text-sm transition-colors ${
-              tab === t.id
-                ? 'border-primary font-medium text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            {t.label}
-          </button>
-        ))}
+      <div
+        className="flex items-center gap-4 px-4"
+        style={{
+          borderBottom: '1px solid var(--life-color-border-subtle)',
+          background: 'var(--life-color-bg-surface-default)',
+        }}
+      >
+        {tabs.map((t) => {
+          const active = tab === t.id;
+          return (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => setTab(t.id)}
+              className="-mb-px py-2"
+              style={{
+                fontSize: 13,
+                fontFamily: 'var(--font-family-primary)',
+                fontWeight: active ? 600 : 400,
+                borderBottom: `2px solid ${active ? 'var(--life-color-border-primary)' : 'transparent'}`,
+                color: active ? 'var(--life-color-text-default)' : 'var(--life-color-text-subtle)',
+                background: 'none',
+                cursor: 'pointer',
+                transition: 'color 0.12s ease, border-color 0.12s ease',
+              }}
+            >
+              {t.label}
+            </button>
+          );
+        })}
       </div>
 
       <div className="flex-1 space-y-2 overflow-y-auto p-4">
         {tab === 'open' && (
           <>
-            <div className="rounded-lg border p-2.5">
-              <div className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            <div className="sb-card">
+              <div
+                className="mb-1 flex items-center gap-1.5"
+                style={{
+                  fontSize: 11,
+                  fontWeight: 700,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.06em',
+                  color: 'var(--life-color-text-subtle)',
+                }}
+              >
                 <MessageSquarePlus className="h-3.5 w-3.5" />
                 {activeBlock ? `Comment on: ${activeBlock.label}` : 'Select a block to comment'}
               </div>
@@ -209,14 +300,22 @@ export default function ReviewCenter({
                 placeholder="Add a comment…"
                 rows={2}
                 disabled={!activeBlock}
-                className="w-full resize-y rounded border border-border bg-background px-2 py-1 text-sm outline-none focus:border-primary disabled:opacity-50"
+                className="w-full resize-y rounded px-2 py-1 outline-none"
+                style={{
+                  fontSize: 13,
+                  border: '1px solid var(--life-color-border-subtle)',
+                  background: 'var(--life-color-bg-surface-default)',
+                  color: 'var(--life-color-text-default)',
+                  opacity: activeBlock ? 1 : 0.5,
+                }}
               />
               <div className="mt-1 flex justify-end">
                 <button
                   type="button"
                   onClick={addTopLevel}
                   disabled={!activeBlock || !draft.trim()}
-                  className="rounded-md bg-[color:var(--primary)] px-3 py-1 text-xs font-semibold text-primary-foreground disabled:opacity-40"
+                  className="sb-toolbar-btn sb-toolbar-btn-primary"
+                  style={{ fontSize: 12, padding: '5px 12px' }}
                 >
                   Comment
                 </button>
@@ -224,7 +323,12 @@ export default function ReviewCenter({
             </div>
 
             {openTops.length === 0 ? (
-              <p className="pt-2 text-center text-sm text-muted-foreground">No open comments.</p>
+              <p
+                className="pt-2 text-center"
+                style={{ fontSize: 13, color: 'var(--life-color-text-subtle)' }}
+              >
+                No open comments.
+              </p>
             ) : (
               openTops.map((c) => (
                 <CommentThread
@@ -243,7 +347,12 @@ export default function ReviewCenter({
 
         {tab === 'resolved' &&
           (resolvedTops.length === 0 ? (
-            <p className="text-center text-sm text-muted-foreground">No resolved comments yet.</p>
+            <p
+              className="text-center"
+              style={{ fontSize: 13, color: 'var(--life-color-text-subtle)' }}
+            >
+              No resolved comments yet.
+            </p>
           ) : (
             resolvedTops.map((c) => (
               <CommentThread
@@ -259,27 +368,47 @@ export default function ReviewCenter({
           ))}
 
         {tab === 'approvals' && (
-          <div className="rounded-lg border border-dashed p-4 text-center text-sm text-muted-foreground">
-            Current status: <span className="font-medium text-foreground">{status.replace('_', ' ')}</span>.
-            <br />
+          <div
+            className="p-4 text-center"
+            style={{
+              fontSize: 13,
+              color: 'var(--life-color-text-subtle)',
+              border: '1px dashed var(--life-color-border-subtle)',
+              borderRadius: 'var(--radius)',
+            }}
+          >
+            Current status:{' '}
+            <span style={{ fontWeight: 600, color: 'var(--life-color-text-default)' }}>
+              {status.replace('_', ' ')}
+            </span>
+            .<br />
             Use the status pill in the top bar to move Draft → In Review → Approved.
           </div>
         )}
 
         {tab === 'activity' &&
           (review.audit.length === 0 ? (
-            <p className="text-center text-sm text-muted-foreground">No activity yet.</p>
+            <p
+              className="text-center"
+              style={{ fontSize: 13, color: 'var(--life-color-text-subtle)' }}
+            >
+              No activity yet.
+            </p>
           ) : (
             review.audit.map((a: StoryboardAuditEvent) => (
-              <div key={a._id} className="rounded-lg border p-2.5 text-sm">
-                <span className="font-medium text-foreground">{a.event.replace('_', ' ')}</span>
+              <div key={a._id} className="sb-card" style={{ fontSize: 13 }}>
+                <span style={{ fontWeight: 600, color: 'var(--life-color-text-default)' }}>
+                  {a.event.replace('_', ' ')}
+                </span>
                 {a.fromStatus && a.toStatus && (
-                  <span className="text-muted-foreground">
+                  <span style={{ color: 'var(--life-color-text-subtle)' }}>
                     {' '}
                     — {a.fromStatus.replace('_', ' ')} → {a.toStatus.replace('_', ' ')}
                   </span>
                 )}
-                <p className="mt-0.5 text-[11px] text-muted-foreground">{timeAgo(a.createdAt)}</p>
+                <p style={{ marginTop: 2, fontSize: 11, color: 'var(--life-color-text-subtle)' }}>
+                  {timeAgo(a.createdAt)}
+                </p>
               </div>
             ))
           ))}

--- a/new-ui-source/src/components/storyboard/StoryboardTopBar.tsx
+++ b/new-ui-source/src/components/storyboard/StoryboardTopBar.tsx
@@ -1,10 +1,17 @@
-// Storyboard top bar (spec AC8/AC10/AC11).
-//   Back · Draft status · Import · AI Actions ▾ · Export ▾ · Share for Review ·
+// Storyboard top bar (spec AC8/AC10/AC11), Figma-aligned (ADAPT-3842).
+//   Back · Draft status · Save · Import · Export ▾ · Share for Review ·
 //   Generate Course →
-// Backend-dependent actions (Import/AI/Export/Share/Generate) are stubbed with
-// a toast and a Phase note until their respective phases land.
+// Backend-dependent actions (Import/Export/Share/Generate) are stubbed with a
+// toast + phase note until their respective phases land. Visual language is
+// the LIFE design system (font-family-primary, --life-color-* tokens, the
+// `.sb-toolbar-btn` and `.sb-status-pill` utilities in index.css) so the port
+// from the Figma "Course Creation Center" prototype is 1:1.
+//
+// AI is no longer a top-bar action — it lives under Add Content → AI Assistance
+// (Samaritan Assistance popover). The underlying /api/storyboard/ai proxy and
+// the card-level AI buttons are unchanged.
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import {
   ArrowLeft,
   Upload,
@@ -13,19 +20,23 @@ import {
   ArrowRight,
   ChevronDown,
   Save,
+  Loader2,
 } from 'lucide-react';
+import { createPortal } from 'react-dom';
 import type { ReviewStatus } from '@/types/storyboard';
 
-// AI is no longer a top-bar action — it lives under Add Content → AI Assistance
-// (Samaritan Assistance popover). The underlying /api/storyboard/ai proxy and
-// the card-level AI buttons are unchanged.
-
-const STATUS_META: Record<ReviewStatus, { label: string; className: string; next: ReviewStatus }> = {
-  draft: { label: 'Draft', className: 'bg-muted text-foreground', next: 'in_review' },
-  in_review: { label: 'In Review', className: 'bg-[#FCE3CF] text-[#92400e]', next: 'approved' },
-  approved: { label: 'Approved', className: 'bg-[#CCEED2] text-[#166534]', next: 'draft' },
+const STATUS_META: Record<
+  ReviewStatus,
+  { label: string; pillClass: string; next: ReviewStatus; nextLabel: string }
+> = {
+  draft:     { label: 'Draft',     pillClass: 'sb-status-pill--draft',    next: 'in_review', nextLabel: 'Send for review' },
+  in_review: { label: 'In Review', pillClass: 'sb-status-pill--review',   next: 'approved',  nextLabel: 'Approve' },
+  approved:  { label: 'Approved',  pillClass: 'sb-status-pill--approved', next: 'draft',     nextLabel: 'Reopen as draft' },
 };
 
+// A small portal-hosted dropdown used for Export — mirrors the Figma popover
+// (subtle border, elevation-lg shadow, Life tokens) and can never be clipped
+// by the sticky header's overflow context.
 function Dropdown({
   label,
   Icon,
@@ -38,43 +49,75 @@ function Dropdown({
   onSelect: (item: string) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{ left: number; top: number }>({ left: 0, top: 0 });
+
+  useLayoutEffect(() => {
+    if (!open || !btnRef.current) return;
+    const r = btnRef.current.getBoundingClientRect();
+    const MENU_W = 200;
+    const left = Math.min(r.right - MENU_W, window.innerWidth - MENU_W - 8);
+    setPos({ left: Math.max(8, left), top: r.bottom + 4 });
+  }, [open]);
+
   useEffect(() => {
     if (!open) return;
-    const h = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    const onDown = (e: MouseEvent) => {
+      const t = e.target as Node;
+      if (btnRef.current?.contains(t) || menuRef.current?.contains(t)) return;
+      setOpen(false);
     };
-    document.addEventListener('mousedown', h);
-    return () => document.removeEventListener('mousedown', h);
+    const close = () => setOpen(false);
+    document.addEventListener('mousedown', onDown);
+    window.addEventListener('resize', close);
+    window.addEventListener('scroll', close, true);
+    return () => {
+      document.removeEventListener('mousedown', onDown);
+      window.removeEventListener('resize', close);
+      window.removeEventListener('scroll', close, true);
+    };
   }, [open]);
+
   return (
-    <div ref={ref} className="relative">
+    <>
       <button
+        ref={btnRef}
         type="button"
         onClick={() => setOpen((o) => !o)}
-        className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-secondary"
+        className="sb-toolbar-btn"
+        aria-haspopup="menu"
+        aria-expanded={open}
       >
         <Icon className="h-3.5 w-3.5" /> {label}
-        <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+        <ChevronDown className="h-3.5 w-3.5" style={{ color: 'var(--life-color-text-subtle)' }} />
       </button>
-      {open && (
-        <div className="absolute right-0 top-full z-30 mt-1 w-52 rounded-md border bg-background py-1 shadow-lg">
-          {items.map((item) => (
-            <button
-              key={item}
-              type="button"
-              onClick={() => {
-                onSelect(item);
-                setOpen(false);
-              }}
-              className="flex w-full items-center px-3 py-1.5 text-sm hover:bg-muted"
-            >
-              {item}
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
+      {open &&
+        createPortal(
+          <div
+            ref={menuRef}
+            role="menu"
+            className="sb-menu"
+            style={{ position: 'fixed', left: pos.left, top: pos.top, width: 200, zIndex: 1000 }}
+          >
+            {items.map((item) => (
+              <button
+                key={item}
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  onSelect(item);
+                  setOpen(false);
+                }}
+                className="sb-menu-item"
+              >
+                {item}
+              </button>
+            ))}
+          </div>,
+          document.body,
+        )}
+    </>
   );
 }
 
@@ -104,54 +147,81 @@ export default function StoryboardTopBar({
   const meta = STATUS_META[status];
 
   return (
-    <header className="flex items-center gap-2 border-b bg-background px-4 py-2">
-      <button
-        type="button"
-        onClick={onBack}
-        className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-secondary"
-      >
+    <header
+      className="flex items-center gap-3 px-4 py-2.5"
+      style={{
+        background: 'var(--life-color-bg-surface-default)',
+        borderBottom: '1px solid var(--life-color-border-subtle)',
+        fontFamily: 'var(--font-family-primary)',
+      }}
+    >
+      <button type="button" onClick={onBack} className="sb-toolbar-btn" title="Back">
         <ArrowLeft className="h-3.5 w-3.5" /> Back
       </button>
+
       <button
         type="button"
         onClick={onCycleStatus}
-        title="Click to change review status"
-        className={`rounded-full px-3 py-1 text-xs font-medium ${meta.className}`}
+        title={`Click to ${meta.nextLabel.toLowerCase()}`}
+        className={`sb-status-pill ${meta.pillClass}`}
       >
         {meta.label}
       </button>
-      {dirty && <span className="text-xs text-[#92400e]">Unsaved changes</span>}
+
+      {dirty && (
+        <span
+          className="text-xs"
+          style={{ color: 'var(--life-color-text-warning)', fontWeight: 500 }}
+        >
+          Unsaved changes
+        </span>
+      )}
 
       <div className="ml-auto flex items-center gap-2">
         <button
           type="button"
           onClick={onSave}
           disabled={!dirty || saving}
-          className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-secondary disabled:opacity-50"
+          className="sb-toolbar-btn"
+          title="Save storyboard"
         >
-          <Save className="h-3.5 w-3.5" /> {saving ? 'Saving…' : 'Save'}
+          {saving ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Save className="h-3.5 w-3.5" />
+          )}
+          {saving ? 'Saving…' : 'Save'}
         </button>
+
         <button
           type="button"
           onClick={onImport}
           title="Import Word, PDF or PowerPoint"
-          className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-secondary"
+          className="sb-toolbar-btn"
         >
           <Upload className="h-3.5 w-3.5" /> Import
         </button>
-        <Dropdown label="Export" Icon={Download} items={['Word (.docx)', 'PDF (.pdf)']} onSelect={onExport} />
+
+        <Dropdown
+          label="Export"
+          Icon={Download}
+          items={['Word (.docx)', 'PDF (.pdf)']}
+          onSelect={onExport}
+        />
+
         <button
           type="button"
           onClick={() => onStub('Share for Review', 'Phase 5')}
-          className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-secondary"
+          className="sb-toolbar-btn"
         >
           <Users className="h-3.5 w-3.5" /> Share for Review
         </button>
+
         <button
           type="button"
           onClick={onGenerate}
-          className="inline-flex items-center gap-1.5 rounded-md px-4 py-1.5 text-sm font-semibold text-primary-foreground hover:opacity-90"
-          style={{ background: 'var(--primary)' }}
+          className="sb-toolbar-btn sb-toolbar-btn-primary"
+          title="Generate the Adapt course from this storyboard"
         >
           Generate Course <ArrowRight className="h-3.5 w-3.5" />
         </button>

--- a/new-ui-source/src/components/storyboard/TableOfContents.tsx
+++ b/new-ui-source/src/components/storyboard/TableOfContents.tsx
@@ -1,9 +1,9 @@
-// TOC tree (spec AC1). Pure projection of document headings, with H1–H4
-// badges, expand/collapse, and click-to-navigate.
+// TOC tree (spec AC1, Figma-aligned ADAPT-3842). Pure projection of document
+// headings, with H1–H4 chip badges (`.sb-heading-chip`), expand/collapse, and
+// click-to-navigate. Selected row uses the LIFE primary-subtle surface.
 
 import { useMemo, useState } from 'react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
-import { cn } from '@/utils';
 import type { StoryboardHeading } from '@/types/storyboard';
 
 interface TocNode extends StoryboardHeading {
@@ -33,25 +33,43 @@ function TocItem({
 }) {
   const [collapsed, setCollapsed] = useState(false);
   const hasChildren = node.children.length > 0;
+  const isActive = node.id === activeId;
 
   return (
     <li>
       <div
-        className={cn(
-          'group flex items-center gap-1.5 rounded px-1.5 py-1 text-sm cursor-pointer hover:bg-muted',
-          node.id === activeId && 'bg-primary/10 text-primary'
-        )}
-        style={{ paddingLeft: `${(node.level - 1) * 14 + 4}px` }}
+        className="group flex items-center gap-1.5 rounded-md py-1 pr-2 cursor-pointer transition-colors"
+        style={{
+          paddingLeft: `${(node.level - 1) * 14 + 6}px`,
+          fontSize: 13,
+          fontFamily: 'var(--font-family-primary)',
+          color: isActive ? 'var(--life-color-text-primary-strong)' : 'var(--life-color-text-default)',
+          background: isActive ? 'var(--life-color-bg-surface-primary-subtle)' : 'transparent',
+          fontWeight: isActive ? 600 : 400,
+        }}
+        onMouseEnter={(e) => {
+          if (!isActive) e.currentTarget.style.background = 'var(--life-color-bg-surface-hover)';
+        }}
+        onMouseLeave={(e) => {
+          if (!isActive) e.currentTarget.style.background = 'transparent';
+        }}
       >
         <button
           type="button"
           aria-label={collapsed ? 'Expand' : 'Collapse'}
           onClick={() => setCollapsed((c) => !c)}
-          className={cn('grid h-4 w-4 shrink-0 place-items-center text-muted-foreground', !hasChildren && 'invisible')}
+          className="grid h-4 w-4 shrink-0 place-items-center"
+          style={{
+            visibility: hasChildren ? 'visible' : 'hidden',
+            color: 'var(--life-color-text-subtle)',
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+          }}
         >
           {collapsed ? <ChevronRight className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
         </button>
-        <span className="shrink-0 text-[10px] font-bold uppercase text-muted-foreground">
+        <span className="sb-heading-chip" style={{ fontSize: 10, padding: '1px 5px', minWidth: 20 }}>
           H{node.level}
         </span>
         <span
@@ -59,7 +77,9 @@ function TocItem({
           title={node.text || 'Untitled'}
           onClick={() => onNavigate(node.id)}
         >
-          {node.text || <em className="text-muted-foreground">Untitled</em>}
+          {node.text || (
+            <em style={{ color: 'var(--life-color-text-subtle)', fontStyle: 'italic' }}>Untitled</em>
+          )}
         </span>
       </div>
       {hasChildren && !collapsed && (
@@ -86,14 +106,21 @@ export default function TableOfContents({
 
   if (tree.length === 0) {
     return (
-      <p className="px-1.5 py-2 text-sm text-muted-foreground">
+      <p
+        className="px-2 py-3"
+        style={{
+          fontSize: 13,
+          color: 'var(--life-color-text-subtle)',
+          fontFamily: 'var(--font-family-primary)',
+        }}
+      >
         Add a heading to build your table of contents.
       </p>
     );
   }
 
   return (
-    <ul>
+    <ul style={{ margin: 0, padding: 0, listStyle: 'none' }}>
       {tree.map((node) => (
         <TocItem key={node.id} node={node} activeId={activeId} onNavigate={onNavigate} />
       ))}

--- a/new-ui-source/src/components/storyboard/blocks/assessmentBlock.tsx
+++ b/new-ui-source/src/components/storyboard/blocks/assessmentBlock.tsx
@@ -106,12 +106,22 @@ function FeedbackGroup({ fb, set }: { fb: AssessmentFeedback; set: (f: Assessmen
 // without re-fetching).
 function OptionImagePicker({ value, onChange }: { value: McqOption; onChange: (patch: Partial<McqOption>) => void }) {
   const [picking, setPicking] = useState(false);
-  const preview = value.imageUrl || value.image || '';
+  // `imageUrl` is only ever set when the persisted link is directly loadable
+  // (see parseAssessmentData) — a DAM-picked `course/assets/<file>` link is
+  // NOT servable, so it must never be used as an `<img src>`. Falling back to
+  // `value.image` here would resurrect the broken-image icon on round-trip.
+  const hasImage = !!(value.imageUrl || value.image);
   return (
     <div className="mb-1 rounded border border-dashed border-border p-2">
-      {preview ? (
+      {hasImage ? (
         <div className="flex items-start gap-2">
-          <img src={preview} alt={value.text || ''} className="h-20 w-24 shrink-0 rounded object-cover" />
+          {value.imageUrl ? (
+            <img src={value.imageUrl} alt={value.text || ''} className="h-20 w-24 shrink-0 rounded object-cover" />
+          ) : (
+            <div className="flex h-20 w-24 shrink-0 items-center justify-center rounded bg-muted text-muted-foreground">
+              <ImageIcon className="h-6 w-6" />
+            </div>
+          )}
           <div className="min-w-0 flex-1">
             <div className="truncate text-[11px] text-muted-foreground" title={value.image}>{value.image}</div>
             <div className="mt-1 flex gap-1">

--- a/new-ui-source/src/components/storyboard/blocks/assessmentBlock.tsx
+++ b/new-ui-source/src/components/storyboard/blocks/assessmentBlock.tsx
@@ -6,10 +6,11 @@
 // ready — options + feedback are written into the Adapt component on Save.
 
 import { useState } from 'react';
-import { RefreshCw, Sparkles, Code, Trash2, Check, Plus, AlertTriangle, MessageSquare } from 'lucide-react';
+import { RefreshCw, Sparkles, Code, Trash2, Check, Plus, AlertTriangle, MessageSquare, FolderOpen, Image as ImageIcon } from 'lucide-react';
 import { storyboardActions } from '../storyboardActions';
 import { createReactBlockSpec } from '@blocknote/react';
 import { storyboardAi } from '@/api/ai';
+import AssetPickerModal from '@/components/common/AssetPickerModal';
 import {
   defaultAssessmentData,
   emptyFeedback,
@@ -29,6 +30,7 @@ const LABELS: Record<AssessmentKind, string> = {
   reorder: 'Sentence Reordering',
   textInput: 'Text Input',
   slider: 'Slider',
+  checklist: 'Checklist',
 };
 
 const FOOTER: Record<AssessmentKind, string> = {
@@ -38,6 +40,7 @@ const FOOTER: Record<AssessmentKind, string> = {
   reorder: 'Place the items in the correct order and then select Submit.',
   textInput: 'Type your answer and then select Submit.',
   slider: 'Move the slider to your answer and then select Submit.',
+  checklist: 'Tick the items that apply and then select Submit.',
 };
 
 const inputCls =
@@ -97,6 +100,64 @@ function FeedbackGroup({ fb, set }: { fb: AssessmentFeedback; set: (f: Assessmen
 
 // ── Per-kind bodies ──────────────────────────────────────────────────────────
 
+// Per-option image picker for Graphic MCQ. Opens the DAM AssetPickerModal and
+// stores the picked asset's course link + preview URL + DAM id on the option
+// (so publish can resolve the courseasset and the editor can show a thumbnail
+// without re-fetching).
+function OptionImagePicker({ value, onChange }: { value: McqOption; onChange: (patch: Partial<McqOption>) => void }) {
+  const [picking, setPicking] = useState(false);
+  const preview = value.imageUrl || value.image || '';
+  return (
+    <div className="mb-1 rounded border border-dashed border-border p-2">
+      {preview ? (
+        <div className="flex items-start gap-2">
+          <img src={preview} alt={value.text || ''} className="h-20 w-24 shrink-0 rounded object-cover" />
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-[11px] text-muted-foreground" title={value.image}>{value.image}</div>
+            <div className="mt-1 flex gap-1">
+              <button
+                type="button"
+                onClick={() => setPicking(true)}
+                className="inline-flex items-center gap-1 rounded border border-primary px-2 py-0.5 text-xs text-primary hover:bg-primary/5"
+              >
+                <RefreshCw className="h-3 w-3" /> Change image
+              </button>
+              <button
+                type="button"
+                onClick={() => onChange({ image: '', imageUrl: '', imageAssetId: undefined })}
+                className="inline-flex items-center gap-1 rounded border border-red-500 px-2 py-0.5 text-xs text-red-600 hover:bg-red-50"
+              >
+                <Trash2 className="h-3 w-3" /> Remove
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setPicking(true)}
+          className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90"
+        >
+          <FolderOpen className="h-3.5 w-3.5" /> Select an image
+          <span className="text-xs opacity-75">
+            <ImageIcon className="ml-1 inline h-3 w-3" />
+          </span>
+        </button>
+      )}
+      {picking && (
+        <AssetPickerModal
+          assetType="image"
+          onClose={() => setPicking(false)}
+          onSelect={(asset) => {
+            onChange({ image: asset.assetLink, imageUrl: asset.url, imageAssetId: asset.id });
+            setPicking(false);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
 function OptionsForm({ data, graphic, update }: { data: AssessmentData; graphic: boolean; update: (n: AssessmentData) => void }) {
   const options = data.options ?? [];
   const setOptions = (next: McqOption[]) => update({ ...data, options: next });
@@ -118,9 +179,7 @@ function OptionsForm({ data, graphic, update }: { data: AssessmentData; graphic:
               <Trash2 className="h-3.5 w-3.5" />
             </button>
           </div>
-          {graphic && (
-            <input value={opt.image ?? ''} placeholder="Image source URL" onKeyDown={stop} onChange={(e) => patch(i, { image: e.target.value })} className={`${inputCls} mb-1`} />
-          )}
+          {graphic && <OptionImagePicker value={opt} onChange={(p) => patch(i, p)} />}
           <label className="block">
             <span className={labelCls}>Option text</span>
             <input value={opt.text} onKeyDown={stop} onChange={(e) => patch(i, { text: e.target.value })} className={inputCls} />
@@ -204,11 +263,63 @@ function SliderForm({ data, update }: { data: AssessmentData; update: (n: Assess
   );
 }
 
+function ChecklistForm({ data, update }: { data: AssessmentData; update: (n: AssessmentData) => void }) {
+  const options = data.options ?? [];
+  const setOptions = (next: McqOption[]) => update({ ...data, options: next });
+  const patch = (i: number, p: Partial<McqOption>) => setOptions(options.map((o, j) => (j === i ? { ...o, ...p } : o)));
+  const selectable = Math.max(1, Number(data.selectable ?? 1));
+  return (
+    <div className="mt-2 rounded border border-border p-2">
+      <div className={labelCls}>Items</div>
+      {options.map((opt, i) => (
+        <div key={i} className="mb-2 rounded border border-border p-2">
+          <div className="mb-1 flex items-center justify-between gap-2">
+            <label className="flex items-center gap-1.5 text-xs font-medium text-foreground">
+              <input type="checkbox" checked={opt.correct} onChange={(e) => patch(i, { correct: e.target.checked })} className="h-4 w-4 accent-[color:var(--primary)]" />
+              Correct
+              <span className="ml-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                Item {i + 1}/{options.length}
+              </span>
+            </label>
+            <button type="button" aria-label="Remove item" onClick={() => setOptions(options.filter((_, j) => j !== i))} className="text-muted-foreground hover:text-foreground">
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </div>
+          <label className="block">
+            <span className={labelCls}>Item text</span>
+            <input value={opt.text} onKeyDown={stop} onChange={(e) => patch(i, { text: e.target.value })} className={inputCls} />
+          </label>
+          <label className="mt-1 block">
+            <span className={labelCls}>Answer-specific feedback</span>
+            <input value={opt.feedback ?? ''} placeholder="Shown when this item is selected" onKeyDown={stop} onChange={(e) => patch(i, { feedback: e.target.value })} className={inputCls} />
+          </label>
+        </div>
+      ))}
+      <button type="button" onClick={() => setOptions([...options, { text: '', correct: false, feedback: '' }])} className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline">
+        <Plus className="h-3 w-3" /> Add item
+      </button>
+      <label className="mt-2 block">
+        <span className={labelCls}>Selectable (how many items the learner may tick)</span>
+        <input
+          type="number"
+          min={1}
+          value={selectable}
+          onKeyDown={stop}
+          onChange={(e) => update({ ...data, selectable: Math.max(1, Number(e.target.value) || 1) })}
+          className={inputCls}
+        />
+      </label>
+    </div>
+  );
+}
+
 function Body({ kind, data, update }: { kind: AssessmentKind; data: AssessmentData; update: (n: AssessmentData) => void }) {
   switch (kind) {
     case 'mcq':
     case 'gmcq':
       return <OptionsForm data={data} graphic={kind === 'gmcq'} update={update} />;
+    case 'checklist':
+      return <ChecklistForm data={data} update={update} />;
     case 'matching':
       return <MatchingForm data={data} update={update} />;
     case 'reorder':
@@ -228,7 +339,7 @@ export const assessmentBlock = createReactBlockSpec(
   {
     type: 'sbAssessment',
     propSchema: {
-      kind: { default: 'mcq', values: ['mcq', 'gmcq', 'matching', 'reorder', 'textInput', 'slider'] },
+      kind: { default: 'mcq', values: ['mcq', 'gmcq', 'matching', 'reorder', 'textInput', 'slider', 'checklist'] },
       title: { default: '' },
       adaptComponent: { default: 'mcq' },
       data: { default: '{}' },

--- a/new-ui-source/src/components/storyboard/blocks/componentBlock.tsx
+++ b/new-ui-source/src/components/storyboard/blocks/componentBlock.tsx
@@ -18,6 +18,7 @@ import {
   AudioLines,
   Puzzle,
   ClipboardList,
+  Award,
   RefreshCw,
   Sparkles,
   Code,
@@ -63,7 +64,8 @@ export type ComponentKind =
   | 'video'
   | 'audio'
   | 'h5p'
-  | 'laerdalForm';
+  | 'laerdalForm'
+  | 'assessmentResult';
 
 export const COMPONENT_KINDS: ComponentKind[] = [
   'text',
@@ -73,6 +75,7 @@ export const COMPONENT_KINDS: ComponentKind[] = [
   'audio',
   'h5p',
   'laerdalForm',
+  'assessmentResult',
 ];
 
 const META: Record<ComponentKind, { badge: string; Icon: typeof Type; comp: string; suggest: ComponentKind[] }> = {
@@ -83,6 +86,7 @@ const META: Record<ComponentKind, { badge: string; Icon: typeof Type; comp: stri
   audio: { badge: 'Audio', Icon: AudioLines, comp: 'media', suggest: ['video', 'text'] },
   h5p: { badge: 'H5P', Icon: Puzzle, comp: 'h5p', suggest: ['video', 'groupedContent'] },
   laerdalForm: { badge: 'Laerdal Form', Icon: ClipboardList, comp: 'text', suggest: ['text'] },
+  assessmentResult: { badge: 'Assessment Result', Icon: Award, comp: 'assessmentResults', suggest: ['text'] },
 };
 
 const LABEL_TO_KIND: Record<string, ComponentKind> = Object.fromEntries(
@@ -104,6 +108,22 @@ interface FormField {
   placeholder: string;
   mandatory: boolean;
 }
+// adapt-contrib-assessmentResults: bands + retry + completion body. Bound to an
+// Adapt article-level assessment via `_assessmentId` — the user picks the
+// article id (visible in the Page Editor) or leaves it blank to use the first
+// assessment in the course at runtime.
+interface ResultBand {
+  score: number;
+  feedback: string;
+  allowRetry: boolean;
+}
+interface AssessmentResultConfig {
+  assessmentId: string;
+  completionBody: string;
+  retryButton: string;
+  retryFeedback: string;
+  bands: ResultBand[];
+}
 interface ComponentData {
   showTitle: boolean;
   description: string;
@@ -112,6 +132,7 @@ interface ComponentData {
   image?: ImageData; // image card (→ _graphic)
   media?: MediaData; // video/audio card (→ _media)
   fields?: FormField[];
+  result?: AssessmentResultConfig; // assessmentResult card
 }
 
 const FORM_CONTROLS = ['Single-Line Text', 'Multi-Line Text', 'Number', 'Checkbox', 'Dropdown'];
@@ -129,6 +150,20 @@ export function defaultComponentData(kind: ComponentKind): ComponentData {
       return { ...base, media: emptyMediaData() };
     case 'laerdalForm':
       return { ...base, fields: [{ control: 'Single-Line Text', label: 'Your answer', placeholder: 'Type here', mandatory: false }] };
+    case 'assessmentResult':
+      return {
+        ...base,
+        result: {
+          assessmentId: '',
+          completionBody: 'You scored {{scoreAsPercent}}%.',
+          retryButton: 'Try again',
+          retryFeedback: 'Take another go and see if you can improve your score.',
+          bands: [
+            { score: 0, feedback: 'You did not pass. Please review the material and try again.', allowRetry: true },
+            { score: 80, feedback: 'Well done — you passed!', allowRetry: false },
+          ],
+        },
+      };
     default:
       return base;
   }
@@ -184,6 +219,14 @@ function AssetPreview({ assetType, value }: { assetType: AssetKind; value: Asset
   if (!src) return null;
   if (assetType === 'image') return <img src={src} alt="" className="max-h-48 w-full rounded object-contain" />;
   if (assetType === 'audio') return <audio src={src} controls className="w-full" />;
+  if (assetType === 'h5p') {
+    // H5P files (.h5p) can't be played inline in the editor — show a badge.
+    return (
+      <div className="flex items-center gap-2 rounded border border-dashed border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+        <Puzzle className="h-4 w-4" /> H5P package selected
+      </div>
+    );
+  }
   return <VideoView src={src} className="max-h-64 w-full rounded" />;
 }
 
@@ -392,10 +435,22 @@ function ComponentBody({ kind, data, set }: { kind: ComponentKind; data: Compone
   }
 
   if (kind === 'h5p') {
+    // laerdal-h5p supports EITHER a `.h5p` DAM asset (→ `h5pAsset`) OR an
+    // external embed URL (→ `_h5pExternalAsset`). The `.external` flag on the
+    // stored AssetRef distinguishes the two; the picker below only accepts
+    // `.h5p` uploads so the DAM branch is never fed an unsupported file.
+    const asset = data.media?.asset;
     return (
-      <div>
+      <div className="space-y-2">
         <span className={labelCls}>H5P source</span>
-        <AssetField assetType="video" value={data.media?.asset} onChange={(a) => set({ ...data, media: { ...(data.media ?? emptyMediaData()), asset: a } })} />
+        <AssetField
+          assetType="h5p"
+          value={asset}
+          onChange={(a) => set({ ...data, media: { ...(data.media ?? emptyMediaData()), asset: a } })}
+        />
+        <p className="text-[11px] italic text-muted-foreground">
+          Choose a <code>.h5p</code> package from the asset library, upload one, or paste an external URL.
+        </p>
       </div>
     );
   }
@@ -438,6 +493,110 @@ function ComponentBody({ kind, data, set }: { kind: ComponentKind; data: Compone
         <button type="button" onClick={() => setFields([...fields, { control: 'Single-Line Text', label: '', placeholder: '', mandatory: false }])} className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline">
           <Plus className="h-3 w-3" /> Add form control
         </button>
+      </div>
+    );
+  }
+
+  if (kind === 'assessmentResult') {
+    const r = data.result ?? {
+      assessmentId: '',
+      completionBody: '',
+      retryButton: 'Try again',
+      retryFeedback: '',
+      bands: [] as ResultBand[],
+    };
+    const setR = (patch: Partial<AssessmentResultConfig>) => set({ ...data, result: { ...r, ...patch } });
+    const setBands = (bands: ResultBand[]) => setR({ bands });
+    const bands = r.bands ?? [];
+    return (
+      <div className="space-y-2">
+        <label className="block">
+          <span className={labelCls}>Assessment ID (article id)</span>
+          <input
+            value={r.assessmentId}
+            placeholder="Leave blank to bind to the first assessment on the page"
+            onKeyDown={stop}
+            onChange={(e) => setR({ assessmentId: e.target.value })}
+            className={inputCls}
+          />
+        </label>
+        <label className="block">
+          <span className={labelCls}>Completion body</span>
+          <textarea
+            value={r.completionBody}
+            placeholder="e.g. You scored {{scoreAsPercent}}%."
+            rows={2}
+            onKeyDown={stop}
+            onChange={(e) => setR({ completionBody: e.target.value })}
+            className={`${inputCls} resize-y`}
+          />
+          <span className="mt-0.5 block text-[11px] italic text-muted-foreground">
+            Supports {'{{score}}'}, {'{{scoreAsPercent}}'}, {'{{maxScore}}'}, {'{{correct}}'}, {'{{questionCount}}'}.
+          </span>
+        </label>
+        <div className="rounded border border-border p-2">
+          <div className={labelCls}>Score bands</div>
+          {bands.map((b, i) => (
+            <div key={i} className="mb-2 grid grid-cols-[80px_1fr_auto] gap-2 rounded border border-border p-2">
+              <label className="block">
+                <span className={labelCls}>Min %</span>
+                <input
+                  type="number"
+                  min={0}
+                  max={100}
+                  value={b.score}
+                  onKeyDown={stop}
+                  onChange={(e) => setBands(bands.map((x, j) => (j === i ? { ...x, score: Math.max(0, Math.min(100, Number(e.target.value) || 0)) } : x)))}
+                  className={inputCls}
+                />
+              </label>
+              <label className="block">
+                <span className={labelCls}>Feedback</span>
+                <textarea
+                  value={b.feedback}
+                  rows={2}
+                  onKeyDown={stop}
+                  onChange={(e) => setBands(bands.map((x, j) => (j === i ? { ...x, feedback: e.target.value } : x)))}
+                  className={`${inputCls} resize-y`}
+                />
+                <label className="mt-1 flex items-center gap-1.5 text-xs text-foreground">
+                  <input
+                    type="checkbox"
+                    checked={b.allowRetry}
+                    onChange={(e) => setBands(bands.map((x, j) => (j === i ? { ...x, allowRetry: e.target.checked } : x)))}
+                    className="h-4 w-4 accent-[color:var(--primary)]"
+                  />
+                  Allow retry
+                </label>
+              </label>
+              <button
+                type="button"
+                aria-label="Remove band"
+                onClick={() => setBands(bands.filter((_, j) => j !== i))}
+                className="self-start text-muted-foreground hover:text-foreground"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={() => setBands([...bands, { score: 0, feedback: '', allowRetry: false }])}
+            className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+          >
+            <Plus className="h-3 w-3" /> Add band
+          </button>
+        </div>
+        <div className="grid grid-cols-2 gap-2 rounded border border-border p-2">
+          <label className="block">
+            <span className={labelCls}>Retry button label</span>
+            <input value={r.retryButton} onKeyDown={stop} onChange={(e) => setR({ retryButton: e.target.value })} className={inputCls} />
+          </label>
+          <label className="block">
+            <span className={labelCls}>Retry feedback</span>
+            <input value={r.retryFeedback} onKeyDown={stop} onChange={(e) => setR({ retryFeedback: e.target.value })} className={inputCls} />
+          </label>
+        </div>
       </div>
     );
   }
@@ -585,6 +744,41 @@ function ComponentPreview({ kind, title, data }: { kind: ComponentKind; title: s
               )}
             </label>
           ))}
+        </div>
+        {instruction}
+      </div>
+    );
+  }
+
+  if (kind === 'assessmentResult') {
+    const r = data.result;
+    const bands = r?.bands ?? [];
+    return (
+      <div>
+        {heading}
+        <div className="rounded-lg border border-dashed border-border bg-muted/40 p-3">
+          <div className="mb-2 inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            <Award className="h-3.5 w-3.5" /> Assessment result
+          </div>
+          {r?.completionBody ? (
+            <p className="whitespace-pre-wrap text-sm text-foreground">{r.completionBody}</p>
+          ) : (
+            <p className="text-sm italic text-muted-foreground">Completion body not set.</p>
+          )}
+          {bands.length > 0 && (
+            <ul className="mt-2 space-y-1 text-xs">
+              {bands.map((b, i) => (
+                <li key={i} className="flex items-baseline gap-2">
+                  <span className="min-w-[3rem] rounded bg-background px-1 py-0.5 text-[10px] font-semibold text-muted-foreground">≥ {b.score}%</span>
+                  <span className="text-foreground">{b.feedback || <span className="italic text-muted-foreground">(no feedback)</span>}</span>
+                  {b.allowRetry && <span className="text-muted-foreground">· retry</span>}
+                </li>
+              ))}
+            </ul>
+          )}
+          {r?.assessmentId && (
+            <div className="mt-2 text-[11px] text-muted-foreground">Bound to assessment id: <code>{r.assessmentId}</code></div>
+          )}
         </div>
         {instruction}
       </div>

--- a/new-ui-source/src/index.css
+++ b/new-ui-source/src/index.css
@@ -119,6 +119,67 @@
   --primary:          var(--life-primary-500);
   --primary-foreground: var(--life-base-white);
   --samaritan:        var(--life-accent2-500);
+  --card:             var(--life-base-white);
+  --card-foreground:  var(--life-base-black);
+  --destructive:      var(--life-critical-500);
+  --ring:             var(--life-primary-400);
+  --input-background: var(--life-base-white);
+
+  /* ── Storyboard Figma alignment (ADAPT-3842) — Life semantic surface/text tokens.
+     These mirror the naming used in the Figma prototype (`var(--life-color-*)`)
+     so screens ported from Figma render with the correct palette. Values map
+     onto the LIFE primitive scale already declared above. Do not inline hex —
+     always use these tokens. */
+  --life-color-bg-surface-default:         var(--life-base-white);
+  --life-color-bg-surface-subtle:          var(--life-neutral-020);
+  --life-color-bg-surface-hover:           var(--life-neutral-050);
+  --life-color-bg-surface-primary:         var(--life-primary-100);
+  --life-color-bg-surface-primary-subtle:  var(--life-primary-050);
+  --life-color-bg-surface-critical-subtle: var(--life-critical-050);
+  --life-color-bg-surface-warning-subtle:  var(--life-warning-050);
+  --life-color-bg-surface-positive-subtle: var(--life-positive-050);
+  --life-color-bg-surface-samaritan-subtle: color-mix(in oklab, var(--life-accent2-500) 8%, transparent);
+
+  --life-color-bg-fill-primary:            var(--life-primary-500);
+  --life-color-bg-fill-primary-hover:      var(--life-primary-600);
+  --life-color-bg-fill-positive:           var(--life-positive-500);
+  --life-color-bg-fill-warning:            var(--life-warning-500);
+  --life-color-bg-fill-critical:           var(--life-critical-500);
+
+  --life-color-border-default:             var(--life-neutral-200);
+  --life-color-border-primary:             var(--life-primary-500);
+  --life-color-border-subtle:              var(--life-neutral-100);
+  --life-color-border-critical:            var(--life-critical-500);
+  --life-color-border-warning:             var(--life-warning-500);
+
+  --life-color-text-default:               var(--life-neutral-850);
+  --life-color-text-subtle:                var(--life-neutral-500);
+  --life-color-text-muted:                 var(--life-neutral-600);
+  --life-color-text-primary:               var(--life-primary-600);
+  --life-color-text-primary-strong:        var(--life-primary-700);
+  --life-color-text-on-primary:            var(--life-base-white);
+  --life-color-text-positive:              var(--life-positive-500);
+  --life-color-text-warning:               var(--life-warning-500);
+  --life-color-text-critical:              var(--life-critical-600);
+
+  /* Typography aliases used in ported Figma code. */
+  --font-family-primary: "Lato", "Noto Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --text-h1:      1.75rem;
+  --text-h2:      1.5rem;
+  --text-h3:      1.25rem;
+  --text-h4:      1rem;
+  --text-p:       0.875rem;
+  --text-label:   0.75rem;
+  --text-button:  0.875rem;
+  --font-weight-regular: 400;
+  --font-weight-medium:  600;
+  --font-weight-bold:    700;
+
+  /* Radius + elevation aliases (shadcn parity). */
+  --radius:       8px;
+  --elevation-sm: 0 1px 2px rgba(15, 41, 52, 0.05), 0 1px 3px rgba(15, 41, 52, 0.06);
+  --elevation-md: 0 4px 8px rgba(15, 41, 52, 0.06), 0 2px 4px rgba(15, 41, 52, 0.05);
+  --elevation-lg: 0 10px 24px rgba(15, 41, 52, 0.10), 0 4px 8px rgba(15, 41, 52, 0.06);
 }
 
 @theme inline {
@@ -131,6 +192,10 @@
   --color-primary: var(--primary);
   --color-primary-foreground: var(--primary-foreground);
   --color-samaritan: var(--samaritan);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-destructive: var(--destructive);
+  --color-ring: var(--ring);
   --font-sans: "Lato", var(--font-geist-sans), "Noto Sans", sans-serif;
   --font-mono: var(--font-geist-mono);
 }
@@ -253,3 +318,206 @@ html, body {
   direction: ltr;
   unicode-bidi: embed;
 }
+
+/* ────────────────────────────────────────────────────────────────────
+   Storyboard (ADAPT-3842) — shared visual primitives ported from the
+   Figma "Course Creation Center" prototype. Everything uses the
+   `--life-color-*` semantic tokens declared at the top of this file.
+   ──────────────────────────────────────────────────────────────────── */
+
+/* Heading-level chip (H1/H2/H3) — used in the Add Heading dropdown, the
+   TOC and elsewhere the outline level needs to be surfaced. Matches the
+   Figma HeadingDropdown chip: bold, monospace-ish caps, primary tint. */
+.sb-heading-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-family-primary);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 2px 6px;
+  min-width: 24px;
+  border-radius: 3px;
+  color: var(--life-color-text-primary);
+  background: var(--life-color-bg-surface-primary);
+  border: 1px solid var(--life-color-border-primary);
+  flex-shrink: 0;
+  letter-spacing: 0.02em;
+}
+
+/* Storyboard menu container (portal dropdowns: Add Heading, Add Content). */
+.sb-menu {
+  background: var(--life-color-bg-surface-default);
+  border: 1px solid var(--life-color-border-subtle);
+  border-radius: var(--radius);
+  box-shadow: var(--elevation-lg);
+  padding: 4px 0;
+  overflow-y: auto;
+}
+.sb-menu-group-label {
+  font-family: var(--font-family-primary);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--life-color-text-subtle);
+  padding: 10px 14px 4px;
+}
+.sb-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 9px 14px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  color: var(--life-color-text-default);
+  font-family: var(--font-family-primary);
+  font-size: 13px;
+  transition: background 0.12s ease;
+}
+.sb-menu-item:hover,
+.sb-menu-item:focus-visible {
+  background: var(--life-color-bg-surface-hover);
+  outline: none;
+}
+.sb-menu-item[aria-selected="true"] {
+  background: var(--life-color-bg-surface-primary-subtle);
+}
+.sb-menu-item .sb-menu-item-icon {
+  color: var(--life-color-text-subtle);
+  flex-shrink: 0;
+}
+
+/* Storyboard toolbar button — the tertiary/ghost bordered buttons used
+   throughout the top bar and document toolbar. */
+.sb-toolbar-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--life-color-border-subtle);
+  background: var(--life-color-bg-surface-default);
+  color: var(--life-color-text-default);
+  font-family: var(--font-family-primary);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+}
+.sb-toolbar-btn:hover:not(:disabled) {
+  background: var(--life-color-bg-surface-hover);
+  border-color: var(--life-color-border-default);
+}
+.sb-toolbar-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sb-toolbar-btn-primary {
+  border: none;
+  background: var(--life-color-bg-fill-primary);
+  color: var(--life-color-text-on-primary);
+  font-weight: 600;
+}
+.sb-toolbar-btn-primary:hover:not(:disabled) {
+  background: var(--life-color-bg-fill-primary-hover);
+}
+
+.sb-toolbar-btn-samaritan {
+  border-color: color-mix(in oklab, var(--samaritan) 30%, transparent);
+  background: var(--life-color-bg-surface-samaritan-subtle);
+  color: var(--samaritan);
+}
+.sb-toolbar-btn-samaritan:hover:not(:disabled) {
+  background: color-mix(in oklab, var(--samaritan) 14%, transparent);
+}
+
+/* Storyboard status pill — Draft / In Review / Approved. */
+.sb-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 9999px;
+  font-family: var(--font-family-primary);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: background 0.12s ease;
+}
+.sb-status-pill--draft {
+  background: var(--life-neutral-050);
+  color: var(--life-neutral-700);
+  border-color: var(--life-neutral-200);
+}
+.sb-status-pill--review {
+  background: var(--life-warning-050);
+  color: var(--life-warning-500);
+  border-color: var(--life-warning-100);
+}
+.sb-status-pill--approved {
+  background: var(--life-positive-050);
+  color: var(--life-positive-500);
+  border-color: var(--life-positive-100);
+}
+
+/* Storyboard panel chrome — Contents (left) and Review Center (right). */
+.sb-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--life-color-bg-surface-subtle);
+}
+.sb-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--life-color-border-subtle);
+  background: var(--life-color-bg-surface-default);
+}
+.sb-panel-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-family-primary);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--life-color-text-subtle);
+}
+.sb-panel-collapse-btn {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  color: var(--life-color-text-subtle);
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+.sb-panel-collapse-btn:hover {
+  background: var(--life-color-bg-surface-hover);
+}
+
+/* Storyboard card — comment threads, activity rows, generation results. */
+.sb-card {
+  background: var(--life-color-bg-surface-default);
+  border: 1px solid var(--life-color-border-subtle);
+  border-radius: var(--radius);
+  padding: 12px;
+}
+.sb-card--samaritan {
+  border-color: color-mix(in oklab, var(--samaritan) 30%, transparent);
+  background: var(--life-color-bg-surface-samaritan-subtle);
+}
+

--- a/new-ui-source/src/pages/CoursePreviewPage.tsx
+++ b/new-ui-source/src/pages/CoursePreviewPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import CommonCourseTopBarRow from "../components/course/CommonCourseTopBarRow";
-import { getCourseBootstrapData, ensureCoursePreview } from "../api/adaptAuthoring";
+import { getCourseBootstrapData, seedMissingCourseDefaults } from "../api/adaptAuthoring";
 import { useAuth } from "../context/AuthContext";
 
 type DeviceMode = "desktop" | "tablet" | "mobile";
@@ -40,7 +40,9 @@ export default function CoursePreviewPage() {
   const [themeName, setThemeName] = useState("");
   const [menuName, setMenuName] = useState("");
   const [deviceMode, setDeviceMode] = useState<DeviceMode>("desktop");
-  const [previewState, setPreviewState] = useState<"preparing" | "ready" | "error">("preparing");
+  // Track when the one-shot defaults seed has resolved so the iframe waits for
+  // the possibly-issued PUT to complete before the framework loads course.json.
+  const [defaultsReady, setDefaultsReady] = useState(false);
 
   useEffect(() => {
     if (!id) return;
@@ -63,41 +65,34 @@ export default function CoursePreviewPage() {
       }
     })();
 
+    // Heal older courses (or courses freshly created via the minimal
+    // POST /api/courses flow) whose top-level fields the Adapt runtime
+    // dereferences — `_buttons`, `_globals`, `themeVariables._components`, … —
+    // are absent or empty. Idempotent + non-blocking on failure.
+    (async () => {
+      try {
+        await seedMissingCourseDefaults(id);
+      } catch {
+        /* seeding is best-effort */
+      } finally {
+        if (!cancelled) setDefaultsReady(true);
+      }
+    })();
+
     return () => {
       cancelled = true;
     };
   }, [id]);
 
-  // Ensure a render shell exists before loading the preview. On a never-built course
-  // this builds the shell once (matching its current fingerprint); otherwise it is an
-  // instant cache hit. Prevents the blank/"unavailable" state on first preview.
-  useEffect(() => {
-    const tenantId = user?._tenantId;
-    if (!id || !tenantId) return;
-    let cancelled = false;
-    setPreviewState("preparing");
-    (async () => {
-      try {
-        const result = await ensureCoursePreview(tenantId, id);
-        if (!cancelled) setPreviewState(result?.success ? "ready" : "error");
-      } catch {
-        if (!cancelled) setPreviewState("error");
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [id, user?._tenantId]);
-
   const pageId = (params.get("pageId") || "").trim();
 
   const previewUrl = useMemo(() => {
-    if (!id || !user?._tenantId) return "";
-    const baseUrl = `/studio/${user._tenantId}/${id}/?embedded=1`;
+    if (!id || !user?._tenantId || !defaultsReady) return "";
+    const baseUrl = `/preview/${user._tenantId}/${id}/`;
     return pageId
-      ? `${baseUrl}&_cs=${Date.now()}#/id/${pageId}`
-      : `${baseUrl}&_cs=${Date.now()}`;
-  }, [id, pageId, user?._tenantId]);
+      ? `${baseUrl}?_cs=${Date.now()}#/id/${pageId}`
+      : `${baseUrl}?_cs=${Date.now()}`;
+  }, [id, pageId, user?._tenantId, defaultsReady]);
 
   const frameSizeClass = useMemo(() => {
     if (deviceMode === "mobile") return "w-[390px]";
@@ -150,11 +145,7 @@ export default function CoursePreviewPage() {
       </div>
 
       <main className="flex-1 overflow-auto bg-[#e9edf2] px-3 md:px-6 py-4">
-        {previewState === "preparing" ? (
-          <div className="h-full flex items-center justify-center text-sm text-[#6b7280]">
-            Preparing preview…
-          </div>
-        ) : previewState === "error" || !previewUrl ? (
+        {!previewUrl ? (
           <div className="h-full flex items-center justify-center text-sm text-[#6b7280]">
             Preview is unavailable for this course.
           </div>

--- a/new-ui-source/src/pages/CoursePreviewPage.tsx
+++ b/new-ui-source/src/pages/CoursePreviewPage.tsx
@@ -146,8 +146,18 @@ export default function CoursePreviewPage() {
 
       <main className="flex-1 overflow-auto bg-[#e9edf2] px-3 md:px-6 py-4">
         {!previewUrl ? (
+          // Three distinct states share the empty-preview slot:
+          //   1. "unavailable"  — no `id` in the URL, or no tenant on the user.
+          //      Nothing to preview, and no seeding will ever make it appear.
+          //   2. "loading"      — id + tenant are known but `defaultsReady` is
+          //      still false while `seedMissingCourseDefaults` runs. Showing
+          //      "unavailable" here mis-communicates a transient state.
+          //   3. (implicit)     — once `defaultsReady` flips, `previewUrl` is
+          //      built and the iframe branch below renders instead.
           <div className="h-full flex items-center justify-center text-sm text-[#6b7280]">
-            Preview is unavailable for this course.
+            {(!id || !user?._tenantId)
+              ? "Preview is unavailable for this course."
+              : "Loading preview\u2026"}
           </div>
         ) : (
           <div className="h-full w-full flex justify-center">

--- a/new-ui-source/src/pages/CoursePreviewPage.tsx
+++ b/new-ui-source/src/pages/CoursePreviewPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import CommonCourseTopBarRow from "../components/course/CommonCourseTopBarRow";
-import { getCourseBootstrapData, seedMissingCourseDefaults } from "../api/adaptAuthoring";
+import { getCourseBootstrapData, seedMissingCourseDefaults, ensureCoursePreview } from "../api/adaptAuthoring";
 import { useAuth } from "../context/AuthContext";
 
 type DeviceMode = "desktop" | "tablet" | "mobile";
@@ -43,6 +43,7 @@ export default function CoursePreviewPage() {
   // Track when the one-shot defaults seed has resolved so the iframe waits for
   // the possibly-issued PUT to complete before the framework loads course.json.
   const [defaultsReady, setDefaultsReady] = useState(false);
+  const [previewState, setPreviewState] = useState<"preparing" | "ready" | "error">("preparing");
 
   useEffect(() => {
     if (!id) return;
@@ -84,15 +85,36 @@ export default function CoursePreviewPage() {
     };
   }, [id]);
 
+  // Ensure a render shell exists before loading the preview. On a never-built course
+  // this builds the shell once (matching its current fingerprint); otherwise it is an
+  // instant cache hit. Prevents the blank/"unavailable" state on first preview.
+  useEffect(() => {
+    const tenantId = user?._tenantId;
+    if (!id || !tenantId) return;
+    let cancelled = false;
+    setPreviewState("preparing");
+    (async () => {
+      try {
+        const result = await ensureCoursePreview(tenantId, id);
+        if (!cancelled) setPreviewState(result?.success ? "ready" : "error");
+      } catch {
+        if (!cancelled) setPreviewState("error");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [id, user?._tenantId]);
+
   const pageId = (params.get("pageId") || "").trim();
 
   const previewUrl = useMemo(() => {
-    if (!id || !user?._tenantId || !defaultsReady) return "";
-    const baseUrl = `/preview/${user._tenantId}/${id}/`;
+    if (!id || !user?._tenantId || !defaultsReady || previewState !== "ready") return "";
+    const baseUrl = `/studio/${user._tenantId}/${id}/?embedded=1`;
     return pageId
-      ? `${baseUrl}?_cs=${Date.now()}#/id/${pageId}`
-      : `${baseUrl}?_cs=${Date.now()}`;
-  }, [id, pageId, user?._tenantId, defaultsReady]);
+      ? `${baseUrl}&_cs=${Date.now()}#/id/${pageId}`
+      : `${baseUrl}&_cs=${Date.now()}`;
+  }, [id, pageId, user?._tenantId, defaultsReady, previewState]);
 
   const frameSizeClass = useMemo(() => {
     if (deviceMode === "mobile") return "w-[390px]";
@@ -146,18 +168,20 @@ export default function CoursePreviewPage() {
 
       <main className="flex-1 overflow-auto bg-[#e9edf2] px-3 md:px-6 py-4">
         {!previewUrl ? (
-          // Three distinct states share the empty-preview slot:
-          //   1. "unavailable"  — no `id` in the URL, or no tenant on the user.
-          //      Nothing to preview, and no seeding will ever make it appear.
-          //   2. "loading"      — id + tenant are known but `defaultsReady` is
-          //      still false while `seedMissingCourseDefaults` runs. Showing
-          //      "unavailable" here mis-communicates a transient state.
-          //   3. (implicit)     — once `defaultsReady` flips, `previewUrl` is
-          //      built and the iframe branch below renders instead.
+          // Four distinct states share the empty-preview slot:
+          //   1. "unavailable"  — no `id` in the URL, no tenant on the user, or the
+          //      Studio render-shell build failed (`previewState === "error"`).
+          //      Nothing to preview, and no amount of waiting will make it appear.
+          //   2. "preparing"    — id + tenant are known but `defaultsReady` is still
+          //      false while `seedMissingCourseDefaults` runs, or the Studio shell is
+          //      still building on a cache miss. Showing "unavailable" here would
+          //      mis-communicate a transient state.
+          //   3. (implicit)     — once both flip ready, `previewUrl` is built and the
+          //      iframe branch below renders instead.
           <div className="h-full flex items-center justify-center text-sm text-[#6b7280]">
-            {(!id || !user?._tenantId)
+            {(!id || !user?._tenantId || previewState === "error")
               ? "Preview is unavailable for this course."
-              : "Loading preview\u2026"}
+              : "Preparing preview…"}
           </div>
         ) : (
           <div className="h-full w-full flex justify-center">

--- a/new-ui-source/src/types/storyboard.ts
+++ b/new-ui-source/src/types/storyboard.ts
@@ -62,6 +62,9 @@ export type StoryboardInsertKind =
   | 'reorder'
   | 'textInput'
   | 'slider'
+  | 'checklist'
+  // results / summary — configured on the storyboard, rendered as a component
+  | 'assessmentResult'
   // interactive placeholders (AC6)
   | 'hotgraphic'
   | 'hotgrid'
@@ -93,6 +96,8 @@ export const INSERT_META: Record<
   reorder: { label: 'Sentence Reordering', category: 'assessment', adaptComponent: 'adapt-contrib-resequence' },
   textInput: { label: 'Text Input', category: 'assessment', adaptComponent: 'adapt-contrib-textInput' },
   slider: { label: 'Slider', category: 'assessment', adaptComponent: 'adapt-contrib-slider' },
+  checklist: { label: 'Checklist', category: 'assessment', adaptComponent: 'adapt-laerdal-checklist' },
+  assessmentResult: { label: 'Assessment Result', category: 'assessment', adaptComponent: 'adapt-contrib-assessmentResults' },
   hotgraphic: { label: 'Hot Graphic', category: 'interactive', adaptComponent: 'adapt-contrib-hotgraphic' },
   hotgrid: { label: 'Hot Grid', category: 'interactive', adaptComponent: 'adapt-laerdal-hotgrid' },
   actionplan: { label: 'Laerdal Action Plan', category: 'interactive', adaptComponent: 'adapt-laerdal-actionplan' },
@@ -105,7 +110,7 @@ export const INSERT_META: Record<
 // configured later in the Page Editor. The Phase 4 generator maps this onto the
 // concrete Adapt component `properties`.
 
-export const ASSESSMENT_KINDS = ['mcq', 'gmcq', 'matching', 'reorder', 'textInput', 'slider'] as const;
+export const ASSESSMENT_KINDS = ['mcq', 'gmcq', 'matching', 'reorder', 'textInput', 'slider', 'checklist'] as const;
 export type AssessmentKind = (typeof ASSESSMENT_KINDS)[number];
 
 export function isAssessmentKind(kind: string): kind is AssessmentKind {
@@ -115,8 +120,16 @@ export function isAssessmentKind(kind: string): kind is AssessmentKind {
 export interface McqOption {
   text: string;
   correct: boolean;
-  /** Optional image reference for Graphic MCQ (gmcq). */
+  /** Optional image reference for Graphic MCQ (gmcq).
+   *  `image` is the persisted link written to `_graphic.src` (either
+   *  `course/assets/<file>` for a DAM asset or an external URL).
+   *  `imageUrl` is the servable preview URL (`/api/asset/serve/<id>`) — not
+   *  persisted; used only to render the picked asset in the editor.
+   *  `imageAssetId` is the DAM asset id, retained so generation can create
+   *  the courseasset publish link. */
   image?: string;
+  imageUrl?: string;
+  imageAssetId?: string;
   /** Answer-specific feedback shown when this option is selected. */
   feedback?: string;
 }
@@ -142,12 +155,14 @@ export interface AssessmentFeedback {
 export interface AssessmentData {
   question: string;
   showTitle?: boolean;
-  options?: McqOption[]; // mcq, gmcq
+  options?: McqOption[]; // mcq, gmcq, checklist
   pairs?: MatchPair[]; // matching
   items?: string[]; // reorder — array order is the correct order
   answers?: string[]; // textInput — acceptable answers
   slider?: SliderConfig; // slider
   feedback?: AssessmentFeedback; // whole-question feedback (all kinds)
+  /** checklist only: how many items the learner may select (1 → single-choice). */
+  selectable?: number;
 }
 
 export function emptyFeedback(): AssessmentFeedback {
@@ -162,6 +177,19 @@ export function defaultAssessmentData(kind: AssessmentKind): AssessmentData {
       return {
         ...base,
         question: '',
+        options: [
+          { text: 'Correct answer', correct: true, feedback: '' },
+          { text: 'Incorrect option', correct: false, feedback: '' },
+          { text: 'Incorrect option', correct: false, feedback: '' },
+        ],
+      };
+    case 'checklist':
+      // Checklist behaves like MCQ but drives the `_selectable` count (how many
+      // items are correct). Default: single-selection, one correct.
+      return {
+        ...base,
+        question: '',
+        selectable: 1,
         options: [
           { text: 'Correct answer', correct: true, feedback: '' },
           { text: 'Incorrect option', correct: false, feedback: '' },
@@ -193,6 +221,17 @@ export function validateAssessment(kind: AssessmentKind, data: AssessmentData): 
       const filled = opts.filter((o) => o.text.trim());
       if (filled.length < 2) issues.push('Add at least two answer options.');
       if (!filled.some((o) => o.correct)) issues.push('Mark at least one option correct.');
+      break;
+    }
+    case 'checklist': {
+      const opts = data.options ?? [];
+      const filled = opts.filter((o) => o.text.trim());
+      if (filled.length < 2) issues.push('Add at least two checklist items.');
+      const correctCount = filled.filter((o) => o.correct).length;
+      if (correctCount < 1) issues.push('Mark at least one item correct.');
+      const selectable = Math.max(1, Number(data.selectable ?? 1));
+      if (selectable > filled.length) issues.push('"Selectable" cannot exceed the number of items.');
+      if (correctCount > selectable) issues.push('More correct items than the "Selectable" limit — raise the limit or unmark items.');
       break;
     }
     case 'matching': {
@@ -242,8 +281,18 @@ export function buildAssessmentFields(kind: AssessmentKind, data: AssessmentData
       text: o.text,
       _shouldBeSelected: !!o.correct,
       feedback: o.feedback ?? '',
-      ...(o.image ? { _graphic: { src: o.image, large: o.image } } : {}),
+      ...(o.image ? { _graphic: { src: o.image, large: o.image, small: o.image, alt: o.text || '', attribution: '' } } : {}),
     }));
+  } else if (kind === 'checklist') {
+    // adapt-laerdal-checklist: `_items[].{ text, altText, _shouldBeSelected,
+    // feedback }` + top-level `_selectable`.
+    patch._items = (data.options ?? []).map((o) => ({
+      text: o.text,
+      altText: o.text,
+      _shouldBeSelected: !!o.correct,
+      feedback: o.feedback ?? '',
+    }));
+    patch._selectable = Math.max(1, Number(data.selectable ?? 1));
   } else if (kind === 'matching') {
     patch._items = (data.pairs ?? []).map((p) => ({
       text: p.prompt,
@@ -291,13 +340,22 @@ export function parseAssessmentData(
   if (kind === 'mcq' || kind === 'gmcq') {
     data.options = items.map((it) => {
       const g = (it._graphic as { large?: string; small?: string; src?: string }) || {};
+      const link = g.large || g.small || g.src || undefined;
       return {
         text: String(it.text ?? ''),
         correct: !!it._shouldBeSelected,
         feedback: it.feedback ? String(it.feedback) : undefined,
-        image: g.large || g.small || g.src || undefined,
+        image: link,
+        imageUrl: link,
       } as McqOption;
     });
+  } else if (kind === 'checklist') {
+    data.options = items.map((it) => ({
+      text: String(it.text ?? ''),
+      correct: !!it._shouldBeSelected,
+      feedback: it.feedback ? String(it.feedback) : undefined,
+    }));
+    data.selectable = Math.max(1, Number(p._selectable ?? 1));
   } else if (kind === 'matching') {
     data.pairs = items.map((it) => {
       const opts = Array.isArray(it._options) ? (it._options as Array<Record<string, unknown>>) : [];

--- a/new-ui-source/src/types/storyboard.ts
+++ b/new-ui-source/src/types/storyboard.ts
@@ -341,12 +341,20 @@ export function parseAssessmentData(
     data.options = items.map((it) => {
       const g = (it._graphic as { large?: string; small?: string; src?: string }) || {};
       const link = g.large || g.small || g.src || undefined;
+      // `image` is the persisted link and can legitimately be a
+      // `course/assets/<file>` path (DAM-picked) which the authoring UI
+      // cannot fetch directly. `imageUrl` is used to render the picker
+      // preview via a plain `<img src>`, so it must be directly loadable
+      // (external URL or absolute path). Leave it unset for DAM links so
+      // the picker shows an empty tile rather than a broken image icon;
+      // re-picking the asset repopulates a servable URL.
+      const isServable = !!link && (/^(https?:)?\/\//i.test(link) || link.startsWith('/'));
       return {
         text: String(it.text ?? ''),
         correct: !!it._shouldBeSelected,
         feedback: it.feedback ? String(it.feedback) : undefined,
         image: link,
-        imageUrl: link,
+        imageUrl: isServable ? link : undefined,
       } as McqOption;
     });
   } else if (kind === 'checklist') {

--- a/routes/studio/index.js
+++ b/routes/studio/index.js
@@ -89,10 +89,11 @@ function computeFingerprint(tenantId, courseId, cb) {
   origin().outputmanager.getOutputPlugin('adapt', (err, plugin) => {
     if (err) return cb(err);
     // The fingerprint needs ONLY the config (theme/menu/enabled component+extension
-    // sets), so use the config-only assembler — NOT getCourseJSON, which would also
-    // fetch and assemble the entire content tree on every ensure call. The returned
-    // config[0] is identical either way, so the fingerprint value is unchanged.
-    plugin.getCourseConfigJSON(courseId, (err, raw) => {
+    // sets). There is no config-only assembler on OutputPlugin — `getCourseJSON` is
+    // the only path that produces the `_enabledComponents`/`_enabledExtensions`
+    // aggregate on `config[0]`. It's assembled once per preview, so reusing it here
+    // is fine (and it's what publish.js consumes anyway).
+    plugin.getCourseJSON(tenantId, courseId, (err, raw) => {
       if (err) return cb(err);
       installHelpers.getInstalledFrameworkVersion((err, fwVersion) => {
         if (err) return cb(err);
@@ -138,15 +139,24 @@ function restoreShell(fingerprint, buildRoot, cb) {
   const app = origin();
   if (!app || typeof app.on !== 'function') return;
   app.on('previewCreated', (tenantId, courseId /*, outputFolder */) => {
-    const buildRoot = courseBuildRoot(String(tenantId), String(courseId));
-    computeFingerprint(String(tenantId), String(courseId), (err, fp) => {
-      if (err) return logger.log('warn', `Studio: fingerprint failed for ${courseId}: ${err.message}`);
-      snapshotShell(buildRoot, fp, (err2) => {
-        if (err2) return logger.log('warn', `Studio: shell snapshot failed for ${courseId}: ${err2.message}`);
-        fsx.writeFile(path.join(buildRoot, FP_MARKER), fp, () => {});
-        logger.log('info', `Studio: cached shell ${fp} for course ${courseId}`);
+    // Wrap in try/catch: this listener runs synchronously from the grunt
+    // exec-exit handler in publish.js, so any thrown error bubbles up through
+    // `app.emit` → node's uncaughtException handler and crashes the response
+    // (surfacing as a 500 to the client even though the build itself succeeded).
+    // Cache warming is best-effort; a failure here must never break preview.
+    try {
+      const buildRoot = courseBuildRoot(String(tenantId), String(courseId));
+      computeFingerprint(String(tenantId), String(courseId), (err, fp) => {
+        if (err) return logger.log('warn', `Studio: fingerprint failed for ${courseId}: ${err.message}`);
+        snapshotShell(buildRoot, fp, (err2) => {
+          if (err2) return logger.log('warn', `Studio: shell snapshot failed for ${courseId}: ${err2.message}`);
+          fsx.writeFile(path.join(buildRoot, FP_MARKER), fp, () => {});
+          logger.log('info', `Studio: cached shell ${fp} for course ${courseId}`);
+        });
       });
-    });
+    } catch (e) {
+      logger.log('warn', `Studio: previewCreated handler error for ${courseId}: ${e && e.message}`);
+    }
   });
 })();
 


### PR DESCRIPTION

## ✅ PR Completion Checklist

* [x] PR title follows format: `Prefix: ADAPT-XXXX Brief description`
* [x] JIRA ID linked in the Context section below
* [ ] Plugin version updated in `bower.json` (if applicable)
* [ ] `npm run test-e2e-dev-pipeline` executed and passing
* [ ] No new issues reported by SonarLint (attach screenshot if applicable)
* [ ] Own diff reviewed before requesting review
* [x] At least two reviewers added (Copilot set as default)

---

## Context

#### Resolves / Addresses [ADAPT-3842](https://laerdal.atlassian.net/browse/ADAPT-3842)

## Summary

Aligns the Storyboard "Add Content" experience in the new UI with the Figma
reference (Course Creation Center → `StoryboardPanel.tsx`), and finishes wiring
all nine storyboard content plugins end-to-end (palette → block editor →
generation → round-trip). Also tightens the H5P asset picker to `.h5p`-only and
replaces the raw GMCQ image URL field with a proper DAM-backed image picker.

Jira: **ADAPT-3842**

## What's changed

### 1. Add Content menu — 1:1 with Figma `CONTENT_TYPE_CATALOG`
- Groups reduced to **Text & Visual / Media / Survey / Assessment** (the extra
  "Interactive" group was not in the design and has been removed).
- Icons, labels and order now match Figma exactly:
  | Group | Item | Icon (Figma) |
  |---|---|---|
  | Text & Visual | Text · Grouped Content · Image | `Type` · `Layers` · `Image` |
  | Media | Video · Audio · H5P | `Film` · `Mic` · `Puzzle` |
  | Survey | Laerdal Form | `ClipboardList` |
  | Assessment | MCQ · GMCQ · Matching · Text Input · Sentence Reordering · Checklist · Slider · Assessment Result | `CheckSquare` · `CheckSquare` · `LayoutList` · `PenLine` · `ArrowUpDown` · `ListChecks` · `SlidersHorizontal` · `Trophy` |
- "Graphic MCQ" → "GMCQ" to match the design.

### 2. New content kinds wired end-to-end
- **Checklist** added as a new `sbAssessment` kind:
  - Palette entry, block editor (items with correct + text + feedback + selectable count), validation (`≥2 items`, `≥1 correct`, `correctCount ≤ selectable ≤ items.length`)
  - Generation emits `_items[].{text, altText, _shouldBeSelected, feedback}` + `_selectable`
- **Assessment Result** added as a new `sbComponent` kind:
  - Palette entry, block editor (Assessment ID, completion body with `{{scoreAsPercent}}` template hint, score bands, retry button/feedback)
  - Generation emits `_assessmentId`, `_completionBody`, `_isVisibleBeforeCompletion:false`, `_setCompletionOn:'pass'`, `_resetType:'hard'`, `_retry.{button,feedback,_routeToAssessment:true}`, `_bands` (sorted ascending)
  - Round-trip reads all of the above back into the editor

### 3. Enrichment of existing kinds
- **GMCQ**: per-option **image picker** using `AssetPickerModal` (replaces the previous free-text URL field). Each option now carries `imageUrl` (preview) + `imageAssetId` (DAM id); generation links the courseasset. `_graphic` shape emitted as `{src, large, small, alt, attribution}`.
- **Slider**: added `slider` and `laerdal-slider` component candidates in mapping.
- **H5P**:
  - Asset picker restricted to `.h5p` (`accept=".h5p,application/zip,application/x-zip-compressed,application/octet-stream"`; client-side filename filter; upload validation rejects non-`.h5p` files with an inline error).
  - Generation writes `h5pAsset` (DAM asset) OR `_h5pExternalAsset` (external URL) based on `asset.external` flag / URL detection.
  - Round-trip reads either shape back.
- **Laerdal Form**: generation builds `_items[]` with `_inputType` (from control-type label), `_label`, `_name` (slugified), `_isRequired`, `_placeholder` (Checkbox becomes single-option `options` array). Round-trip re-maps control types back to UI labels.

### 4. Asset picker
- `AssetKind` extended to include `"h5p"`.
- `queryAssets('h5p')` skips the mimeType filter and narrows client-side to `/\.h5p$/i`.
- Modal renders a puzzle-piece tile for H5P assets and shows a proper heading ("Select an H5P File").

## Files touched (new-ui-source/src)

- `types/storyboard.ts` — new kinds, validation, `buildAssessmentFields`, `parseAssessmentData`
- `api/componentMapping.ts` — plugin candidates + REVERSE map for `checklist`, `assessmentResult`, `slider`
- `api/adaptAuthoring.ts` — `AssetKind` extended; H5P/`laerdalForm`/`assessmentResult` round-trip
- `api/storyboardGeneration.ts` — H5P, Laerdal Form, Assessment Result, GMCQ per-option courseasset linking
- `components/common/AssetPickerModal.tsx` — `.h5p` accept/upload validation + H5P tile
- `components/storyboard/AddContentMenu.tsx` — Figma-aligned groups/icons/order
- `components/storyboard/blocks/assessmentBlock.tsx` — `OptionImagePicker`, `ChecklistForm`, `checklist` routing
- `components/storyboard/blocks/componentBlock.tsx` — `assessmentResult` editor + preview; H5P uses `assetType="h5p"`
- `components/storyboard/BlockNoteStoryboardEditor.tsx` — `assessmentResult` added to `COMPONENT_CARD_KINDS`
- Plus supporting tweaks in other storyboard components already staged with this feature branch

## Screens affected

- Storyboard editor "Add Content" dropdown
- MCQ / GMCQ / Matching / Text Input / Sentence Reordering / Checklist / Slider / Assessment Result block editors
- H5P, Video, Audio, Laerdal Form component editors
- Asset picker (Image / Video / Audio / **H5P**)

## Backend contract (Adapt component JSON)

- **MCQ / GMCQ**: `_items[]` with `_graphic:{src,large,small,alt,attribution}` on GMCQ
- **Checklist** (`laerdal-checklist`): `_items[].{text,altText,_shouldBeSelected,feedback}` + `_selectable`
- **Assessment Result** (`assessmentResults`): `_assessmentId`, `_completionBody`, `_isVisibleBeforeCompletion`, `_setCompletionOn`, `_resetType`, `_retry`, `_bands[]`
- **H5P**: `h5pAsset` (DAM) or `_h5pExternalAsset` (URL)
- **Laerdal Form**: `_items[]` with `_inputType`, `_label`, `_name`, `_isRequired`, `_placeholder`, optional `options[]`

## Build & sync

- `cd new-ui-source && npm run build` → **2722 modules, 0 TS errors**
- `node scripts/sync-new-ui.js` → synced to `public/new/`
- `public/new/` is gitignored (build artifact) — not included in this PR.

## Test plan

1. Open Storyboard editor, click **+ Add Content**. Verify groups, icons, labels, and order match the Figma reference (see table above).
2. Insert **Checklist**: add ≥2 items, mark ≥1 correct, adjust "Selectable" count → save → export → verify `_items[]` + `_selectable` in course JSON. Reload the storyboard → data round-trips.
3. Insert **Assessment Result**: set an Assessment ID, edit completion body, add score bands (0 / 60 / 80), set retry button + feedback → save → verify emitted `_bands` are ascending, `_retry` populated, `_assessmentId` matches.
4. Insert **GMCQ**: for each option click the image tile → pick an asset from the DAM → save. Verify preview updates, exported `_graphic.large/small/src` is the CDN URL and courseasset is linked to the component.
5. Insert **H5P**: open the asset picker → confirm heading reads "Select an H5P File" and only `.h5p` uploads are accepted (try uploading a `.mp4` → red error). Pick an existing `.h5p` asset → save → verify `h5pAsset` is written. Enter an external URL instead → verify `_h5pExternalAsset` path.
6. Insert **Laerdal Form** with fields of every control type (Single-Line Text, Multi-Line Text, Number, Dropdown, Checkbox) → save → verify each `_items[i]._inputType`, `_label`, `_name`, `_isRequired`, `_placeholder` (and Checkbox `options`) in JSON. Reload → field types round-trip.
7. Verify the removed **Interactive** items (Accordion / Hot Graphic / Hot Grid / Laerdal Action Plan) no longer appear in the Add Content dropdown.

## Follow-ups (not in this PR)

- Extend GMCQ options with per-option `altText` + `attribution` inputs (Figma exposes both; currently derived).
- Slider: add `scaleLabelStart`, `scaleLabelEnd`, `prefix`, `suffix`, and full 5-field feedback in the editor.
- Text Input: add `prefix`, `suffix`, and full `MCQFeedback` (currently answers-only).
- Grouped Content: per-item `imageAlt` and `imageCaption`.
- Multi-image support in the Image block (Figma allows `ImageItem[]`).

## Risk

Low — all changes are contained to the new UI (`new-ui-source/`) and the backend
JSON we produce matches existing plugin schemas (`laerdal-checklist`,
`assessmentResults`, `adapt-contrib-mcq/gmcq`, `laerdal-h5p`, `laerdal-form`,
`adapt-contrib-slider`). No server-side or DB changes.