### PR TITLE
Bugfix: ADAPT-3756-CDN GetPrevious link and Set Expiry issue fixed

### DIFF
--- a/new-ui-source/src/api/adaptAuthoring.ts
+++ b/new-ui-source/src/api/adaptAuthoring.ts
@@ -3210,11 +3210,18 @@ export async function restoreCdnLink(
   courseid: string,
   cdnid: string,
   versionfolder: string,
-): Promise<CdnLinkEntry[]> {
-  const result = await apiClient.get<{ data?: CdnLinkEntry[] }>(
+): Promise<boolean> {
+  // Backend `handleCDNRestoreLink` shells out to `cdndeploy mv` and returns
+  // whatever JSON.parse'd stdout produces — historically an array of link
+  // rows, but on some CLI versions/paths it's an object or a status string.
+  // The caller only needs to know whether the request succeeded (HTTP 2xx);
+  // trying to shape-check the payload here caused the UI to falsely report
+  // "No links found." on a successful restore. apiClient.request already
+  // throws on non-2xx, so `success` is the truthy signal we care about.
+  const result = await apiClient.get<{ success?: boolean }>(
     `/api/cdn/restoreLink/${encodeURIComponent(groupid)}/${encodeURIComponent(courseid)}/${encodeURIComponent(cdnid)}/${encodeURIComponent(versionfolder)}`,
   );
-  return Array.isArray(result?.data) ? result.data : [];
+  return Boolean(result?.success);
 }
 
 export async function setCdnLinkExpiry(
@@ -3223,11 +3230,16 @@ export async function setCdnLinkExpiry(
   cdnid: string,
   versionfolder: string,
   expiredate: string,
-): Promise<CdnLinkEntry[]> {
-  const result = await apiClient.get<{ data?: CdnLinkEntry[] }>(
+): Promise<boolean> {
+  // Backend `handleCDNSaveLinks` inserts the row and now returns the
+  // refreshed rows for the key, but the caller only needs a success signal —
+  // the page reloads the previous-links table separately, which is the
+  // source of truth for what's displayed. See restoreCdnLink comment for
+  // why we don't shape-check the payload.
+  const result = await apiClient.get<{ success?: boolean }>(
     `/api/cdn/setExpiry/${encodeURIComponent(groupid)}/${encodeURIComponent(courseid)}/${encodeURIComponent(cdnid)}/${encodeURIComponent(versionfolder)}/${encodeURIComponent(expiredate)}`,
   );
-  return Array.isArray(result?.data) ? result.data : [];
+  return Boolean(result?.success);
 }
 
 // ── Users & roles ─────────────────────────────────────────────────────────────

--- a/new-ui-source/src/api/adaptAuthoring.ts
+++ b/new-ui-source/src/api/adaptAuthoring.ts
@@ -3213,15 +3213,15 @@ export async function restoreCdnLink(
 ): Promise<boolean> {
   // Backend `handleCDNRestoreLink` shells out to `cdndeploy mv` and returns
   // whatever JSON.parse'd stdout produces — historically an array of link
-  // rows, but on some CLI versions/paths it's an object or a status string.
-  // The caller only needs to know whether the request succeeded (HTTP 2xx);
-  // trying to shape-check the payload here caused the UI to falsely report
-  // "No links found." on a successful restore. apiClient.request already
-  // throws on non-2xx, so `success` is the truthy signal we care about.
-  const result = await apiClient.get<{ success?: boolean }>(
+  // rows, but on some CLI versions/paths it's an object or a status string,
+  // and it isn't always wrapped in a `{ success }` envelope. The caller only
+  // needs to know whether the request succeeded (HTTP 2xx); apiClient.request
+  // already throws on non-2xx, so reaching this line at all IS the success
+  // signal — don't gate on a `success` field that may not be present.
+  await apiClient.get(
     `/api/cdn/restoreLink/${encodeURIComponent(groupid)}/${encodeURIComponent(courseid)}/${encodeURIComponent(cdnid)}/${encodeURIComponent(versionfolder)}`,
   );
-  return Boolean(result?.success);
+  return true;
 }
 
 export async function setCdnLinkExpiry(
@@ -3235,11 +3235,11 @@ export async function setCdnLinkExpiry(
   // refreshed rows for the key, but the caller only needs a success signal —
   // the page reloads the previous-links table separately, which is the
   // source of truth for what's displayed. See restoreCdnLink comment for
-  // why we don't shape-check the payload.
-  const result = await apiClient.get<{ success?: boolean }>(
+  // why we don't gate on a `success` field in the payload.
+  await apiClient.get(
     `/api/cdn/setExpiry/${encodeURIComponent(groupid)}/${encodeURIComponent(courseid)}/${encodeURIComponent(cdnid)}/${encodeURIComponent(versionfolder)}/${encodeURIComponent(expiredate)}`,
   );
-  return Boolean(result?.success);
+  return true;
 }
 
 // ── Users & roles ─────────────────────────────────────────────────────────────

--- a/new-ui-source/src/pages/setup/cdnDeploymentPage.tsx
+++ b/new-ui-source/src/pages/setup/cdnDeploymentPage.tsx
@@ -444,10 +444,15 @@ export function CdnDeploymentPage({
     if (!cfg) return;
     setRestoringEntry(entry.entry);
     try {
-      const result = await restoreCdnLink(cfg.groupid, cfg.courseid, cfg.cdnid, entry.entry);
-      if (!result.length) throw new Error("No links found.");
+      // Success is signalled by the request not throwing (apiClient.request
+      // throws on non-2xx). The exact payload shape from `cdndeploy mv`
+      // varies by CLI version, so we don't try to shape-check it — instead
+      // we reload the previous-links table below, which is the source of
+      // truth for what's currently in storage.
+      await restoreCdnLink(cfg.groupid, cfg.courseid, cfg.cdnid, entry.entry);
       setRestoredEntries((prev) => new Set(prev).add(entry.entry));
       setToast({ type: "success", message: "Link restored successfully" });
+      void loadPreviousLinks(cfg);
     } catch {
       setToast({
         type: "error",
@@ -462,11 +467,12 @@ export function CdnDeploymentPage({
     if (!cfg || !expiryDate) return;
     setExpirySaving(true);
     try {
-      const result = await setCdnLinkExpiry(cfg.groupid, cfg.courseid, cfg.cdnid, entry.entry, expiryDate);
-      if (!result.length) throw new Error("No links found.");
+      // See handleRestore for why we don't shape-check the response.
+      await setCdnLinkExpiry(cfg.groupid, cfg.courseid, cfg.cdnid, entry.entry, expiryDate);
       setToast({ type: "success", message: "Expiry date set successfully for this version" });
       setExpiryTarget(null);
       setExpiryDate("");
+      void loadPreviousLinks(cfg);
     } catch (err) {
       setToast({ type: "error", message: err instanceof Error ? err.message : "Failed to set expiry." });
     } finally {


### PR DESCRIPTION
## ✅ PR Completion Checklist

* [x] PR title follows format: `Prefix: ADAPT-XXXX Brief description`
* [x] JIRA ID linked in the Context section below
* [ ] Plugin version updated in `bower.json` (if applicable)
* [ ] `npm run test-e2e-dev-pipeline` executed and passing
* [ ] No new issues reported by SonarLint (attach screenshot if applicable)
* [ ] Own diff reviewed before requesting review
* [x] At least two reviewers added (Copilot set as default)

---

## Context

#### Resolves / Addresses [ADAPT-3756](https://laerdal.atlassian.net/browse/ADAPT-3756)

Fixed the CDN Set Expiry issue
