### PR TITLE
Bugfix: ADAPT-3756 cdn get previous links auto trigger fixed

### DIFF
--- a/new-ui-source/src/api/adaptAuthoring.ts
+++ b/new-ui-source/src/api/adaptAuthoring.ts
@@ -3274,7 +3274,7 @@ export const CDN_STORAGE_CONTAINERS = ["cdn-esim-dev", "cdn-esim-prod", "cdn-esi
 
 // Schema defaults (adapt-cdn-config/properties.schema) used when the extension
 // hasn't been configured on this course yet.
-const DEFAULT_CDN_DEPLOYMENT_SETTINGS: CdnDeploymentSettings = {
+export const DEFAULT_CDN_DEPLOYMENT_SETTINGS: CdnDeploymentSettings = {
   isEnabled: false,
   cdnid: CDN_STORAGE_CONTAINERS[0],
   groupid: "default-project",

--- a/new-ui-source/src/pages/setup/cdnDeploymentPage.tsx
+++ b/new-ui-source/src/pages/setup/cdnDeploymentPage.tsx
@@ -241,7 +241,9 @@ const STATUS_BADGE: Record<LinkStatus, { label: string; className: string }> = {
 // than trusting free-text label content ("Version Specific" / "Latest").
 function extractVersionFolder(href: string): string {
   try {
-    const segments = new URL(href).pathname.split("/").filter(Boolean);
+    // href may be protocol-relative ("//host/...") or root-relative ("/...") —
+    // both shapes appendIsCDNModeParam can produce — so a base is required.
+    const segments = new URL(href, window.location.origin).pathname.split("/").filter(Boolean);
     return segments.length >= 2 ? segments[segments.length - 2] : "latest";
   } catch {
     return "latest";
@@ -304,8 +306,9 @@ export function CdnDeploymentPage({
   const logIdRef = useRef(0);
 
   const [linksLoading, setLinksLoading] = useState(false);
-  // null = not yet fetched. Only an explicit "Get Previous Links" click should
-  // populate this — saving the config or triggering a build must not.
+  // null = not yet populated. Populated either by an explicit "Get Previous
+  // Links" click or by a completed build (showing just that build's links) —
+  // but never automatically by saving the config or starting a build.
   const [links, setLinks] = useState<DisplayLinkEntry[] | null>(null);
   const [restoringEntry, setRestoringEntry] = useState<string | null>(null);
   const [restoredEntries, setRestoredEntries] = useState<Set<string>>(new Set());
@@ -694,8 +697,9 @@ export function CdnDeploymentPage({
                   </div>
                 )}
 
-                {/* Previous versions — only shown once the user explicitly clicks
-                    "Get Previous Links" (links stays null until then). */}
+                {/* Previous versions — shown once populated by "Get Previous Links" or
+                    a completed build; stays hidden (links === null) until then, and is
+                    never auto-populated just by saving the config or starting a build. */}
                 {cfg.isEnabled && (linksLoading || links !== null) && (
                   <div className="rounded-lg border border-[#e5e7eb] overflow-hidden">
                     <table className="w-full text-xs">

--- a/new-ui-source/src/pages/setup/cdnDeploymentPage.tsx
+++ b/new-ui-source/src/pages/setup/cdnDeploymentPage.tsx
@@ -235,6 +235,46 @@ const STATUS_BADGE: Record<LinkStatus, { label: string; className: string }> = {
   inactive: { label: "Inactive", className: "text-[#9ca3af]" },
 };
 
+// Both the "specific" and "latest" deploy links always end in `<versionfolder>/index.html`
+// (destination.js: dest.specific = `${groupid}/courses/${courseid}/${version}.${timestamp}`,
+// dest.latest = `.../latest`) — recover the version-folder id from the path itself rather
+// than trusting free-text label content ("Version Specific" / "Latest").
+function extractVersionFolder(href: string): string {
+  try {
+    const segments = new URL(href).pathname.split("/").filter(Boolean);
+    return segments.length >= 2 ? segments[segments.length - 2] : "latest";
+  } catch {
+    return "latest";
+  }
+}
+
+function ordinal(n: number): string {
+  const suffixes = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return `${n}${suffixes[(v - 20) % 10] ?? suffixes[v] ?? suffixes[0]}`;
+}
+
+function formatBuildTimestamp(epochMs: number): string {
+  const d = new Date(epochMs);
+  const month = d.toLocaleString("en-US", { month: "long" });
+  const time = d.toLocaleString("en-US", { hour: "numeric", minute: "2-digit", second: "2-digit", hour12: true }).toLowerCase();
+  return `${month} ${ordinal(d.getDate())} ${d.getFullYear()}, ${time}`;
+}
+
+// A version-folder id embeds its creation timestamp as the trailing dot-segment
+// (e.g. "0.0.1.1755500064000") — "latest" has no timestamp of its own.
+function buildDisplayLinkEntry(link: CdnLink): DisplayLinkEntry {
+  const entry = extractVersionFolder(link.href);
+  const rawTimestamp = entry !== "latest" ? Number(entry.split(".").pop()) : NaN;
+  return {
+    entry,
+    link: link.href,
+    timestampPretty: Number.isFinite(rawTimestamp) ? formatBuildTimestamp(rawTimestamp) : undefined,
+    href: link.href,
+    status: "active",
+  };
+}
+
 /* ── CDN Deployment Page ─────────────────────────────────────────────────── */
 
 export function CdnDeploymentPage({
@@ -426,13 +466,21 @@ export function CdnDeploymentPage({
       if (urlMatch) {
         const specificMatch = data.match(/<div class="specific">([\s\S]*?)<\/div>/);
         const latestMatch = data.match(/<div class="latest">([\s\S]*?)<\/div>/);
+        const specificLink = specificMatch ? parseCdnLinkHtml(specificMatch[1]) ?? undefined : undefined;
+        const latestLink = latestMatch ? parseCdnLinkHtml(latestMatch[1]) ?? undefined : undefined;
         appendLog({
           eventType: "link",
-          specificLink: specificMatch ? parseCdnLinkHtml(specificMatch[1]) ?? undefined : undefined,
-          latestLink: latestMatch ? parseCdnLinkHtml(latestMatch[1]) ?? undefined : undefined,
+          specificLink,
+          latestLink,
           comment: cfg.buildTriggerComment,
           triggeredBy: user?.email,
         });
+        // Show just the two links this build produced, in the same table used
+        // for "Get Previous Links" — not the full deployment history.
+        const freshEntries = [latestLink, specificLink]
+          .filter((l): l is CdnLink => !!l)
+          .map(buildDisplayLinkEntry);
+        if (freshEntries.length) setLinks(freshEntries);
       } else {
         appendLog({ eventType: "message", message: data });
       }
@@ -670,10 +718,20 @@ export function CdnDeploymentPage({
                             const restored = restoredEntries.has(entry.entry);
                             const status: LinkStatus = restored ? "active" : entry.status;
                             const badge = STATUS_BADGE[status];
+                            // Mirrors the AT tool's `linkdisabled`/`inactiveState` rule (cdnCourseView.js):
+                            // Restore is only for links that are actually down (expired/not-found) — an
+                            // active link has nothing to restore, and Set Expiry is what takes it down.
+                            const isExpired = status === "not-found" || status === "inactive";
+                            const canRestore = !isLatest && isExpired;
                             return (
-                              <tr key={entry.entry} className="border-t border-[#f3f4f6]">
+                              <tr key={entry.entry} className={`border-t border-[#f3f4f6] ${isExpired ? "bg-[#fff7e6]" : ""}`}>
                                 <td className="px-3 py-2">
-                                  <a href={entry.href} target="_blank" rel="noreferrer" className="underline text-[var(--life-primary-500)]">
+                                  <a
+                                    href={entry.href}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className={isExpired ? "line-through text-[#6b7280]" : "underline text-[var(--life-primary-500)]"}
+                                  >
                                     {/* Full version-folder name (e.g. "0.0.1.1755500064000"), not the
                                         CLI's truncated 3-part semver (entry.version) — matches what
                                         was actually deployed and keeps each row's link unambiguous. */}
@@ -695,7 +753,7 @@ export function CdnDeploymentPage({
                                   <div className="flex items-center gap-1.5">
                                     <button
                                       type="button"
-                                      disabled={isLatest || restored || restoringEntry === entry.entry}
+                                      disabled={!canRestore || restoringEntry === entry.entry}
                                       onClick={() => void handleRestore(entry)}
                                       className="inline-flex items-center gap-1 rounded border border-[#d1d5db] px-2 py-0.5 text-[11px] text-[#374151] hover:bg-[#f9fafb] disabled:opacity-40 transition-colors"
                                     >

--- a/new-ui-source/src/pages/setup/cdnDeploymentPage.tsx
+++ b/new-ui-source/src/pages/setup/cdnDeploymentPage.tsx
@@ -10,6 +10,7 @@ import {
   restoreCdnLink,
   setCdnLinkExpiry,
   CDN_STORAGE_CONTAINERS,
+  DEFAULT_CDN_DEPLOYMENT_SETTINGS,
   type CdnDeploymentSettings,
   type CdnLinkEntry,
 } from "../../api/adaptAuthoring";
@@ -263,7 +264,9 @@ export function CdnDeploymentPage({
   const logIdRef = useRef(0);
 
   const [linksLoading, setLinksLoading] = useState(false);
-  const [links, setLinks] = useState<DisplayLinkEntry[]>([]);
+  // null = not yet fetched. Only an explicit "Get Previous Links" click should
+  // populate this — saving the config or triggering a build must not.
+  const [links, setLinks] = useState<DisplayLinkEntry[] | null>(null);
   const [restoringEntry, setRestoringEntry] = useState<string | null>(null);
   const [restoredEntries, setRestoredEntries] = useState<Set<string>>(new Set());
   const [expiryTarget, setExpiryTarget] = useState<string | null>(null);
@@ -308,7 +311,15 @@ export function CdnDeploymentPage({
         setCfg(settings);
         setSavedSnapshot(settings);
         setCdnCliVersion(version);
-        if (settings.isEnabled) void loadPreviousLinks(settings);
+      } catch {
+        // Without this, a failed fetch left `cfg` null forever and the page
+        // was stuck on the loading spinner indefinitely — fall back to the
+        // schema defaults (extension effectively "not configured") so the
+        // page always renders, and let the user know the load failed.
+        if (cancelled) return;
+        setCfg(DEFAULT_CDN_DEPLOYMENT_SETTINGS);
+        setSavedSnapshot(DEFAULT_CDN_DEPLOYMENT_SETTINGS);
+        setToast({ type: "error", message: "Couldn't load CDN deployment settings. Please refresh and try again." });
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -336,8 +347,9 @@ export function CdnDeploymentPage({
     try {
       await saveCdnDeploymentSettings(courseId, next);
       setSavedSnapshot(next);
-      if (next.isEnabled) void loadPreviousLinks(next);
-      else setLinks([]);
+      // Saving config must not auto-fetch/show previous links (QA:
+      // that list should only populate on an explicit button click).
+      setLinks(null);
       return true;
     } catch {
       setToast({ type: "error", message: "Couldn't save. Please try again." });
@@ -387,6 +399,10 @@ export function CdnDeploymentPage({
     if (!cfg || building) return;
     setBuilding(true);
     setLogEntries([]);
+    // Clear any previously-fetched previous-links table — after a build, only
+    // the latest/version-specific link (surfaced inline via the SSE log below)
+    // should be shown, not the full previous-links list.
+    setLinks(null);
 
     const url = new URL(`${API_BASE_URL}/api/cdn/deploy`, window.location.origin);
     // "courseid" must be the authoring tool's real course _id (used server-side to
@@ -431,7 +447,6 @@ export function CdnDeploymentPage({
       appendLog({ eventType: "close", message: "⚫ Connection closed" });
       setBuilding(false);
       es.close();
-      void loadPreviousLinks(cfg);
     };
     es.onerror = stop;
     es.addEventListener("server-error", (event) => {
@@ -631,8 +646,9 @@ export function CdnDeploymentPage({
                   </div>
                 )}
 
-                {/* Previous versions */}
-                {cfg.isEnabled && (
+                {/* Previous versions — only shown once the user explicitly clicks
+                    "Get Previous Links" (links stays null until then). */}
+                {cfg.isEnabled && (linksLoading || links !== null) && (
                   <div className="rounded-lg border border-[#e5e7eb] overflow-hidden">
                     <table className="w-full text-xs">
                       <thead className="bg-[#f9fafb] text-left">
@@ -646,7 +662,7 @@ export function CdnDeploymentPage({
                       <tbody>
                         {linksLoading ? (
                           <tr><td colSpan={4} className="px-3 py-4 text-center text-[#6b7280]"><Spinner className="inline mr-2" />Loading previous versions…</td></tr>
-                        ) : links.length === 0 ? (
+                        ) : !links || links.length === 0 ? (
                           <tr><td colSpan={4} className="px-3 py-4 text-center text-[#6b7280]">No previous versions found.</td></tr>
                         ) : (
                           links.map((entry) => {


### PR DESCRIPTION
## ✅ PR Completion Checklist

* [x] PR title follows format: `Prefix: ADAPT-XXXX Brief description`
* [x] JIRA ID linked in the Context section below
* [ ] Plugin version updated in `bower.json` (if applicable)
* [ ] `npm run test-e2e-dev-pipeline` executed and passing
* [ ] No new issues reported by SonarLint (attach screenshot if applicable)
* [ ] Own diff reviewed before requesting review
* [x] At least two reviewers added (Copilot set as default)

---

## Context

#### Resolves / Addresses [ADAPT-3756](https://laerdal.atlassian.net/browse/ADAPT-3756)
Fixed cdn get previous links auto trigger fixed
